### PR TITLE
fix: add id-token write permission and bump checkout to v5

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -11,8 +11,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0     # full history so the agent can git diff since the last run
 

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Fix para el workflow \openwiki-update.yml\:\n\n- Agrega \id-token: write\ al permissions (el \claude-code-action\ lo requiere para OIDC)\n- Bump \ctions/checkout@v4\ a \@v5\ (Node.js 20 deprecado) en ambos workflows