### PR TITLE
docs: deep rewrite of the openwiki reference pages

### DIFF
--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,6 +1,6 @@
 {
-  "last_commit": "b8cd20476716bde3f9caee6de885163d699d66ca",
-  "updated_at": "2026-07-07T07:55:26Z",
+  "last_commit": "a0b057cf49bf271b3f8baad5f6700f3de5b0be1d",
+  "updated_at": "2026-07-13T09:33:55Z",
   "mode": "full-generation",
   "generator": "openwiki-writer"
 }

--- a/openwiki/agents.md
+++ b/openwiki/agents.md
@@ -1,84 +1,133 @@
 # ATC Agents (DEL / GND / TWR)
 
-The three stateless ATC pilot agents that draft ICAO-compliant readbacks. Source under
-[`agents/`](../agents/). Called by the [orchestrator](services/orchestrator_service.md); see the
-[architecture](architecture.md) pipeline.
+Three stateless Gemini pilots, one per controller position, deployed independently to **Google
+Cloud Run** — not part of `docker-compose.yml`. Source under [`agents/`](../agents/); the
+orchestrator reaches them through `DEL_AGENT_URL` / `GND_AGENT_URL` / `TWR_AGENT_URL`. Called by
+the [orchestrator](services/orchestrator_service.md); see the [architecture](architecture.md)
+pipeline.
 
 ## What it does
 
-These are **the pilots**. Every readback a controller hears is drafted by one of three
-stateless Gemini agents, one per controller position (Delivery, Ground, Tower). They receive
-the transmission plus prefetched context, apply ICAO phraseology, and return the pilot's
-reply — they hold no memory and touch no database.
+These are the pilots on the other side of the radio. One Cloud Run service per controller
+position — Delivery, Ground, Tower — each wrapping a single Google ADK `Agent` on Gemini:
+stateless Gemini pilots that draft the ICAO readback — nothing more. They don't know what a
+controller phase is — that state machine (`APP`/`DEL`/`GND`/`TWR`) lives entirely in PostgreSQL,
+owned by the orchestrator; these three are phase-agnostic workers that take a transmission plus
+whatever context the orchestrator decided to attach, and hand back a readback.
 
 | Relations | Modules |
 |---|---|
-| **Called by** | [Orchestrator](services/orchestrator_service.md) (`forward` tool → `POST /agents/<role>/run` on Cloud Run) |
-| **Calls** | Gemini on Vertex AI — nothing else in the stack |
+| **Called by** | The orchestrator's `forward_to_agent` tool only — the routing brain that decides which aircraft, which controller phase, which pilot agent, and turns the reply into state and motion |
+| **Calls** | Gemini (`gemini-3.1-flash-lite`) via Google ADK / Vertex AI — nothing else in the stack |
 
-**Deploy & smoke-test them:** [Cloud Agents Deployment](guides/cloud-agents-deployment.md).
+The call itself is a plain HTTP `POST` — no A2A protocol, no `/tasks/send` handshake.
+`forward_to_agent()` is a single `httpx.post()` against `DEL_AGENT_URL` / `GND_AGENT_URL` /
+`TWR_AGENT_URL` plus the role's path. (An earlier prototype, `services/pilots_communication/`,
+did speak `/tasks/send`; it was never wired into `docker-compose.yml` and isn't part of this
+pipeline.)
 
-## Overview
+## One call, one readback
 
-| Agent | Dir | Role |
-|---|---|---|
-| **DEL** — Clearance Delivery | [`agents/del/`](../agents/del/) | Issues IFR clearances (pre-pushback) |
-| **GND** — Ground Control | [`agents/gnd/`](../agents/gnd/) | Pushback approval, taxi routes |
-| **TWR** — Tower | [`agents/twr/`](../agents/twr/) | Takeoff / landing clearances, runway sequencing |
+Follow one ground exchange end to end. By the time this call happens, the orchestrator has
+already matched the callsign, resolved the phase to GND, and — because this is a taxi
+clearance — run the A\* search over the taxiway graph itself; none of that happens inside the
+agent.
 
-- **Framework:** `google-adk` (Agent Development Kit) + **Gemini** (`gemini-3-flash-preview` by
-  default; via `AGENT_MODEL` / Vertex AI).
-- **Deployment:** each agent is deployed **independently to Google Cloud Run** and reached by the
-  orchestrator through `DEL_AGENT_URL` / `GND_AGENT_URL` / `TWR_AGENT_URL`. They are **not** part
-  of `docker-compose.yml`.
-- **Stateless:** the orchestrator passes all needed context (flight plan, clearances, weather,
-  aircraft state) on every call; agents hold no cross-request memory of their own.
+```mermaid
+sequenceDiagram
+    autonumber
+    participant O as Orchestrator forward tool
+    participant M as main.py FastAPI
+    participant R as runner.py ADK Runner
+    participant G as Gemini gemini-3.1-flash-lite
+    O->>M: POST /agents/ground/run
+    M->>R: run_agent(session_id, message, clearance_data)
+    R->>R: get or create ADK session by session_id
+    R->>G: Content = message + CONTEXT block
+    Note over G: tools = none - the agent cannot look anything up
+    G-->>R: streamed events, final response text
+    R->>R: regex-extract the JSON block
+    R-->>M: instruction_text + taxi_data
+    M-->>O: RunResponse JSON
+```
 
-## Per-agent layout
+`main.py` is a thin FastAPI wrapper: the `POST` handler hands the call to `run_agent()` on a
+four-worker `ThreadPoolExecutor`, because `runner.py` opens its own event loop with
+`asyncio.run()` and a FastAPI handler is already inside one — the same constraint the
+orchestrator's own runner works around. Inside `runner.py`, an `InMemorySessionService` keyed by
+`session_id` gives the ADK `Runner` a place to keep turn history for a live conversation; it
+isn't depended on for facts, since the orchestrator re-attaches full context on every call — a
+cold Cloud Run instance with an empty session table produces the same reply. Once Gemini answers,
+the runner regexes `\{.*\}` out of the raw text, `json.loads`s it, and pulls the two fields the
+prompt's output contract promised.
 
-Each agent directory follows the same shape:
+## Why stateless
+
+The design argument is upstream, not in these services. The orchestrator already merges
+PostgreSQL clearances, the flight plan, live Redis state, and — for GND taxi clearances — a
+pre-computed A\* route, before it ever calls `forward_to_agent()`. Because all of that lands in
+the request body, the pilot agent needs no database connection, no Redis client, and no tool the
+way the orchestrator's own routing agent has six. That buys three things: Cloud Run can scale
+each agent to zero between transmissions since there's no persistent connection to keep warm;
+benchmarking is hermetic — [`benchmark_agents.py`](../agents_evaluation/benchmark_agents.py) can
+replay a fixed corpus entry against the live endpoint and get a repeatable grade without standing
+up the rest of the stack; and there's no cross-request drift, because nothing about aircraft N's
+clearance can leak into aircraft M's readback through shared state.
+
+## The three positions
+
+| Agent | Source | Clears | Receives | Returns |
+|---|---|---|---|---|
+| **DEL** | [`agents/del/`](../agents/del/) | IFR clearance, pre-pushback | `flight_plan`, `atis` | `clearance_text` + `clearance_data` (squawk, initial_altitude, instrumental_departure, runway_in_use, altimeter, destination_icao) |
+| **GND** | [`agents/gnd/`](../agents/gnd/) | Pushback + taxi route | `clearance_data`, incl. `taxi_route.taxiway_sequence` | `instruction_text` + `taxi_data` (pushback_approved, taxi_route, runway_in_use, stand_id, taxi_purpose) |
+| **TWR** | [`agents/twr/`](../agents/twr/) | Lineup, takeoff, landing, go-around, handoff to ground | `clearance_data` | `reply_text` + `reply_data` (runway_in_use, sid or frequency) |
+
+*DEL:* "Cleared to Barcelona via DVOR2G departure, maintain 6000 feet, squawk 2341, QNH 1013,
+EC-REU." *GND:* "Iberia 123, taxi holding point runway 06R via Bravo, Delta, Echo." *TWR:*
+"Runway 32L, cleared for takeoff, NANDO3R departure, EC-REU."
+
+TWR's prompt actually classifies every reply into a `clearance_type` — `takeoff` / `lineup` /
+`landing` / `goaround` / `handoff_gnd` / `other` — as a top-level sibling of `reply_text` in the
+JSON it's told to emit. `runner.py`, though, only extracts `reply_text` and `reply_data`;
+`clearance_type` is parsed and then discarded, and `RunResponse` has no field for it. The
+classification logic is real and drives the phrasing, it just never crosses the HTTP boundary
+back to the orchestrator today.
+
+## Anatomy of an agent
 
 ```
 agents/<phase>/
-  main.py                     # FastAPI/HTTP entrypoint exposed on Cloud Run
-  runner.py                   # google-adk Runner wiring: builds Content, runs the agent, extracts reply
-  agent/agent.py              # the adk Agent definition (model, tools, instruction)
-  agent/prompts/              # system / instruction prompts (ICAO phraseology rules)
-  agent/tools/                # (gnd, twr) agent-side tools
-  shared/callbacks.py         # (gnd, twr) adk callbacks (logging / guardrails)
-  Dockerfile, requirements.txt
+  main.py                   # FastAPI: POST /agents/<role>/run, GET /health, GET /agents/<role>/info
+  runner.py                 # ADK Runner + InMemorySessionService, JSON extraction
+  agent/agent.py             # Agent(model=AGENT_MODEL, tools=[], instruction=SYSTEM_PROMPT)
+  agent/prompts/system.py     # ICAO phraseology rules + the JSON output contract
+  agent/tools/                # gnd, twr only - present but empty, nothing registered on the Agent
+  shared/callbacks.py          # log_before / log_after - a local copy per agent
 ```
 
-## Runner pattern
+The prompt in `agent/prompts/system.py` is where all the ATC knowledge actually lives:
+message-type classification (a clearance versus a greeting versus "say again"), the exact ICAO
+readback phrasing, and the JSON shape the runner expects back. `agent/tools/` exists as an empty
+package under GND and TWR — a leftover from an earlier shape. It's not used: the `Agent(...)`
+constructor in every `agent/agent.py` passes `tools=[]` explicitly, so nothing is actually
+callable from inside the model. `shared/callbacks.py` is duplicated per agent rather than
+imported once — one `log_before`/`log_after` pair per file, each tuned to that agent's own field
+names (`clearance_data`, `taxi_data`, `reply_data`) for structured before/after-agent logging.
+Despite the name, this is not the repo-wide [`shared/`](shared.md) package — it's a same-named,
+independent directory local to each agent.
 
-Runners use an in-memory adk session keyed by `session_id`, create the session on first contact,
-then stream events and collect the final response text. Example
-([`agents/gnd/runner.py`](../agents/gnd/runner.py)):
+## Deployment and evaluation
 
-```python
-_runner = Runner(agent=gnd_agent, app_name="airport_gnd", session_service=InMemorySessionService())
-
-def run_agent(session_id, message, clearance_data=None):
-    # orchestrator-provided context is appended under a [CONTEXT] block
-    enriched = message + f"\n[CONTEXT]\nClearance data: {clearance_data}"
-    # ... create/get session, run_async, collect event.is_final_response() text
-```
-
-The orchestrator enriches each call with pre-fetched context so the agent doesn't have to fetch
-data itself. GND, for instance, receives `clearance_data`.
-
-## How the orchestrator reaches them
-
-The orchestrator's `forward` tool
-([`services/orchestrator_service/agent/tools/forward.py`](../services/orchestrator_service/agent/tools/forward.py))
-posts the transmission to the selected agent's endpoint and returns the readback. Which agent is
-chosen depends on the aircraft's phase (see the state machine in [architecture](architecture.md)).
-
-## Evaluation
-
-Agent quality and WER are benchmarked against phase-specific corpora under
-[`agents_evaluation/`](../agents_evaluation/) (`corpus_wer/del|gnd|twr`). See
-[data-and-testing](data-and-testing.md).
+Each agent deploys independently with its own `gcloud run deploy`; the walkthrough, required env
+vars, and smoke-test `curl` commands are in
+[Cloud Agents Deployment](guides/cloud-agents-deployment.md). Quality is tracked outside the
+request path: [`benchmark_agents.py`](../agents_evaluation/benchmark_agents.py) replays a
+142-entry corpus (42 DEL + 50 GND + 50 TWR) against the live Cloud Run endpoints and reports
+latency percentiles plus schema validity per agent; [`validate_agents.py`](../agents_evaluation/validate_agents.py)
+goes further, phonetically decoding the expected squawk/altitude/runway out of the ATC text and
+comparing it field by field against what the agent actually returned. Both read their corpus from
+[`agents_evaluation/corpus_wer/`](../agents_evaluation/corpus_wer/) (`del/`, `gnd/`, `twr/`); see
+[data-and-testing](data-and-testing.md) for the rest of the evaluation and test layout.
 
 ## Related
-[index](index.md) · [architecture](architecture.md) · [orchestrator](services/orchestrator_service.md) · [data-and-testing](data-and-testing.md)
+[index](index.md) · [architecture](architecture.md) · [orchestrator](services/orchestrator_service.md) · [data-and-testing](data-and-testing.md) · [Cloud Agents Deployment](guides/cloud-agents-deployment.md)

--- a/openwiki/architecture.md
+++ b/openwiki/architecture.md
@@ -1,104 +1,251 @@
 # Architecture
 
-End-to-end design of AIrport: how a spoken controller instruction becomes aircraft motion in
-X-Plane 12. See [index](index.md) for the page map.
+How AIrport works end to end: what happens between the moment the controller presses
+push-to-talk and the moment an aircraft moves and answers back inside X-Plane 12. This page is
+the hub — every diagram here is referenced from the per-component pages, and each section links
+to the page that owns the detail. For the page map, see [index](index.md).
 
-## Voice → motion pipeline
+Two ideas organize the whole system:
 
-1. **Controller speaks** into the mic in the Controller HMI web UI
-   ([controller_hmi_service](services/controller_hmi_service.md), port 8005).
-2. **ASR** ([asr_service](services/asr_service.md), 8006) transcribes the audio with a Whisper
-   model fine-tuned for ATC, then corrects the callsign (phonetics + LLM corrector).
-3. **Orchestrator** ([orchestrator_service](services/orchestrator_service.md), 8007) receives the
-   transcript at `POST /dispatch`. An LLM orchestrator agent (google-adk + Gemini):
-   - looks up known aircraft (PostgreSQL / flight-plan service / Redis),
-   - identifies & corrects the callsign,
-   - decides the responsible controller from the aircraft's **phase** (`DEL → GND → TWR`),
-   - forwards the message to the matching agent and returns the reply.
-4. **ATC agent** ([agents](agents.md), DEL/GND/TWR on Cloud Run) drafts the ICAO-compliant pilot
-   readback with Gemini, using context (flight plan, clearances, weather) supplied by the orchestrator.
-5. **Taxi routing** ([shared/services/taxi_router](shared.md)) computes an A\* taxi route with
-   pushback leg and dispatches a multi-leg move plan (via Redis) to the plugin.
-6. **X-Plane plugin** ([xplane](xplane.md)) moves/spawns the aircraft and speaks the readback with
-   X-Plane's built-in TTS.
+1. **HTTP inside Docker, Redis across the boundary.** The backend services call each other over
+   plain HTTP on the Compose network. The X-Plane plugin runs on the host, inside the simulator,
+   and is reached exclusively through Redis: it polls keys for commands and publishes events
+   back. Redis is the boundary between the Docker backend and the host-side sim plugin.
+2. **The LLM decides, deterministic code executes.** Gemini models decide *which aircraft is
+   being addressed* and *what the pilot says back*. Everything safety-shaped — parsing taxiway
+   clearances, computing routes, moving the aircraft — is deterministic Python that can be
+   unit-tested.
 
+## The voice → motion pipeline
+
+Take one concrete exchange. The controller holds push-to-talk and says: *"Vueling four five
+zero two, pushback approved, taxi holding point runway one seven via Bravo."*
+
+1. The browser records the audio and sends it to the [Controller HMI](services/controller_hmi_service.md)
+   (port 8005) — the controller's screen, and the single host the browser ever talks to. The HMI
+   proxies the audio to the ASR service.
+2. The [ASR service](services/asr_service.md) (8006) turns controller speech into corrected ATC
+   text: a Whisper model fine-tuned for ATC transcribes, then a correction pass repairs numbers,
+   callsigns, SIDs and taxiway letters.
+3. The browser shows the transcript and dispatches it — again through the HMI gateway — to the
+   [orchestrator](services/orchestrator_service.md) (8007), the routing brain.
+4. The orchestrator merges *known aircraft* from three sources — PostgreSQL clearances (the
+   authoritative controller phase), the [Flight Plan service](services/flight_plan_service.md),
+   and live Redis state — matches the callsign to **VLG4502**, reads its phase (GND), and, since
+   this is a taxi clearance, pre-computes an A\* route over the airport taxiway graph.
+5. It forwards the message plus context with a plain HTTP POST to the matching
+   [pilot agent](agents.md) on Cloud Run — stateless Gemini pilots that draft the ICAO readback,
+   nothing more.
+6. With the readback in hand, the orchestrator persists what must survive (clearance row, phase
+   change) to PostgreSQL, has the [taxi router](shared.md) turn the acknowledged clearance into a
+   multi-leg movement plan stored at `aircraft:{reg}:move_cmd`, and RPUSHes the reply text onto
+   `tts:queue`.
+7. Inside X-Plane, the [plugin](xplane.md) polls Redis: the mover picks up the plan and starts
+   the pushback; the window manager pops `tts:queue` and speaks the readback with X-Plane's
+   built-in TTS. The controller hears the pilot answer and watches the aircraft comply on the
+   ground radar.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant H as HMI 8005
+    participant A as ASR 8006
+    participant O as Orchestrator 8007
+    participant P as PostgreSQL
+    participant G as Pilot agent on Cloud Run
+    participant R as Redis
+    B->>H: push-to-talk audio
+    H->>A: POST /transcribe
+    A-->>H: corrected transcript
+    H-->>B: transcript in chat
+    B->>H: POST /dispatch
+    H->>O: transcript + session_id
+    O->>P: merge known aircraft + phase
+    Note over O: match callsign · pick DEL/GND/TWR ·<br/>detect handoff · A* route if taxi
+    O->>G: POST /agents/gnd/run
+    G-->>O: ICAO readback JSON
+    O->>P: persist clearance / advance phase
+    O->>R: SET aircraft:{reg}:move_cmd · RPUSH tts:queue
+    O-->>B: readback in chat
 ```
-Controller mic
-   │ audio
-   ▼
-ASR (Whisper-ATC + callsign correction)          services/asr_service  :8006
-   │ transcript
-   ▼
-Orchestrator  POST /dispatch                      services/orchestrator_service :8007
-   │  • identify aircraft + callsign (Postgres / Redis / flight_plan)
-   │  • pick controller by phase (DEL→GND→TWR)
-   │  • agent tools: get_taxi_route, advance_to_gnd, advance_twr, forward, confirm
-   ▼ forward
-DEL / GND / TWR agent (Gemini, google-adk)        agents/  → Cloud Run (*_AGENT_URL)
-   │ ICAO readback
-   ▼
-taxi_router (A* route + pushback) ── Redis move plan ──▶ X-Plane plugin  (xplane_plugin/, plugins/)
-                                                                │
-                                                                ▼
-                                                    aircraft moves + TTS readback
+
+The diagram deliberately stops at Redis. What happens on the other side of that boundary is the
+next section.
+
+## One boundary, two worlds: Redis
+
+The plugin cannot be a Docker service — it lives inside X-Plane's process on the host. Instead
+of exposing an HTTP server in the sim, AIrport gives both worlds one shared Redis and a small
+key contract. The crucial design point: **for commands, the plugin polls; it never subscribes.**
+The mover scans `aircraft:*:move_cmd` every second, the window manager LPOPs `tts:queue` and
+re-reads `airport:session_request` every two seconds. Polling keeps X-Plane's flight loop in
+control (no blocking socket callbacks in the render thread) and survives restarts on either side.
+Pub/sub flows in the *outbound* direction only: motion milestones on `aircraft:{reg}:move_events`
+and chat messages on `hmi:chat`.
+
+```mermaid
+flowchart LR
+    subgraph Backend [Docker backend]
+        ORCH[Orchestrator + taxi router]
+        ARR[Arrival Simulator]
+        HMI[Controller HMI]
+    end
+    subgraph RB [Redis - the boundary]
+        CMD["aircraft:{reg}:move_cmd"]
+        TTS["tts:queue"]
+        SREQ["airport:session_request"]
+        ST["aircraft:state:{reg}"]
+        EV["aircraft:{reg}:move_events"]
+    end
+    subgraph Sim [X-Plane host plugin]
+        MV[AircraftMover]
+        WM[WindowManager]
+    end
+    ORCH -- "SET with TTL" --> CMD
+    ARR -- "SET" --> CMD
+    ORCH -- "RPUSH" --> TTS
+    HMI -- "HSET" --> SREQ
+    CMD -- "scan every 1 s - poll" --> MV
+    TTS -- "LPOP every 2 s - poll" --> WM
+    SREQ -- "poll every 2 s" --> WM
+    MV -- "HSET every 0.5 s" --> ST
+    MV -- "PUBLISH" --> EV
+    ST -- "read" --> HMI
+    EV -- "psubscribe" --> ORCH
+    EV -- "subscribe" --> ARR
 ```
 
-## Aircraft phase state machine
+## The Redis contract
 
-The orchestrator tracks each aircraft through phases defined in
-[`shared/models/phases.py`](../shared/models/phases.py). Phase determines which controller owns
-the aircraft and which agent gets the message:
+If you touch Redis anywhere in this repo, this is the contract. Key templates live in
+[`shared/services/taxi_router/config.py`](../shared/services/taxi_router/config.py),
+[`shared/services/aircraft_state_store.py`](../shared/services/aircraft_state_store.py) and
+[`services/orchestrator_service/session_log.py`](../services/orchestrator_service/session_log.py);
+`{reg}` is the aircraft registration, `{sid}` the session id.
 
-- **Departure:** `parked → pushback → taxi_out → holding → lineup → takeoff_roll → airborne`
-- **Arrival:** `approach → short_final → landing_roll → vacating → taxi_in`
+| Key / channel | Kind | Writer → reader | Purpose |
+|---|---|---|---|
+| `aircraft:{reg}:move_cmd` | string JSON, TTL | taxi router, arrival sim → plugin mover (1 s scan) | The multi-leg movement plan — the only way anything moves |
+| `aircraft:spawn_request:{reg}` | string JSON | arrival sim → plugin mover (deleted after spawn) | Spawn an airborne arrival |
+| `tts:queue` | list | orchestrator, arrival event bridge → plugin (2 s LPOP) | Pilot lines to speak in-sim |
+| `airport:session_request` | hash | HMI → plugin (2 s poll) | Session start/stop handshake |
+| `aircraft:state:{reg}` | hash, TTL 1 h | plugin → HMI radar, taxi router | Live position/heading/speed/phase snapshot |
+| `aircraft:active_set` | set | plugin state store → HMI, orchestrator | Registrations currently alive |
+| `aircraft:updates` | pub/sub | plugin state store → any listener | Fan-out of every state write |
+| `aircraft:{reg}:move_events` | pub/sub | plugin mover → orchestrator, arrival event bridge | Motion milestones (`touchdown`, `reached_end`, …) |
+| `hmi:chat` | pub/sub | taxi router → HMI WebSocket, orchestrator log | Pilot-voice rejections and chat lines |
+| `aircraft:{reg}:last_error` | string, TTL 5 min | taxi router → humans debugging | Why the last routing attempt failed |
+| `airport:current:*` | keys/hashes | plugin airport loader → taxi router, plugin | Parsed airport graph, stands, frequencies, occupancy |
+| `airport:asr_config` | hash | HMI login → (legacy) | Stored user API key; the ASR now reads env config |
+| `arrivals:assigned` | set | arrival sim | Arrivals already dispatched this session |
+| `session:current` | hash | airport data store | Active session metadata |
+| `session:{sid}:transcripts` / `:agent_replies` / `:events` | lists, TTL 2 h | orchestrator → debrief builder | Everything said and done, for the debrief |
 
-Controller mapping: **DEL** (clearance, pre-pushback) → **GND** (pushback, taxi) → **TWR**
-(lineup, takeoff/landing). Orchestrator agent tools `advance_to_gnd`, `advance_twr`, and
-`advance_to_gnd_arrival` move an aircraft between controllers.
+## Two state machines, not one
+
+Earlier versions of these docs blurred a distinction the code keeps sharp. There are **two**
+state machines, owned by different components, living in different stores:
+
+- The **controller-phase state machine** — `APP / DEL / GND / TWR`, stored in the PostgreSQL
+  column `aircraft_clearances.dependency`, owned by the orchestrator. It answers *"which
+  controller position owns this aircraft right now?"* and only explicit handoff phrases
+  ("contact ground", "contact tower") move it. Home:
+  [orchestrator](services/orchestrator_service.md).
+- The **motion state machine** — `waiting → pushback → taxi_out → done` for departures,
+  `approach → landing_roll → vacating → taxi_in → parked` for arrivals, kept per-aircraft inside
+  the plugin's mover. It answers *"what is this aircraft physically doing?"*. Home:
+  [xplane](xplane.md).
+
+They interact but never merge: a controller handoff does not move the aircraft, and a completed
+taxi does not change who owns the frequency.
 
 ## Service topology
 
-All application services are FastAPI + Uvicorn, containerized via
-[`docker-compose.yml`](../docker-compose.yml). Ports are `host:container`.
+All backend services are FastAPI + Uvicorn containers defined in
+[`docker-compose.yml`](../docker-compose.yml); each exposes a `/health` endpoint used by the
+Compose healthchecks. The three pilot agents are **not** in Compose — they deploy independently
+to Google Cloud Run and are reached through `DEL_AGENT_URL` / `GND_AGENT_URL` / `TWR_AGENT_URL`.
 
-| Service | Port | Talks to |
+```mermaid
+flowchart TD
+    subgraph Client
+        BR[Browser]
+    end
+    subgraph Docker [Docker - airport_network]
+        HMI[Controller HMI 8005]
+        ASR[ASR 8006]
+        ORCH[Orchestrator 8007]
+        FP[Flight Plan 8003]
+        WX[Weather 8004]
+        AS[Arrival Simulator 8008]
+        RD[(Redis 6379)]
+    end
+    subgraph GCP [Google Cloud Run]
+        AG[DEL / GND / TWR pilot agents]
+    end
+    subgraph Host [X-Plane 12 host]
+        PL[XPPython3 plugin]
+    end
+    BR --> HMI
+    HMI --> ASR
+    HMI --> ORCH
+    HMI --> FP
+    HMI --> WX
+    ORCH --> AG
+    ORCH --> FP
+    ORCH --> WX
+    AS --> FP
+    AS --> HMI
+    AS --> ORCH
+    ORCH --> RD
+    AS --> RD
+    PL --> RD
+```
+
+| Service | Port (host:container) | Talks to (HTTP) |
 |---|---|---|
-| [Controller HMI](services/controller_hmi_service.md) | 8005:8000 | asr, orchestrator, flight_plan, weather, Postgres, Redis |
-| [Flight Plan](services/flight_plan_service.md) | 8003:8000 | Postgres, flightplandatabase.com |
-| [Weather](services/weather_service.md) | 8004:8000 | Postgres, external METAR/TAF sources |
-| [ASR](services/asr_service.md) | 8006:8000 | Redis, orchestrator |
-| [Orchestrator](services/orchestrator_service.md) | 8007:8006 | flight_plan, weather, Postgres, Redis, DEL/GND/TWR agents |
-| [Arrival Simulator](services/arrival_simulator_service.md) | 8008:8000 | Redis, flight_plan, orchestrator, HMI |
+| [Controller HMI](services/controller_hmi_service.md) | 8005:8000 | asr, orchestrator, flight_plan, weather |
+| [Flight Plan](services/flight_plan_service.md) | 8003:8000 | flightplandatabase.com (optional) |
+| [Weather](services/weather_service.md) | 8004:8000 | aviationweather.gov |
+| [ASR](services/asr_service.md) | 8006:8000 | orchestrator (optional server-side dispatch) |
+| [Orchestrator](services/orchestrator_service.md) | 8007:8006 | flight_plan, weather, DEL/GND/TWR agents |
+| [Arrival Simulator](services/arrival_simulator_service.md) | 8008:8000 | flight_plan, hmi, orchestrator |
 
-The three ATC agents are **not** in Compose — they deploy independently to **Google Cloud Run**
-and are reached through `DEL_AGENT_URL` / `GND_AGENT_URL` / `TWR_AGENT_URL`.
+## Three data stores, three jobs
 
-## Data stores
+| Store | Port | Job |
+|---|---|---|
+| PostgreSQL `postgres:15-alpine` | 5432:5432 | Durable rows: `users`, `flight_plans`, `atis_broadcasts`, `aircraft_clearances` |
+| Redis `redis:7-alpine` | 6379:6379 | Live state + the message bus (the contract above) |
+| InfluxDB `influxdb:2.7-alpine` | 8087:8086 | Time series: every aircraft state as measurement `aircraft_state` |
 
-| Store | Image | Port | Used for |
-|---|---|---|---|
-| PostgreSQL | `postgres:15-alpine` | 5432:5432 | Flight plans, clearances, aircraft records, weather/ATIS (`config/postgres/init.sql`) |
-| Redis | `redis:7-alpine` | 6379:6379 | Aircraft state store, live positions, move-command plans, pub/sub events |
-| InfluxDB | `influxdb:2.7-alpine` | 8087:8086 | Time-series (telemetry/metrics) |
+```mermaid
+flowchart LR
+    SVC[Backend services] -- "durable rows" --> PG[(PostgreSQL)]
+    PL[Plugin state store] -- "live state, TTL" --> RD[(Redis)]
+    PL -- "batched points" --> IN[(InfluxDB)]
+    RD -- "positions" --> RADAR[HMI ground radar]
+    IN -- "query_replay" --> DEB[Session debrief]
+```
 
-## Inter-service communication
+The same aircraft state is written twice on purpose: to Redis for *now* (the radar, the taxi
+router) and to InfluxDB for *history* (the post-session debrief replays it). Details:
+[shared](shared.md).
 
-- **HTTP (REST):** services call each other via the `*_SERVICE_URL` / `*_AGENT_URL` env vars
-  (see the `environment:` blocks in [`docker-compose.yml`](../docker-compose.yml)). Each service
-  exposes a `/health` endpoint used by Compose healthchecks.
-- **Redis pub/sub:** the orchestrator subscribes to events via
-  [`api/events_subscriber.py`](../services/orchestrator_service/api/events_subscriber.py); the
-  arrival simulator publishes arrival lifecycle events (`core/event_bridge.py`). Aircraft state
-  and move plans flow through Redis keys consumed by the plugin.
+## Departure and arrival, side by side
 
-## Two main flows
+A **departure** is driven by the controller's voice from the first clearance: DEL issues the IFR
+clearance, GND approves pushback and taxi (this is where `move_cmd` plans are born), TWR clears
+takeoff. The whole chain is exercised end-to-end by
+[`tests/integration/test_departure_pipeline.py`](../tests/integration/test_departure_pipeline.py).
 
-- **Departure pipeline:** HMI → ASR → orchestrator `/dispatch` → DEL→GND→TWR → taxi_router → plugin.
-  Integration test: [`tests/integration/test_departure_pipeline.py`](../tests/integration/test_departure_pipeline.py).
-- **Arrival pipeline:** [arrival_simulator](services/arrival_simulator_service.md) spawns aircraft
-  on the ILS and drives them through arrival phases to vacate/taxi-in; orchestrator handles arrival
-  handoffs (`api/arrivals.py`, `advance_to_gnd_arrival`).
-  Integration test: [`tests/integration/test_arrival_pipeline.py`](../tests/integration/test_arrival_pipeline.py).
+An **arrival** is born in software instead: the
+[Arrival Simulator](services/arrival_simulator_service.md) spawns it on the ILS and flies it
+down; the controller first hears from it at four miles final, clears it to land, and hands it to
+ground after vacating — the reverse handoff (`advance_to_gnd_arrival`). End-to-end test:
+[`tests/integration/test_arrival_pipeline.py`](../tests/integration/test_arrival_pipeline.py).
 
 ## Related
-[index](index.md) · [agents](agents.md) · [orchestrator](services/orchestrator_service.md) · [shared](shared.md) · [xplane](xplane.md)
+
+[index](index.md) · [orchestrator](services/orchestrator_service.md) · [agents](agents.md) · [shared](shared.md) · [xplane](xplane.md) · [asr](services/asr_service.md)

--- a/openwiki/data-and-testing.md
+++ b/openwiki/data-and-testing.md
@@ -1,46 +1,134 @@
 # Data, evaluation & testing
 
-Airport data, agent/WER evaluation, and the pytest suite. See [index](index.md).
+How AIrport checks its own work: offline airport data that seeds the simulator, two benchmark
+families that score the ASR and the pilot agents against a hand-written corpus, and the pytest
+suite that exercises the deterministic code without touching Redis, PostgreSQL, or an LLM. See
+[index](index.md).
 
-## `data/` — airport data & scripts
+## Airport data: data/
 
-| Path | Role |
-|---|---|
-| [`data/airport_data/LEBL/`](../data/airport_data/) | Barcelona (LEBL) airport data — taxiways, stands, graph inputs |
-| [`data/scripts/airport_data_fetcher.py`](../data/scripts/airport_data_fetcher.py) | Fetches raw airport data |
-| [`data/scripts/airport_graph_builder.py`](../data/scripts/airport_graph_builder.py) | Builds the taxiway graph consumed by [taxi_router](shared.md) |
-| [`data/notebooks/visualization.ipynb`](../data/notebooks/) | Visualization notebook |
+Barcelona (LEBL) is the one airport with data checked into the repo, under
+[`data/airport_data/LEBL/`](../data/airport_data/LEBL/): the raw apt.dat scenery file
+(`LEBL.dat`), a parsed `LEBL_graph.json`, and an interactive `LEBL_airport_map.html`. Two scripts
+under [`data/scripts/`](../data/scripts/) produce them. `airport_data_fetcher.py`
+(`XPlaneAirportDownloader`) pulls the scenery package straight from the X-Plane Scenery Gateway
+via the `xplane-airports` package — `downloader.download()` writes `airport_data/{ICAO}/{ICAO}.dat`.
+`airport_graph_builder.py` (`AirportMapVisualizer`) then parses the same apt.dat row codes the
+plugin understands — `100` runways, `1201`/`1202` taxi nodes and edges, `1300` stands — and
+renders them as a layered Folium map; a `get_graph_data()` method exposes the same parsed
+elements as a plain dict for notebook use.
+[`data/notebooks/visualization.ipynb`](../data/notebooks/visualization.ipynb) drives this
+visualizer interactively.
 
-Plotting/analysis utilities live under [`scripts/`](../scripts/): `plot_airport_routes.py`,
-`plot_agent_benchmark.py`, `analyze_pipeline_log.py`, `plot_lest_*`, `overlay_lest_routes_on_image.py`.
+It's tempting to assume this is where the taxiway graph `taxi_router` actually routes over comes
+from — it isn't. Every session re-parses the current airport's apt.dat from scratch at runtime:
+the plugin's `data_parser.py` and `graph.py` build the graph fresh and write it into Redis under
+`airport:current:*` (see [xplane](xplane.md)). The `LEBL_graph.json` checked into `data/` gives
+the game away once you compare shapes — its nodes carry a `usage` field that matches the plugin's
+`TaxiNode`, not `get_graph_data()`'s output — so it's an offline snapshot for analysis, not a
+build input consumed by anything at runtime.
 
-## `agents_evaluation/` — agent & WER benchmarks
+Repo-root [`scripts/`](../scripts/) holds the plotting utilities that turn benchmark and log
+output into figures, mostly for the thesis write-up: `plot_airport_routes.py` renders airport
+plans with sample routes; `plot_lest_graph.py`, `plot_lest_routes.py` and
+`overlay_lest_routes_on_image.py` do the same for a second airport, LEST, whose source data isn't
+checked into `data/` — the last one homography-warps the routes onto a real X-Plane screenshot;
+`analyze_pipeline_log.py` extracts per-stage latencies from `logs/pipeline.log`;
+`plot_agent_benchmark.py` charts the agent benchmark below; and the newest,
+`plot_asr_benchmark.py`, renders the ASR benchmark CSVs into WER/RTF/latency figures under
+`output/asr_bench/figs/`.
 
-| Path | Role |
-|---|---|
-| [`benchmark_agents.py`](../agents_evaluation/benchmark_agents.py) | Benchmarks the DEL/GND/TWR [agents](agents.md) |
-| [`validate_agents.py`](../agents_evaluation/validate_agents.py) | Validates agent responses |
-| [`evaluate_wer.py`](../agents_evaluation/evaluate_wer.py) | Word Error Rate for [ASR](services/asr_service.md) (uses `jiwer`) |
-| [`corpus_wer/`](../agents_evaluation/corpus_wer/) | Phase-specific corpora (`del` / `gnd` / `twr`) + [README](../agents_evaluation/corpus_wer/README.md) |
-| `output/` | Benchmark results (CSV) |
+## Measuring the AI: agents_evaluation/
 
-## `tests/` — pytest suite
+Two independent benchmark families live in [`agents_evaluation/`](../agents_evaluation/), and both
+draw on the same corpus: [`corpus_wer/`](../agents_evaluation/corpus_wer/) holds a `del/`, `gnd/`
+and `twr/` subfolder, each with a `corpus_wer_*.txt` of 100 hand-written exchanges (300 total) — a
+`>` controller transmission and a `<` expected ICAO pilot readback per entry, format documented in
+[`corpus_wer/README.md`](../agents_evaluation/corpus_wer/README.md).
 
-Config in [`pyproject.toml`](../pyproject.toml) (`[tool.pytest.ini_options]`): `asyncio_mode = auto`,
-`testpaths = ["tests"]`, coverage `fail_under = 70`. `pythonpath` includes the orchestrator and
-arrival_simulator service roots so their modules import bare in tests.
+**Speech** asks how well the ASR — which turns controller speech into corrected ATC text — hears.
+[`evaluate_wer.py`](../agents_evaluation/evaluate_wer.py) is the local loop: it transcribes every
+corpus `.wav` through a live ASR endpoint and scores `jiwer` WER against the reference line, and
+optionally replays the DEL hypotheses through the orchestrator as a smoke test.
+[`benchmark_asr.py`](../agents_evaluation/benchmark_asr.py) (new) targets the deployed Cloud Run
+ASR instead: stdlib-only, with its own word-level Levenshtein aligner (substitutions, deletions,
+insertions — no `jiwer`), it reports micro- and macro-averaged WER both raw and after
+canonicalisation (numbers, callsigns and SIDs folded to coded form, reusing the service's own
+`core.postprocess` when importable), plus server-side latency, RTF, and estimated cost from
+`--cost-per-h`. Three `--context` modes (`none` / `generic` / `session`) exercise the service's
+fuzzy entity matcher, the last feeding it per-session callsign/SID vocabularies pulled straight
+from the corpus. Audio is referenced from an external `pilot-readback-corpus` checkout, never
+copied into this repo. Results land under `output/asr_bench/` (a different tree from
+`agents_evaluation/output/` below) and are charted by
+[`plot_asr_benchmark.py`](../scripts/plot_asr_benchmark.py).
+
+**Agents** asks how well the pilots answer. Each DEL/GND/TWR endpoint is one of the stateless
+Gemini pilots that draft the ICAO readback — nothing more — so grading them means grading the
+reply itself. [`benchmark_agents.py`](../agents_evaluation/benchmark_agents.py) posts every corpus
+line to its matching Cloud Run endpoint and checks latency, HTTP status, and whether the
+structured block (`clearance_data` / `taxi_data` / `reply_data`) carries every required field.
+[`validate_agents.py`](../agents_evaluation/validate_agents.py) goes deeper, regex-decoding the
+expected values straight out of the phonetic ATC text (squawk, SID, runway, QNH, destination…)
+and comparing them field-by-field against the agent's response, three dependency workers running
+in parallel. Newest of all: [`judge_responses.py`](../agents_evaluation/judge_responses.py) runs
+an LLM-as-judge pass — `gemini-2.5-pro` on Vertex scores each reply against the transmission and
+reference readback on five axes (values correct, complete, no hallucination, phraseology 1-5,
+overall) — and [`judge_agreement.py`](../agents_evaluation/judge_agreement.py) turns a
+hand-labelled sample of the judge's verdicts into a Cohen's-kappa reliability figure for it.
+
+```mermaid
+flowchart LR
+    CORPUS["corpus_wer/: del + gnd + twr, 100 each"]
+    WAV["external wav dataset"]
+    SPEECHB["speech benchmarks: evaluate_wer.py, benchmark_asr.py"]
+    ASRN["ASR: local service or deployed Cloud Run"]
+    SPEECHOUT["WER / latency / RTF / cost CSVs"]
+    AGENTB["agent benchmarks: benchmark_agents.py, validate_agents.py, judge_responses.py"]
+    AGENTS["DEL / GND / TWR agents on Cloud Run"]
+    SCHEMAOUT["schema + semantic reports"]
+    JUDGEOUT["LLM-judge CSVs + agreement"]
+    CORPUS --> SPEECHB
+    WAV --> SPEECHB
+    SPEECHB --> ASRN
+    ASRN --> SPEECHOUT
+    CORPUS --> AGENTB
+    AGENTB --> AGENTS
+    AGENTS --> SCHEMAOUT
+    AGENTS --> JUDGEOUT
+```
+
+## The pytest suite
+
+Config lives in [`pyproject.toml`](../pyproject.toml)'s `[tool.pytest.ini_options]`:
+`asyncio_mode = "auto"`, `testpaths = ["tests"]`, `pythonpath` extended with the orchestrator and
+arrival-simulator service roots so their modules import bare, and a coverage gate of
+`fail_under = 70` scoped to a specific `source` list (the orchestrator's agent/api/db layers, the
+arrival-simulator core modules, `shared/services/taxi_router`) rather than the whole repo. What
+makes the deepest tests possible is [`tests/fixtures/`](../tests/fixtures/):
+[`fake_redis.py`](../tests/fixtures/fake_redis.py) is a synchronous in-memory stand-in for the
+Redis commands the code actually uses (KV, hash, set, list, pub/sub, pipelines),
+[`fake_db.py`](../tests/fixtures/fake_db.py) builds a per-test SQLite `:memory:` engine from the
+real SQLAlchemy `Base.metadata`, and [`adk_runner.py`](../tests/fixtures/adk_runner.py)'s
+`FakeADKRunner` scripts what the Gemini agent runner would yield without ever calling an LLM.
+Wired together in one fixture, these three fakes let even
+[`tests/integration/test_departure_pipeline.py`](../tests/integration/test_departure_pipeline.py)
+and [`test_arrival_pipeline.py`](../tests/integration/test_arrival_pipeline.py) run the full
+clearance-to-Redis-write pipeline hermetically — no simulator, no cloud call, no open network
+socket anywhere in the run.
 
 | Area | Path | Covers |
 |---|---|---|
-| Departure/arrival e2e | [`tests/integration/`](../tests/integration/) | `test_departure_pipeline.py`, `test_arrival_pipeline.py` |
-| Orchestrator units | [`tests/unit/orchestrator/`](../tests/unit/orchestrator/) | dispatch, advance tools, arrivals endpoint, events subscriber, forward tool, frequency audit, repository, runner, session log |
+| Departure/arrival e2e | [`tests/integration/`](../tests/integration/) | full pipeline over the three fakes |
+| Orchestrator units | [`tests/unit/orchestrator/`](../tests/unit/orchestrator/) | dispatch, advance tools, arrivals endpoint, events subscriber, forward tool, frequency audit, known-aircraft tool, taxi-route tool, repository, runner, session log |
 | Arrival simulator units | [`tests/unit/arrival_simulator/`](../tests/unit/arrival_simulator/) | event bridge |
 | Taxi routing | [`tests/taxi_router/`](../tests/taxi_router/) | graph construction, token resolution, routing e2e, pushback leg, HMI chat |
 | Arrivals | [`tests/arrivals/`](../tests/arrivals/) | phases, runway config, arrival planner, geo |
 | Debrief | [`tests/debrief/`](../tests/debrief/) | debrief builder |
-| Fixtures | [`tests/fixtures/`](../tests/fixtures/) | `fake_db.py`, `fake_redis.py`, `adk_runner.py` |
 
-Run: `uv run pytest` (or `pytest`). Coverage source/omit lists are in `[tool.coverage.run]`.
+Run with `uv run pytest` (or plain `pytest`). The honest gap sits outside this table entirely:
+`xplane_plugin/` — the in-sim motion engine — appears nowhere in the coverage `source` list and
+has no unit tests of its own. The mover's state machine is exercised only indirectly, through the
+integration fakes above and manual sessions inside X-Plane.
 
 ## Related
-[index](index.md) · [agents](agents.md) · [orchestrator](services/orchestrator_service.md) · [shared](shared.md)
+[architecture](architecture.md) · [agents](agents.md) · [asr](services/asr_service.md) · [xplane](xplane.md) · [index](index.md)

--- a/openwiki/guides/cloud-agents-deployment.md
+++ b/openwiki/guides/cloud-agents-deployment.md
@@ -31,11 +31,11 @@ gcloud run deploy airport-del-agent \
   --source agents/del \
   --region europe-west1 \
   --service-account <sa-name>@<project>.iam.gserviceaccount.com \
-  --set-env-vars AGENT_MODEL=gemini-3-flash-preview,GOOGLE_GENAI_USE_VERTEXAI=True,GOOGLE_CLOUD_PROJECT=<project>,GOOGLE_CLOUD_LOCATION=global
+  --set-env-vars AGENT_MODEL=gemini-3.1-flash-lite,GOOGLE_GENAI_USE_VERTEXAI=True,GOOGLE_CLOUD_PROJECT=<project>,GOOGLE_CLOUD_LOCATION=global
 ```
 
 `AGENT_MODEL` is **required** — the agents read it at startup (`os.environ["AGENT_MODEL"]`).
-Keep it aligned with `GEMINI_MODEL` in your `.env` (default `gemini-3-flash-preview`).
+Keep it aligned with `GEMINI_MODEL` in your `.env` (default `gemini-3.1-flash-lite`).
 
 ## 3. Wire the URLs into `.env`
 

--- a/openwiki/guides/configuration.md
+++ b/openwiki/guides/configuration.md
@@ -13,7 +13,7 @@ settings module.
 | `DEL_AGENT_URL` / `GND_AGENT_URL` / `TWR_AGENT_URL` | — | Cloud Run URLs of the pilot agents ([deployment guide](cloud-agents-deployment.md)). `.env.example` ships a stray `DEL_AGENT_URL=1` — replace it. |
 | `VERTEX_PROJECT` | — | GCP project ID. Compose forwards it as `GOOGLE_CLOUD_PROJECT` to ASR and Orchestrator. |
 | `VERTEX_LOCATION` | `global` | Forwarded as `GOOGLE_CLOUD_LOCATION`. |
-| `GEMINI_MODEL` | `gemini-3-flash-preview` | Forwarded as `ASR_LLM_MODEL` (ASR corrector) and `AGENT_MODEL` (Orchestrator agent; also required by each Cloud Run agent). |
+| `GEMINI_MODEL` | `gemini-3.1-flash-lite` | Forwarded as `ASR_LLM_MODEL` (ASR corrector) and `AGENT_MODEL` (Orchestrator agent; also required by each Cloud Run agent). |
 | ⚠ `GOOGLE_APPLICATION_CREDENTIALS_JSON` | — | Service-account JSON **on a single line**; read by ASR and Orchestrator (the Orchestrator entrypoint writes it to `/tmp/sa-key.json`). Missing from `.env.example`. |
 | `GOOGLE_GENAI_USE_VERTEXAI` | `True` (set by compose) | Makes google-genai/adk use Vertex AI instead of an API key. |
 | `GCP_SA_KEY_PATH` / `GCLOUD_CREDENTIALS_DIR` | `./secrets/sa-key.json` / — | Alternative key-file mounting paths. |

--- a/openwiki/index.md
+++ b/openwiki/index.md
@@ -2,20 +2,54 @@
 
 > This wiki serves two audiences. **Users**: start with the [Guides](#guides) —
 > installation, configuration, troubleshooting, and a quickstart. **Developers and coding
-> agents**: the [reference pages](#pages) are structured for finding repo context fast —
-> short sections, tables, and cross-links. Prose docs under [`docs/`](../docs/) now point
-> here; the wiki guides are the maintained versions.
+> agents**: the [reference pages](#reference-pages) are structured for finding repo context
+> fast — narrative "how it works" sections, diagrams, and cross-links. Prose docs under
+> [`docs/`](../docs/) now point here; the wiki guides are the maintained versions.
 
 ## What is AIrport
 
-AIrport is an AI-powered Air Traffic Control (ATC) training simulator built on **X-Plane 12**.
-A human plays the controller: they speak an ATC instruction into a mic, the system transcribes
-it with an ATC-fine-tuned Whisper model, an LLM **orchestrator** figures out which aircraft and
-which controller phase (Delivery / Ground / Tower) the message belongs to, a **Gemini agent**
-(via `google-adk`, running on Cloud Run) drafts the ICAO-compliant pilot readback, and the
-**X-Plane plugin** actually moves/spawns the aircraft in the simulator and speaks the readback
-back with X-Plane's built-in TTS. Backend: Python 3.11, `uv`-managed, FastAPI microservices,
-Docker Compose. See [`README.md`](../README.md) for the human-facing project overview.
+AIrport is an AI-powered ATC training simulator on X-Plane 12 — the human is the controller,
+the AI plays the pilots. You key the mic and speak real ICAO phraseology; a Whisper model
+fine-tuned for ATC transcribes you; a Gemini **orchestrator** works out which aircraft and
+which controller position (Delivery / Ground / Tower) you addressed; a stateless Gemini
+**pilot agent** drafts the readback; and the **X-Plane plugin** makes it real — the aircraft
+pushes back, taxis, lands, and answers you over the speakers.
+
+Stack in one sentence: Python 3.11 (`uv`-managed) FastAPI microservices on Docker Compose,
+Google ADK + Gemini pilot agents on Cloud Run, an XPPython3 plugin inside the sim, and
+PostgreSQL / Redis / InfluxDB underneath — with Redis as the boundary between the Docker
+backend and the host-side sim plugin. See [`README.md`](../README.md) for the human-facing
+project overview.
+
+## The sixty-second tour
+
+```mermaid
+flowchart LR
+    MIC[Controller mic] --> HMI[HMI 8005]
+    HMI --> ASR[ASR 8006]
+    ASR --> ORCH[Orchestrator 8007]
+    ORCH --> AG[Pilot agent on Cloud Run]
+    AG -- "ICAO readback" --> ORCH
+    ORCH -- "move plan + speech" --> RD[(Redis)]
+    RD --> PL[X-Plane plugin]
+    PL --> OUT[Aircraft moves and speaks]
+```
+
+1. The browser records push-to-talk audio and sends everything through the
+   [Controller HMI](services/controller_hmi_service.md) — the controller's screen, and the
+   single host the browser ever talks to.
+2. The [ASR service](services/asr_service.md) turns controller speech into corrected ATC text.
+3. The [orchestrator](services/orchestrator_service.md) — the routing brain — matches the
+   callsign, picks the controller phase, and routes the message.
+4. A [pilot agent](agents.md) on Cloud Run drafts the ICAO readback — nothing more.
+5. The orchestrator turns the acknowledged clearance into state and motion: a clearance row in
+   PostgreSQL, a movement plan and a speech line in Redis (via the
+   [shared taxi router](shared.md)).
+6. The [X-Plane plugin](xplane.md) polls Redis, moves the aircraft, and speaks the readback —
+   everything inside the simulator: spawn, move, speak.
+
+The full walkthrough with the sequence diagram, the Redis key contract, and the topology lives
+in [architecture.md](architecture.md).
 
 ## Guides
 
@@ -34,72 +68,55 @@ Human-facing, hand-maintained pages (source: [`guides/`](guides/) — not auto-g
 | [System Overview](guides/system-overview.md) | Every module, what it does, and how they relate |
 | [Wiki Maintenance](guides/wiki-maintenance.md) | How this wiki is generated and published — never edit it by hand |
 
-## Architecture at a glance
-
-```
-Controller mic ──▶ ASR (Whisper ATC) ──▶ Orchestrator (LLM router) ──▶ DEL/GND/TWR agent (Gemini)
-                                              │  DB: aircraft phase (DEL→GND→TWR)         │
-                                              ▼                                            ▼
-                                     shared/services/taxi_router               ICAO pilot readback
-                                              │                                            │
-                                              ▼                                            ▼
-                                     Redis move_cmd plan ───────────▶ X-Plane plugin (mover/spawner)
-                                                                              │
-                                                                              ▼
-                                                                    aircraft moves + speaks (TTS)
-```
-
-Full breakdown, ports, and data stores: [architecture.md](architecture.md).
-
-## Pages
+## Reference pages
 
 | Page | Covers |
 |---|---|
-| [architecture.md](architecture.md) | End-to-end voice→motion pipeline, microservice topology, data stores, inter-service communication (HTTP + Redis pub/sub) |
-| [agents.md](agents.md) | The DEL / GND / TWR Gemini pilot agents: prompts, runner, callbacks, Cloud Run deployment shape |
-| [services/orchestrator_service.md](services/orchestrator_service.md) | Agent routing, aircraft phase state machine, dispatch, debrief generation, frequency audit |
-| [services/asr_service.md](services/asr_service.md) | Whisper transcription + callsign correction, dispatch to the orchestrator |
-| [services/weather_service.md](services/weather_service.md) | METAR/TAF fetch, ATIS generation |
-| [services/flight_plan_service.md](services/flight_plan_service.md) | IFR flight plan generation (API-backed + local fallback) |
-| [services/arrival_simulator_service.md](services/arrival_simulator_service.md) | Spawns AI arrivals on the ILS, drives them to vacate, maintains a minimum concurrent count |
-| [services/controller_hmi_service.md](services/controller_hmi_service.md) | Web UI (flight strips, ground radar, ATIS/chat) and API gateway to the other services |
-| [shared.md](shared.md) | Cross-service `shared/` package: models, taxi router (A\* graph routing), aircraft state store, stand assigner, geo helpers |
-| [xplane.md](xplane.md) | `xplane_plugin/` (in-sim XPPython3 plugin) and `plugins/` (deployable X-Plane files): spawner, mover, airport graph parsing |
-| [data-and-testing.md](data-and-testing.md) | `data/` (LEBL airport data, scripts, notebooks), `agents_evaluation/` (WER + agent benchmarks), `tests/` layout |
+| [architecture.md](architecture.md) | The hub: voice→motion pipeline, the Redis boundary and key contract, the two state machines, topology, data stores |
+| [services/orchestrator_service.md](services/orchestrator_service.md) | The routing brain — decides which aircraft, which controller phase, which pilot agent, and turns the reply into state and motion |
+| [agents.md](agents.md) | Stateless Gemini pilots that draft the ICAO readback — nothing more |
+| [services/asr_service.md](services/asr_service.md) | Turns controller speech into corrected ATC text |
+| [services/controller_hmi_service.md](services/controller_hmi_service.md) | The controller's screen, and the single host the browser ever talks to |
+| [services/arrival_simulator_service.md](services/arrival_simulator_service.md) | Keeps AI arrivals coming down the ILS so the controller always has traffic |
+| [services/flight_plan_service.md](services/flight_plan_service.md) | Generates and stores the IFR flight plans that give every aircraft its identity |
+| [services/weather_service.md](services/weather_service.md) | Fetches real METAR/TAF and generates the ATIS the whole session keys off |
+| [shared.md](shared.md) | The backend's common library — models, geo, state stores, and the A\* taxi router |
+| [xplane.md](xplane.md) | Everything inside the simulator: spawn, move, speak |
+| [data-and-testing.md](data-and-testing.md) | LEBL airport data, the speech and agent benchmarks, and the pytest suite |
 
-## Services (active, wired into `docker-compose.yml`)
+## Services and infrastructure
 
-| Service | Host port | Responsibility |
+Active services, wired into [`docker-compose.yml`](../docker-compose.yml). Ports are
+`host:container`; every service exposes `/health`.
+
+| Service | Port | One-line role |
 |---|---|---|
-| Controller HMI | 8005 | Web UI (flight strips, ground radar, chat) and API gateway |
-| Flight Plan | 8003 | IFR flight plan generation (flightplandatabase.com, with local fallback) |
-| Weather | 8004 | METAR, TAF, and ATIS generation |
-| ASR | 8006 | Whisper transcription + callsign correction |
-| Orchestrator | 8007 (container listens on 8006) | Agent routing, aircraft state machine, dispatch, debrief |
-| Arrival Simulator | 8008 | Spawns AI arrivals on the ILS, drives vacate sequences |
+| [Controller HMI](services/controller_hmi_service.md) | 8005:8000 | Web UI + API gateway |
+| [Flight Plan](services/flight_plan_service.md) | 8003:8000 | IFR flight plan generation (external API with full local fallback) |
+| [Weather](services/weather_service.md) | 8004:8000 | METAR/TAF fetch + ATIS generation |
+| [ASR](services/asr_service.md) | 8006:8000 | Whisper transcription + ATC text correction |
+| [Orchestrator](services/orchestrator_service.md) | 8007:8006 | Routing, phase state machine, dispatch, debrief |
+| [Arrival Simulator](services/arrival_simulator_service.md) | 8008:8000 | Spawns and flies AI arrivals on the ILS |
 
-The three ATC pilot agents (**DEL**, **GND**, **TWR** — see [agents.md](agents.md)) are not in
-`docker-compose.yml`; they are deployed independently to **Google Cloud Run** and reached via
-`DEL_AGENT_URL` / `GND_AGENT_URL` / `TWR_AGENT_URL`.
-
-### Infrastructure
-
-| Component | Image | Port (host:container) |
+| Infrastructure | Image | Port |
 |---|---|---|
 | PostgreSQL | `postgres:15-alpine` | 5432:5432 |
 | Redis | `redis:7-alpine` | 6379:6379 |
 | InfluxDB | `influxdb:2.7-alpine` | 8087:8086 |
 
-### Placeholder / not-wired-up services (under `services/`, no page — don't expect real code)
+The three pilot agents (**DEL**, **GND**, **TWR** — see [agents.md](agents.md)) are not in
+Compose; they deploy independently to **Google Cloud Run** and are reached via
+`DEL_AGENT_URL` / `GND_AGENT_URL` / `TWR_AGENT_URL`.
+
+## Not part of the running system
 
 | Directory | State |
 |---|---|
-| `services/analytics_service/` | Empty — only a `.gitkeep` |
-| `services/nlp_service/` | Empty — only a `.gitkeep` |
-| `services/tts_service/` | Empty — only a `.gitkeep` (TTS today is X-Plane's built-in speech, driven from `xplane_plugin/services/hmi_service.py` + `utils`) |
-| `services/xplane_manager/` | Empty — only a `.gitkeep` |
-| `services/database/` | Only `redis/test_redis.py`, a scratch script exercising basic Redis get/set/hset — not a service |
-| `services/pilots_communication/` | Has real code (`main.py`, `router.py`, `config.py` — a `/process` endpoint that transcribes audio via a `transcription` service and forwards to a DEL/GND/TWR agent's `/tasks/send`), but it is **not** listed in `docker-compose.yml` and is not part of the active pipeline described in [architecture.md](architecture.md). Looks like an earlier prototype of what `asr_service` + `orchestrator_service` now do together. |
+| `services/analytics_service/`, `services/nlp_service/`, `services/xplane_manager/` | Empty placeholders — only a `.gitkeep` |
+| `services/tts_service/` | Empty placeholder — speech actually happens in the sim: the plugin's window manager drains `tts:queue` into X-Plane's built-in TTS (see [xplane.md](xplane.md)) |
+| `services/database/` | A scratch Redis test script, not a service |
+| `transcription/` (repo root) | Superseded prototype of the [ASR service](services/asr_service.md) — real code, not in Compose |
+| `services/pilots_communication/` | Superseded prototype of what ASR + orchestrator now do together — real code, not in Compose |
 
 ## Related
 

--- a/openwiki/services/arrival_simulator_service.md
+++ b/openwiki/services/arrival_simulator_service.md
@@ -1,56 +1,180 @@
 # Arrival Simulator Service
 
 **Port 8008:8000** · [`services/arrival_simulator_service/`](../../services/arrival_simulator_service/) ·
-spawns AI arrivals on the ILS and drives them to vacate. Health: `/api/v1/arrivals/health`. See
-[architecture](../architecture.md).
+keeps AI arrivals coming down the ILS so the controller always has traffic. Health:
+`/api/v1/arrivals/health`. See [architecture](../architecture.md).
 
 ## What it does
 
-Keeps traffic coming: spawns AI arrivals on the ILS, flies them through approach, landing
-and vacate, and hands each one off to the controller as ground traffic — so a single trainee
-always has aircraft to sequence.
+Keeps AI arrivals coming down the ILS so the controller always has traffic: an asyncio scheduler
+tops up a pool of simultaneous arrivals, builds each one's spawn point and multi-leg flight plan,
+and hands it to the same plugin mover that flies taxi clearances. A second task listens for what
+the mover reports back and turns two of its milestones into pilot radio calls, so the controller's
+first contact with an arrival is geometry-triggered: 4 NM out.
 
 | Relations | Modules |
 |---|---|
-| **Called by** | its own scheduler (start/stop via API) |
-| **Calls** | [Flight Plan](flight_plan_service.md) (plan catalog) · [Controller HMI](controller_hmi_service.md) (arrival strips) · [Orchestrator](orchestrator_service.md) (arrival handoff) · Redis (aircraft state + move events) |
+| **Called by** | the X-Plane plugin's in-sim UI — `POST /api/v1/arrivals/restart` on session start (host port 8008, triggered when it reads `airport:session_request` from Redis) · `/start`, `/stop`, `/active` for manual/Swagger use |
+| **Calls** | [Flight Plan](flight_plan_service.md) (`GET /plans`, arrivals into LEST) · [Controller HMI](controller_hmi_service.md) (`POST /strips/arrival`) · [Orchestrator](orchestrator_service.md) (`POST /arrivals/register`) · Redis (spawn, move, events, tts) |
 
 **Try it standalone:** <http://localhost:8008/docs> · health `GET /api/v1/arrivals/health` ·
 `POST /api/v1/arrivals/start` — tuning knobs in
 [Configuration](../guides/configuration.md#arrival-simulator-prefix-arrival_).
 
-## Responsibility
+## The slot machine: keeping arrivals on final
 
-Continuously spawn AI arrival traffic (on the ILS), drive each aircraft through the arrival phases
-(`approach → short_final → landing_roll → vacating → taxi_in`), and publish lifecycle events so the
-[orchestrator](orchestrator_service.md) can handle the handoff to GND. Interval configured by
-`ARRIVAL_INTERVAL_S` (default 120s).
+Nothing runs until something calls `/start` or `/restart` — unlike most of AIrport's backend, this
+service sits idle by default. Once running, `ArrivalScheduler._run_loop` wakes up every
+`ARRIVAL_CHECK_INTERVAL_S` (default 15 s), compares how many registrations are currently tracked as
+active against `ARRIVAL_MIN_CONCURRENT` (default 3), and — this is the detail that earns the "slot
+machine" name — dispatches *all* of the shortfall in the same tick, not one per tick. If three
+arrivals land and vacate close together, the very next check spawns three replacements at once,
+staggered along the localizer at `ARRIVAL_SPAWN_DISTANCE_NM + slot_index * ARRIVAL_SLOT_SEP_NM`
+(10, 15, 20 NM by default) so they don't stack on top of each other on final.
 
-## Layout
+Each dispatch pulls its aircraft from `plan_catalog.fetch_pending_arrival`: first choice is any
+plan from the [Flight Plan service](flight_plan_service.md) — which generates and stores the IFR
+flight plans that give every aircraft its identity — whose `destination_ICAO` is the session
+airport and isn't already spoken for; failing that, a built-in synthetic pool of six aircraft
+(IBE3001, VLG4502, RYR7810, IBE3045, VLG4610, RYR5521) cycles indefinitely, so the simulator works
+with zero flight-plan setup. Either way, the registration lands in the Redis set
+`arrivals:assigned` the moment it's dispatched, so the catalog never repeats an aircraft in one
+session. `/start` also purges `aircraft:spawn_request:*` and synthetic-pool `move_cmd` keys left
+from the last run, so nothing ghost-spawns at stale coordinates. `GET /active` exposes exactly what
+the scheduler is tracking — handy for debugging a session that feels traffic-starved.
+
+```mermaid
+flowchart TD
+    TICK["tick every ARRIVAL_CHECK_INTERVAL_S (15s)"] --> CHECK{"active < min_concurrent (3)?"}
+    CHECK -- "no" --> TICK
+    CHECK -- "yes, need N" --> DB["query Flight Plan service: dest = LEST"]
+    DB -- "plan found" --> PICK["next un-dispatched plan"]
+    DB -- "none left" --> SYN["synthetic pool: IBE3001, VLG4502, ..."]
+    SYN --> PICK
+    PICK --> SLOT["slot i = 0..N-1"]
+    SLOT --> SPAWN["spawn at 10 + 5*i NM on final"]
+    SPAWN --> TRACK[("arrivals:assigned")]
+    TRACK --> TICK
+```
+
+## Birth of an arrival
+
+`arrival_planner.dispatch_arrival` turns one catalog plan into a live aircraft: it projects the
+spawn point on the extended runway centerline with
+[`shared/services/geo.py`](../../shared/services/geo.py)'s
+`project_on_localizer(threshold_lat, threshold_lon, heading_deg, distance_nm)`, then scales the
+spawn altitude proportionally to distance so every staggered slot rides the same descent gradient
+to the threshold — documented as a 3° glideslope, though the shipped numbers (5,000 ft AGL at 10
+NM, -1,333 fpm at 160 kt) actually compute closer to 4.7°, per the module's own comment.
+
+Two Redis keys follow — this service's only way across the boundary between the Docker backend and
+the host-side sim plugin. `aircraft:spawn_request:{reg}` tells the plugin to spawn the
+aircraft airborne at that point (and is deleted once it does); `aircraft:{reg}:move_cmd` is the
+same three-leg plan shape the taxi router writes for departures — `approach` (descend to the
+threshold, firing a `request_landing` event at `ARRIVAL_REQUEST_AT_NM`, 4 NM by default),
+`landing_roll` (decelerate down the centerline to a taxi speed), and `vacate` (two waypoints: abeam
+the exit, then a sharp turn onto taxiway E3) — the same **motion state machine** the plugin tracks
+per aircraft, detailed in [xplane](../xplane.md). The mover that picks this up flies the plan and
+publishes milestones on `aircraft:{reg}:move_events`; it doesn't know or care that the plan came
+from the arrival simulator instead of the taxi router — one contract, two writers, full key list in
+[architecture](../architecture.md).
+
+Two HTTP calls close out the dispatch. One registers a virtual strip in the
+[Controller HMI](controller_hmi_service.md) — the controller's screen, and the single host the
+browser ever talks to — so the arrival shows up in the ARRIVALS column despite no controller ever
+having created it. The other registers the aircraft with the
+[orchestrator](orchestrator_service.md) — the routing brain — at `dependency='APP'`, seeding the
+**controller-phase state machine** with an aircraft it never cleared. That row is the only reason
+"contact ground" later resolves as a valid handoff instead of an unknown callsign.
+
+One hard-coded seam: every arrival flies LEST runway 17 geometry (threshold, ~166° heading, the E3
+vacate exit) from `runway_config.py`; `get_active_runway` raises for any other ICAO. Most of
+AIrport is written to be multi-airport — this service currently isn't.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant S as Scheduler
+    participant C as plan_catalog
+    participant P as arrival_planner
+    participant R as Redis
+    participant H as HMI 8005
+    participant O as Orchestrator 8007
+    participant M as Plugin mover
+    S->>C: fetch_pending_arrival "LEST"
+    C-->>S: plan (DB or synthetic)
+    S->>P: dispatch_arrival plan, slot i
+    Note over P: project_on_localizer -> spawn point,<br/>altitude scaled to the slot
+    P->>R: SET "aircraft:spawn_request:{reg}"
+    P->>R: SET "aircraft:{reg}:move_cmd"
+    P->>H: POST /strips/arrival
+    P->>O: POST /arrivals/register, dependency=APP
+    M->>R: scan move_cmd (poll, 1 s)
+    R-->>M: move_cmd plan JSON
+    M->>R: PUBLISH "aircraft:{reg}:move_events"
+```
+
+## Listening back: the event bridge
+
+`event_bridge.py` is the one part of this service that subscribes instead of polling — it runs
+alongside the scheduler as its own task and `psubscribe`s to `aircraft:*:move_events`, the same
+pattern the orchestrator listens to for every aircraft in the sim. A small in-memory map, filled by
+`register_arrival()` right after dispatch, is how it tells its own arrivals apart from ordinary
+departure taxi traffic on that same channel; anything it didn't dispatch itself is ignored.
+
+Three milestones matter. At `request_landing` — fired by the mover once the aircraft crosses
+`ARRIVAL_REQUEST_AT_NM` (4 NM final) — the bridge builds "Tower, {callsign}, {N} miles final runway
+17, request landing." and RPUSHes it onto `tts:queue`, where the plugin speaks it and the
+controller hears the check-in. At `rolling_out` it pushes "{callsign} vacating runway 17." At
+`reached_end` — the vacate leg's last waypoint — it unregisters the aircraft and calls back into
+`scheduler.remove_arrival()`, which drops the registration from the active set. That's the slot the
+next scheduler tick sees as a shortfall and refills: spawn, fly, event, slot freed, spawn again.
+
+The scheduler's tick is timer-driven; the pilot's first radio call is not — `request_landing`
+fires the instant the mover's distance-to-threshold crosses 4 NM, on whatever cadence the aircraft
+actually flew.
+
+## Tuning knobs
+
+`POST /start` and `/restart` also accept an optional `min_concurrent` JSON field that overrides
+`ARRIVAL_MIN_CONCURRENT` for that run; the plugin's own session-start call sends no body, so in
+practice the env default governs every session today.
+
+| Env var | Default | Controls |
+|---|---|---|
+| `ARRIVAL_MIN_CONCURRENT` | `3` | Target simultaneous arrivals |
+| `ARRIVAL_CHECK_INTERVAL_S` | `15.0` | Scheduler tick |
+| `ARRIVAL_SPAWN_DISTANCE_NM` / `ARRIVAL_SLOT_SEP_NM` | `10.0` / `5.0` | Base spawn distance and per-slot stagger on the localizer |
+| `ARRIVAL_SPAWN_ALT_AGL_FT` | `5000.0` | AGL height at the base spawn distance |
+| `ARRIVAL_IAS_KTS` / `ARRIVAL_VS_FPM` | `160.0` / `-1333.0` | Approach speed and descent rate |
+| `ARRIVAL_REQUEST_AT_NM` | `4.0` | Distance that fires `request_landing` |
+| `ARRIVAL_DECEL_KTS_S` / `ARRIVAL_STOP_KTS` | `4.0` / `20.0` | Landing-roll deceleration and end speed |
+| `ARRIVAL_VACATE_KTS` | `15.0` | Taxi speed off the runway |
+
+Full defaults and the rest of the prefix live in
+[Configuration](../guides/configuration.md#arrival-simulator-prefix-arrival_). One env var is a
+trap: `ARRIVAL_INTERVAL_S` (default `120`) is still set in `docker-compose.yml`, but nothing in
+`core/` reads it — it predates the current min-concurrent scheduler, and the cadence that actually
+governs today is `ARRIVAL_CHECK_INTERVAL_S`.
+
+## Layout and tests
 
 | Path | Role |
 |---|---|
-| [`main.py`](../../services/arrival_simulator_service/main.py) | FastAPI entrypoint + scheduler startup |
-| [`api/routes.py`](../../services/arrival_simulator_service/api/routes.py) | Arrivals endpoints |
-| [`core/scheduler.py`](../../services/arrival_simulator_service/core/scheduler.py) | Periodic spawn loop (maintains concurrent arrivals) |
-| [`core/arrival_planner.py`](../../services/arrival_simulator_service/core/arrival_planner.py) | Plans an arrival (route to threshold, phase timeline) |
-| [`core/plan_catalog.py`](../../services/arrival_simulator_service/core/plan_catalog.py) | Catalog of arrival plans |
-| [`core/runway_config.py`](../../services/arrival_simulator_service/core/runway_config.py) | Active runway / approach config |
-| [`core/event_bridge.py`](../../services/arrival_simulator_service/core/event_bridge.py) | Publishes arrival lifecycle events (Redis) to the orchestrator |
-| `core/phases.py`, `core/geo.py` | Phase timeline + geographic helpers |
+| [`main.py`](../../services/arrival_simulator_service/main.py) | FastAPI entrypoint; stops the scheduler on shutdown |
+| [`api/routes.py`](../../services/arrival_simulator_service/api/routes.py) | `/health`, `/start`, `/restart`, `/stop`, `/active` |
+| [`core/scheduler.py`](../../services/arrival_simulator_service/core/scheduler.py) | The tick loop and active-arrival bookkeeping |
+| [`core/arrival_planner.py`](../../services/arrival_simulator_service/core/arrival_planner.py) | Builds and dispatches one arrival's spawn + move plan |
+| [`core/plan_catalog.py`](../../services/arrival_simulator_service/core/plan_catalog.py) | Picks the next un-dispatched plan (DB or synthetic) |
+| [`core/event_bridge.py`](../../services/arrival_simulator_service/core/event_bridge.py) | Subscribes to move events; drives TTS and slot release |
+| [`core/runway_config.py`](../../services/arrival_simulator_service/core/runway_config.py) | Fixed LEST RWY 17 geometry |
 
-## Integrations
-
-`REDIS_URL`, `FLIGHT_PLAN_SERVICE_URL`, `HMI_SERVICE_URL`, `ORCHESTRATOR_SERVICE_URL` (see the
-`environment:` block in [`docker-compose.yml`](../../docker-compose.yml)). Handoff lands in the
-orchestrator via [`api/arrivals.py`](../../services/orchestrator_service/api/arrivals.py) +
-`advance_to_gnd_arrival`.
-
-## Tests
-
-[`tests/unit/arrival_simulator/`](../../tests/unit/arrival_simulator/) (event bridge),
-[`tests/arrivals/`](../../tests/arrivals/) (planner, phases, runway config, geo),
-[`tests/integration/test_arrival_pipeline.py`](../../tests/integration/test_arrival_pipeline.py).
+No separate `config.py` — every env var above is read inline where it's used, in `scheduler.py` and
+`arrival_planner.py`. Tests: [`tests/arrivals/`](../../tests/arrivals/) covers the planner's
+geometry, [`tests/unit/arrival_simulator/`](../../tests/unit/arrival_simulator/) covers the event
+bridge, and
+[`tests/integration/test_arrival_pipeline.py`](../../tests/integration/test_arrival_pipeline.py)
+exercises the whole spawn-to-vacate chain end to end.
 
 ## Related
-[architecture](../architecture.md) · [orchestrator](orchestrator_service.md) · [flight_plan](flight_plan_service.md) · [data-and-testing](../data-and-testing.md)
+[architecture](../architecture.md) · [xplane](../xplane.md) · [flight_plan](flight_plan_service.md) · [orchestrator](orchestrator_service.md) · [index](../index.md)

--- a/openwiki/services/asr_service.md
+++ b/openwiki/services/asr_service.md
@@ -1,52 +1,184 @@
 # ASR Service
 
-**Port 8006:8000** · [`services/asr_service/`](../../services/asr_service/) · speech-to-text for
-controller transmissions. Health: `/api/v1/asr/health`. See [architecture](../architecture.md).
+**Port 8006:8000** · [`services/asr_service/`](../../services/asr_service/) · speech-to-text and
+correction for controller transmissions. Health: `/api/v1/asr/health`. See
+[architecture](../architecture.md).
 
 ## What it does
 
-Turns the controller's spoken transmission into clean text: Whisper ATC transcribes the
-audio, the callsign corrector normalizes it ("iberia five four seven one" → `IBE5471`), and
-the transcript is forwarded to the Orchestrator so the right pilot agent can answer.
+The ASR service **turns controller speech into corrected ATC text**: a push-to-talk recording
+lands on `/api/v1/asr/transcribe`, a Whisper model fine-tuned for ATC transcribes it, a four-stage
+deterministic pipeline repairs numbers, callsigns, SIDs and taxiway letters, and an optional Gemini
+pass mops up whatever the deterministic pass couldn't confidently resolve.
 
 | Relations | Modules |
 |---|---|
-| **Called by** | [Controller HMI](controller_hmi_service.md) (`/asr/transcribe` proxy) |
-| **Calls** | [Orchestrator](orchestrator_service.md) `/dispatch` · Vertex AI (LLM corrector) · Redis |
+| **Called by** | Controller HMI proxy — browser push-to-talk audio, forwarded byte-for-byte via `/api/v1/hmi/asr/transcribe` |
+| **Calls** | [Orchestrator](orchestrator_service.md) `/dispatch` — optional, only when `ORCHESTRATOR_URL` is set · Gemini on Vertex AI — LLM entity-mapping fallback |
 
-**Try it standalone:** <http://localhost:8006/docs> · health `GET /api/v1/asr/health` ·
-env vars in [Configuration](../guides/configuration.md#asr-prefix-asr_).
+## From audio to ATC text
 
-## Responsibility
+[`api/transcribe_service.py`](../../services/asr_service/api/transcribe_service.py) picks the
+inference backend from the configured model ID via `core.config.get_model_backend`
+([`core/config.py`](../../services/asr_service/core/config.py)): the default,
+`jacktol/whisper-medium.en-fine-tuned-for-ATC-faster-whisper`, runs on `faster-whisper`/CTranslate2
+(`int8` on CPU by default — `ASR_WHISPER_DEVICE`, `ASR_WHISPER_COMPUTE_TYPE`); the other four
+models on the menu run through a HuggingFace `transformers` speech-recognition pipeline instead.
+Either way, inference runs inside a two-worker `ThreadPoolExecutor` via `loop.run_in_executor`,
+keeping the event loop free while the model call blocks a worker thread instead.
 
-Transcribe controller mic audio with a **Whisper model fine-tuned for ATC** (faster-whisper), then
-**correct the callsign** using phonetics + an LLM corrector, and hand the clean transcript to the
-[orchestrator](orchestrator_service.md) (`ORCHESTRATOR_URL`). Uses Redis and Gemini (Vertex AI)
-for the corrector (`ASR_LLM_MODEL`, default `gemini-3-flash-preview`).
-
-## Layout
-
-| Path | Role |
+| Model ID | Backend |
 |---|---|
-| [`main.py`](../../services/asr_service/main.py) | FastAPI entrypoint |
-| [`api/routes.py`](../../services/asr_service/api/routes.py) | ASR endpoints (transcribe) |
-| [`api/transcribe_service.py`](../../services/asr_service/api/transcribe_service.py) | Transcription orchestration |
-| [`api/config_service.py`](../../services/asr_service/api/config_service.py) | Runtime config endpoints |
-| [`core/corrections.py`](../../services/asr_service/core/corrections.py) | Callsign correction logic |
-| [`core/phonetics.py`](../../services/asr_service/core/phonetics.py) | ICAO phonetic alphabet handling |
-| [`core/config.py`](../../services/asr_service/core/config.py), [`core/settings.py`](../../services/asr_service/core/settings.py) | Model / service settings |
-| [`prompts/whisper_context.py`](../../services/asr_service/prompts/whisper_context.py) | Whisper initial-prompt / context biasing |
-| [`prompts/llm_corrector.py`](../../services/asr_service/prompts/llm_corrector.py) | LLM corrector prompt |
-| [`download_model.py`](../../services/asr_service/download_model.py) | Fetches the Whisper ATC model into the `asr_hf_cache` volume (~1.5 GB on first run) |
+| `jacktol/whisper-medium.en-fine-tuned-for-ATC-faster-whisper` (default) | faster-whisper |
+| `jacktol/whisper-large-v3-finetuned-for-ATC` | transformers |
+| `jlvdoorn/whisper-tiny-atco2-asr` | transformers |
+| `jlvdoorn/whisper-medium-atco2-asr` | transformers |
+| `jlvdoorn/whisper-large-v3-atco2-asr` | transformers |
 
-> Related standalone module: [`transcription/`](../../transcription/) is a separate ASR module
-> (Whisper + callsign correction + phonetics) with its own Dockerfile — an alternate/earlier
-> packaging of the same capability.
+Before transcribing, [`api/routes.py`](../../services/asr_service/api/routes.py) builds a Whisper
+`initial_prompt` from [`prompts/whisper_context.py`](../../services/asr_service/prompts/whisper_context.py)'s
+`ATC_PROMPT` — realistic ATC exchanges rather than a word list, since Whisper continues the *style*
+it's shown. Three `context_mode` values shape it: `none` sends no prompt at all; `generic` (the
+default) sends `ATC_PROMPT` unchanged; `session` appends whatever `session_callsigns`/`session_sids`
+the caller supplied as two extra sentences ("Active callsigns: ...", "Expected SIDs: ..."). Setting
+`use_initial_prompt=False` suppresses the prompt regardless of mode, kept for backward
+compatibility.
+
+## The correction pipeline
+
+`api/routes.py` hands the raw Whisper string to
+[`core/postprocess.py`](../../services/asr_service/core/postprocess.py)'s
+`postprocess_transcription`, four deterministic stages that run in a fixed order because each one
+depends on what the last left alone:
+
+1. **Numbers** (`normalize_numbers`) — phonetic digits become figures only inside known ATC
+   contexts (`squawk`, `QNH`, `runway`, climb/altitude "... thousand", `flight level`, frequency);
+   digits anywhere else are left untouched.
+2. **Callsign** — a known-typo regex table in
+   [`core/corrections.py`](../../services/asr_service/core/corrections.py) fixes 11 airline
+   mishearings ("fueling"/"vuelin" → Vueling, "speed burd" → Speedbird, …), then
+   `_apply_callsign_compaction` finds the airline-plus-phonetic-code span and compacts it to ICAO
+   form (`AIRLINE_ICAO`, 14 airlines — "Ryanair four seven three" → `RYR473`), snapping to a
+   `session_callsigns` entry when the rapidfuzz similarity is ≥80. Unrecognized airlines keep their
+   spoken name rather than get an invented designator.
+3. **SID** (`_apply_sid_fuzzy`) — matches the phrase "via [the] NAME digit letter departure" or a
+   bare `NAME<digit><letter>` token, fuzzy-snapped to `session_sids` the same way.
+4. **Phonetic letters** ([`core/phonetics.py`](../../services/asr_service/core/phonetics.py)) —
+   taxiways/stands ("via alpha bravo" → "via A B") — normalized *last* so they can't consume the
+   spelled-out letters stage 3 still needs.
+
+Session context is what makes stages 2 and 3 safe to apply automatically: the fuzzy snap never
+invents a callsign or SID, it only ever accepts one the caller says is actually active this
+session; without a session list, correction stops at the compacted-but-unverified form.
+
+A fifth, optional step layers on top.
+[`core/llm_postprocess.py`](../../services/asr_service/core/llm_postprocess.py)'s
+`llm_map_entities` runs only when `apply_corrections` is on, `context_mode == "session"`, the
+fallback is enabled (`ASR_LLM_FALLBACK`, overridable per request), a session list was actually
+given, *and* the deterministic pass left something unresolved (no fuzzy candidate, or a score under
+that same 80-point threshold). It's one targeted Gemini call (Vertex AI, `google-genai`) on
+`cfg.llm_model` — `core/config.py`'s own fallback is `gemini-3-flash-preview`, but docker-compose
+always sets `ASR_LLM_MODEL=${GEMINI_MODEL:-gemini-3.1-flash-lite}`, so the running stack defaults to
+`gemini-3.1-flash-lite` — instructed to replace *only* the callsign/SID and leave everything else
+untouched, with a strict JSON schema, an 8-second timeout, and a fail-open contract: any error just
+keeps the deterministic result.
+
+One live-wiring nuance: the browser client
+([`ptt.js`](../../services/controller_hmi_service/static/js/ptt.js)) posts only `audio` and
+`session_id` — never `session_callsigns`, `session_sids` or `context_mode` — and the HMI's proxy
+forwards that multipart body byte-for-byte. So every PTT transmission today runs stages 1-4 under
+the `generic` prompt; the session-aware fuzzy snap and the LLM step are fully wired and gated as
+described above, but so far the only caller that populates the session fields is
+[`agents_evaluation/benchmark_asr.py`](../../agents_evaluation/benchmark_asr.py).
+
+The response returns the untouched `raw_transcription` alongside the corrected `text`/
+`transcription` and the full `postprocess_steps` trace (`after_number_norm`, `after_callsign_fix`,
+`final`, `cs_fuzzy_candidate`/`cs_fuzzy_score`, `sid_fuzzy_candidate`/`sid_fuzzy_score`, `cs_icao`,
+`cs_unknown_airline`), plus `llm_applied`/`llm_latency_s`.
+
+```mermaid
+flowchart LR
+    RAW["Raw Whisper text"] --> NUM["Number normalization<br/>squawk, QNH, runway, FL"]
+    NUM --> CS["Callsign typo fixes +<br/>ICAO compaction"]
+    CS --> SID["SID phrase / token match"]
+    SID --> PHON["Isolated phonetic letters<br/>taxiways, stands"]
+    PHON --> LLM["LLM entity mapping<br/>Gemini, session mode only"]
+    LLM --> FINAL["Corrected text + trace"]
+    SESS[("Session callsigns / SIDs")] -.-> CS
+    SESS -.-> SID
+    SESS -.-> LLM
+```
+
+## Who calls it, and what happens next
+
+The only production caller today is the [Controller HMI](controller_hmi_service.md): the browser
+records push-to-talk audio and posts it to `/api/v1/hmi/asr/transcribe`, a byte-for-byte proxy
+(`services/controller_hmi_service/api/routes.py`) onto this service's `/transcribe`. The browser
+reads only `data.text` from the reply and shows it in the chat log, then — as a second, independent
+call — posts `{session_id, message: text}` to the HMI's orchestrator proxy to get the pilot
+readback. See [architecture](../architecture.md) for the full voice-to-motion sequence and the
+Redis contract that takes over once the orchestrator has the text.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant H as HMI proxy 8005
+    participant A as ASR 8006
+    participant O as Orchestrator 8007
+    B->>H: POST /api/v1/hmi/asr/transcribe
+    H->>A: POST /transcribe
+    A-->>H: corrected text + trace
+    H-->>B: transcript in chat
+    B->>H: POST /api/v1/hmi/orchestrator/dispatch
+    H->>O: POST /dispatch
+    O-->>H: readback
+    H-->>B: readback in chat
+```
+
+One nuance: docker-compose always sets `ORCHESTRATOR_URL` (`http://orchestrator_service:8006`), so
+`/transcribe`'s own handler *also* posts the corrected text to the orchestrator's `/dispatch` and,
+on success, folds `reply`/`agent`/`aircraft_registration` into its own response — wrapped in a
+try/except that logs a warning and falls back to transcription-only on failure. The browser never
+reads those fields, though: `ptt.js` always performs its own `/dispatch` call regardless of what the
+ASR response contains. So that second, independent browser call — not the ASR's embedded one — is
+the path of record for what the controller actually sees answered in the chat.
+
+## Models and hardware
+
+[`download_model.py`](../../services/asr_service/download_model.py) pre-downloads whatever
+`ASR_HF_MODEL` is configured (same default as `core/config.py`) at Docker build time —
+`WhisperModel(..., device="cpu", compute_type="int8")` for faster-whisper IDs,
+`transformers.pipeline(...)` for everything else — so the first real request never pays for the
+download. The cache lands under `/root/.cache/huggingface`, which
+[`docker-compose.yml`](../../docker-compose.yml) mounts as the named volume `asr_hf_cache`
+(`airport_asr_hf_cache`), so it survives container recreation.
+
+Three Dockerfiles exist, but `docker-compose.yml`'s `asr_service` block only ever builds the plain
+[`Dockerfile`](../../services/asr_service/Dockerfile) — CPU `torch`/`torchaudio`, the medium
+faster-whisper model baked in via a build `ARG`.
+[`Dockerfile.gpu`](../../services/asr_service/Dockerfile.gpu) and
+[`Dockerfile.ct2`](../../services/asr_service/Dockerfile.ct2) are **not referenced anywhere in
+docker-compose.yml** — they read as Cloud-Run-oriented experiments, not something Compose exercises
+today: `.gpu` installs `cu121` CUDA torch wheels and defaults to
+`jlvdoorn/whisper-large-v3-atco2-asr` on `ASR_WHISPER_DEVICE=cuda`; `.ct2` converts
+`jlvdoorn/whisper-medium-atco2-asr` to an int8 CTranslate2 model *at build time*
+(`ct2-transformers-converter`) and points `ASR_HF_MODEL` at that local directory, deliberately
+skipping `download_model.py` since it would otherwise try to load a local CT2 folder through
+`transformers.pipeline` and fail.
 
 ## Evaluation
 
-WER is measured with `jiwer` via [`agents_evaluation/evaluate_wer.py`](../../agents_evaluation/evaluate_wer.py)
-against the phase corpora. See [data-and-testing](../data-and-testing.md).
+[`agents_evaluation/evaluate_wer.py`](../../agents_evaluation/evaluate_wer.py) measures WER locally
+with `jiwer` against the phase corpora.
+[`agents_evaluation/benchmark_asr.py`](../../agents_evaluation/benchmark_asr.py) is the heavier
+harness: it drives a *deployed* ASR endpoint over an external voice dataset per model/tier/
+context-mode combination and reports WER (S/D/I breakdown), latency, real-time factor and
+per-transcription cost to a CSV trace. See
+[data-and-testing](../data-and-testing.md) for how these fit the rest of the test suite. The
+root-level [`transcription/`](../../transcription/) directory is an earlier, simpler prototype of
+this service — the same Whisper-plus-corrections idea, without `postprocess.py`'s multi-stage
+pipeline or the LLM fallback — superseded by this one.
 
 ## Related
-[architecture](../architecture.md) · [orchestrator](orchestrator_service.md) · [controller_hmi](controller_hmi_service.md) · [data-and-testing](../data-and-testing.md)
+[architecture](../architecture.md) · [orchestrator](orchestrator_service.md) · [controller_hmi](controller_hmi_service.md) · [data-and-testing](../data-and-testing.md) · [index](../index.md)

--- a/openwiki/services/controller_hmi_service.md
+++ b/openwiki/services/controller_hmi_service.md
@@ -1,51 +1,171 @@
 # Controller HMI Service
 
 **Port 8005:8000** · [`services/controller_hmi_service/`](../../services/controller_hmi_service/) ·
-the web UI a human controller uses, and the API gateway to the rest of the system. Health:
-`/api/v1/hmi/health`. Open at [http://localhost:8005](http://localhost:8005). See
-[architecture](../architecture.md).
+the controller-facing web app and API gateway. Health: `/api/v1/hmi/health` · open at
+[http://localhost:8005](http://localhost:8005). See [architecture](../architecture.md).
 
 ## What it does
 
-The screen the human controller works on — flight strips, ground radar, ATIS and
-push-to-talk chat — and the API gateway that proxies the browser's requests to the backend
-services, so the front-end only ever talks to one host.
+The controller's screen, and the single host the browser ever talks to: every panel — flight
+strips, ground radar, ATIS, push-to-talk chat — renders through this one gateway, which proxies
+out to the backend services and reads Redis directly for whatever needs to feel live.
 
 | Relations | Modules |
 |---|---|
-| **Called by** | the browser · the X-Plane plugin (plugin routes, chat) · [Arrival Simulator](arrival_simulator_service.md) (registers arrival strips) |
-| **Calls** | [ASR](asr_service.md) (transcribe) · [Orchestrator](orchestrator_service.md) (dispatch/debrief) · [Flight Plan](flight_plan_service.md) · [Weather](weather_service.md) · Redis (live state + `hmi:chat` WebSocket fan-out) · Postgres |
+| **Called by** | the browser — every panel, plus login and session control (those routes live under `/api/v1/plugin/*`, despite the name) · the X-Plane plugin (`POST /airport` to report the ICAO it's running, `DELETE /strips/arrivals` to clear stale strips at session start) · [Arrival Simulator](arrival_simulator_service.md) (`POST /strips/arrival`, registers virtual strips) |
+| **Calls** | [ASR](asr_service.md) (`/transcribe`) · [Orchestrator](orchestrator_service.md) (`/dispatch`, `/debrief/generate`) · [Weather](weather_service.md) · [Flight Plan](flight_plan_service.md) — all HTTP proxies · PostgreSQL `users` (auth) · Redis (live positions, session handshake, chat fan-out) |
 
-**Try it standalone:** UI at <http://localhost:8005> · health `GET /api/v1/hmi/health`.
+## One host for the browser
 
-## Responsibility
+A browser tab cannot be handed five different backend addresses and told to keep them straight —
+so it isn't. It knows one origin, port 8005, and for the core comms loop nothing else. At startup
+`main.py` reads `ASR_URL` and `ORCHESTRATOR_URL` from the environment and writes them into
+`static/config.js` as `window.HMI_CONFIG`, so the same static bundle works unmodified whether
+those services sit behind docker-compose names, Cloud Run URLs, or localhost.
 
-Serve the controller-facing web app — **flight strips, ground radar, ATIS, chat/push-to-talk** —
-and proxy requests to [ASR](asr_service.md), [orchestrator](orchestrator_service.md),
-[flight plan](flight_plan_service.md) and [weather](weather_service.md). Talks to Postgres and
-Redis directly for state it needs to render.
+Three distinct mechanisms sit behind that one origin. Strips, ATIS and PTT are request/response:
+the browser calls an HMI endpoint, the HMI calls ASR, the orchestrator, weather or flight plan
+over plain HTTP, and hands back the JSON. The ground radar is a read, not a request in the usual
+sense — large parts of the UI are simply a view over Redis, and the radar is the clearest case: it
+polls an HMI endpoint that reads `aircraft:active_set` for who's currently flying, then
+`aircraft:state:{reg}` for each one's live latitude, longitude, heading and phase, once a second.
+And the chat log is pushed, not polled: the HMI subscribes to the Redis pub/sub channel
+`hmi:chat` and fans every message out over a WebSocket to every browser tab currently open, so a
+taxi-clearance rejection spoken in the pilot's voice reaches every open controller position at
+once.
 
-## Layout
+```mermaid
+flowchart LR
+    subgraph Browser["Browser (port 8005)"]
+        STRIPS[Flight strips]
+        RADAR["Ground radar / SMR"]
+        ATIS["ATIS + weather panel"]
+        PTT["PTT + chat panel"]
+    end
+    HMI[HMI API]
+    subgraph Proxies["a) HTTP proxies"]
+        ASRP["ASR /transcribe"]
+        ORCHP["Orchestrator /dispatch + /debrief"]
+        WXP[Weather service]
+        FPP[Flight Plan service]
+    end
+    subgraph Reads["b) Redis reads"]
+        ACTIVE["aircraft:active_set"]
+        STATE["aircraft:state:{reg}"]
+    end
+    subgraph Fanout["c) Redis pub/sub"]
+        CHAT["hmi:chat"]
+        WS["WebSocket, every tab"]
+    end
+    STRIPS --> HMI
+    RADAR --> HMI
+    ATIS --> HMI
+    PTT --> HMI
+    HMI --> ASRP
+    HMI --> ORCHP
+    HMI --> WXP
+    HMI --> FPP
+    HMI --> ACTIVE
+    ACTIVE --> STATE
+    STATE --> HMI
+    CHAT --> WS
+    WS --> PTT
+```
+
+## The controller's picture
+
+Four columns make up the flight-strip board: **PRE_TAXI**, **TAXI**, **RUNWAY**, **ARRIVALS**. A
+departure is born in PRE_TAXI and moves right as the controller works it — dragging a strip
+between columns issues `PATCH /strips/{reg}/state`, which accepts either the HMI's own upper-case
+phase codes (`PUSHBACK`, `TAXI`, `LINEUP`, `CLEARED`...) or the lower-case vocabulary the plugin's
+mover uses for its own motion state machine (`taxi_out`, `landing_roll`, `vacating`...) and
+normalizes both through one `column_map` — the two state machines described in
+[architecture](../architecture.md) don't share a vocabulary, so this endpoint is where that gets
+papered over. Arrivals skip PRE_TAXI and TAXI entirely: the moment the
+[Arrival Simulator](arrival_simulator_service.md) spawns an aircraft on the ILS it registers a
+**virtual strip** — a synthetic flight plan with no row in the flight-plan database — straight
+into ARRIVALS, where it stays through approach, landing roll, vacating and taxi-in until the
+aircraft parks and the strip is removed.
+
+The ground radar (SMR) is drawn, not simulated. `GET /airport/graph` parses the airport's X-Plane
+`.dat` file into nodes, edges, stands and runways — cached in memory per ICAO, downloaded
+automatically the first time that airport is requested — and the browser projects the graph into
+an SVG. Aircraft dots use real coordinates from `aircraft:state:{reg}` whenever a live position
+exists; only a strip with no position yet falls back to an estimated slot inside its column. ATIS
+and weather are plain proxies onto the [Weather service](weather_service.md), including on-demand
+ATIS generation with controller-supplied runway and QFE overrides. The chat panel merges two
+sources: the push-to-talk round trip below renders straight into the tab that triggered it, and
+the `hmi:chat` fan-out described above adds pilot-voice taxi-clearance rejections from the taxi
+router to every tab.
+
+```mermaid
+stateDiagram-v2
+    [*] --> PRE_TAXI
+    PRE_TAXI --> TAXI: pushback / taxi clearance
+    TAXI --> RUNWAY: line-up / cleared for take-off
+    [*] --> ARRIVALS: virtual strip registered at spawn
+    ARRIVALS --> [*]: aircraft parks, strip removed
+```
+
+## Push-to-talk, step by step
+
+1. The controller holds the PTT key — Spacebar by default, rebindable from the chat panel's gear
+   icon or the ASR settings screen (both save to the same `airport_asr_settings` entry in
+   `localStorage`).
+2. `MediaRecorder` starts capturing the microphone the instant the key goes down.
+3. Releasing the key stops the recorder and POSTs the clip to `/api/v1/hmi/asr/transcribe` — the
+   HMI's own proxy, which forwards the raw multipart body to `ASR_URL/transcribe` server-side.
+4. The corrected transcript comes back and is pushed into the chat log as the controller's line.
+5. The same script immediately POSTs that transcript to `/api/v1/hmi/orchestrator/dispatch`; the
+   reply that comes back is pushed into the chat log under the responding callsign — the pilot's
+   readback.
+
+See [architecture](../architecture.md) for the full voice-to-motion sequence, and
+[ASR](asr_service.md) for why "transcribe" is really two steps — a Whisper pass and an LLM
+callsign correction — hidden behind that one proxy call.
+
+## Starting a session from the browser
+
+Session control is not an HTTP call the plugin answers — it is a Redis hash the plugin polls, the
+same pattern as everything else that crosses the Docker/X-Plane boundary. The HMI only ever asks;
+the plugin does the work. That said, the routing is easy to misread from the file names alone: the
+setup screens live under the URL prefix `/api/v1/plugin` and the file `api/plugin_routes.py`,
+which reads like "the X-Plane plugin's API" — but every one of those endpoints (`/login`,
+`/register`, `/session/start`, `/session/stop`, `/session/status`, the per-user API-key routes) is
+called by the **browser's** setup screen, not by the plugin. The plugin's only two HTTP calls into
+this service are `POST /airport`, to report the ICAO it just loaded, and `DELETE
+/strips/arrivals`, to clear stale virtual strips at session start — a session can't even be
+started from the browser until the plugin has reported an airport at least once.
+
+Logging in checks the username/password hash in Postgres `users`; if that user has a stored key,
+login also writes it into the `airport:asr_config` hash under `api_key`, the same hash the ASR
+service is meant to read its runtime key from. The ASR backend and model choice, by contrast,
+never leave the browser — they live only in `localStorage`. Starting a session writes one hash in
+one shot: `type`, `weather`, `aircraft_count`, `complexity`, the current `icao`, `status:
+"pending"` and an empty `session_id`, all `HSET` into `airport:session_request`. The plugin polls
+that hash every two seconds ([xplane](../xplane.md) has the full lifecycle); seeing `pending` it
+flips the status to `starting`, does the heavy lifting — loads the airport, generates flight
+plans, spawns the fleet — and writes back `status: active` with a real `session_id`, or `status:
+error` if any step failed. The setup screen polls `/session/status` every 1.5 s and jumps the
+browser into the HMI proper the moment it reads `active`. Stopping mirrors this: the browser posts
+`/session/stop`, which snapshots the outgoing `session_id` (so a debrief can still be requested)
+and sets `status: stop_pending`; the plugin tears the session down and deletes the hash outright,
+so the next status read reports `idle`.
+
+## Auth and layout
+
+Passwords are salted and hashed with PBKDF2-SHA256 (`api/auth.py`), never stored in the clear; the
+`users` table carries one extra column, `openai_api_key`, for the per-user ASR key described
+above.
 
 | Path | Role |
 |---|---|
-| [`main.py`](../../services/controller_hmi_service/main.py) | FastAPI entrypoint; mounts static app |
-| [`api/routes.py`](../../services/controller_hmi_service/api/routes.py) | Main HMI endpoints (strips, radar state) |
-| [`api/chat.py`](../../services/controller_hmi_service/api/chat.py) | Chat / transmission endpoint → ASR → orchestrator |
-| [`api/plugin_routes.py`](../../services/controller_hmi_service/api/plugin_routes.py) | Endpoints the X-Plane plugin calls |
-| [`api/auth.py`](../../services/controller_hmi_service/api/auth.py) | Auth |
-| [`api/models.py`](../../services/controller_hmi_service/api/models.py) | Pydantic models |
-| `static/` | Front-end assets (served UI) |
-
-## Integrations
-
-Env: `REDIS_URL`, `DB_*` (Postgres), `ASR_URL`, `ORCHESTRATOR_URL`. Depends (Compose healthchecks)
-on postgres, redis, flight_plan, weather. The plugin reaches it via
-[`xplane_plugin/services/hmi_service.py`](../../xplane_plugin/services/hmi_service.py).
-
-## Tests
-
-HMI chat routing is exercised in [`tests/taxi_router/test_hmi_chat.py`](../../tests/taxi_router/test_hmi_chat.py).
+| [`main.py`](../../services/controller_hmi_service/main.py) | FastAPI entrypoint; writes `static/config.js`, mounts the static app |
+| [`api/routes.py`](../../services/controller_hmi_service/api/routes.py) | Strips, radar, weather/ATIS, ASR + orchestrator proxies |
+| [`api/chat.py`](../../services/controller_hmi_service/api/chat.py) | `hmi:chat` WebSocket fan-out |
+| [`api/plugin_routes.py`](../../services/controller_hmi_service/api/plugin_routes.py) | Auth, session handshake, per-user ASR key — browser-called, despite the name |
+| [`api/auth.py`](../../services/controller_hmi_service/api/auth.py) | Postgres connection + password hashing |
+| `static/` | The served UI: strips, radar, ATIS, PTT, setup |
 
 ## Related
-[architecture](../architecture.md) · [asr](asr_service.md) · [orchestrator](orchestrator_service.md) · [xplane](../xplane.md)
+[architecture](../architecture.md) · [xplane](../xplane.md) · [asr](asr_service.md) · [orchestrator](orchestrator_service.md) · [index](../index.md)

--- a/openwiki/services/flight_plan_service.md
+++ b/openwiki/services/flight_plan_service.md
@@ -1,44 +1,106 @@
 # Flight Plan Service
 
-**Port 8003:8000** · [`services/flight_plan_service/`](../../services/flight_plan_service/) · IFR
-flight plan generation. Health: `/api/v1/flight-plan/health`. Backed by PostgreSQL. See
-[architecture](../architecture.md).
+**Port 8003:8000** · [`services/flight_plan_service/`](../../services/flight_plan_service/) ·
+generates and stores the IFR flight plans that give every aircraft its identity. Health:
+`/api/v1/flight-plan/health`. Backed by PostgreSQL. See [architecture](../architecture.md).
 
 ## What it does
 
-Generates and stores the IFR flight plans that give every aircraft its identity (callsign,
-route, levels). With a `FLIGHT_PLAN_GENERATOR_KEY` it uses flightplandatabase.com; without
-one it falls back to a local generator.
+Generates and stores the IFR flight plans that give every aircraft its identity: registration,
+callsign, aircraft type, route, cruise level. Every plan comes from one of two generators — a live
+routing API or a fully local one — and callers can't tell which produced it from the response
+shape; the service always answers with a complete plan and a `200`.
 
 | Relations | Modules |
 |---|---|
-| **Called by** | [Orchestrator](orchestrator_service.md) · [Arrival Simulator](arrival_simulator_service.md) · [Controller HMI](controller_hmi_service.md) · X-Plane plugin |
-| **Calls** | PostgreSQL (`flight_plans`) · flightplandatabase.com (external) |
+| **Called by** | [Controller HMI](controller_hmi_service.md) (`/strips` proxy) · [Arrival Simulator](arrival_simulator_service.md) (plan catalog) · [Orchestrator](orchestrator_service.md) (known-aircraft context) · X-Plane plugin (session-start fleet generation) |
+| **Calls** | flightplandatabase.com (optional, `FLIGHT_PLAN_GENERATOR_KEY`) · PostgreSQL (`flight_plans`) |
 
 **Try it standalone:** <http://localhost:8003/docs> · health `GET /api/v1/flight-plan/health`.
 
-## Responsibility
+## How a plan is generated
 
-Generate IFR flight plans (routes, SIDs/STARs, levels) for aircraft, sourced from
-**flightplandatabase.com** with a local generator fallback, and persist them.
+Two GET endpoints under `/api/v1/flight-plan` produce a plan, and the difference between them is
+the whole story. `/generate/api`
+([`api/routes.py`](../../services/flight_plan_service/api/routes.py)) tries
+[`core/api_generator.py`](../../services/flight_plan_service/core/api_generator.py) first: it
+POSTs to flightplandatabase.com's `/auto/generate` with a departure (default `LEST`, overridable)
+and one of four hard-coded destinations — `LEBL`, `LEMD`, `LEVC`, `LEAL` — picked at random if none
+is given, then GETs `/plan/{id}` for the full waypoint list and collapses consecutive nodes on the
+same airway into a single `entry AIRWAY exit` route string. It authenticates with
+`FLIGHT_PLAN_GENERATOR_KEY` (blank by default in `.env.example`), sent as the HTTP basic-auth
+username. `/generate` (no suffix) never touches the network: it calls
+[`core/generator.py`](../../services/flight_plan_service/core/generator.py) directly, which draws
+every field from the tables in [`core/data.py`](../../services/flight_plan_service/core/data.py) —
+7 aircraft types, 10 airlines, and 12 Spanish airports with point-to-point distances — falling back
+to `LEST` only if the requested departure isn't one of those 12, and choosing a destination from
+any of the other 11, not just the API route's fixed four.
+
+The fallback is what makes this resilient rather than merely "has an offline mode": the
+`/generate/api` handler wraps the entire external call in a bare `except Exception`, so a missing
+key, an expired session, a timeout, or a 500 from flightplandatabase.com all land in the same place
+— a fresh call to the identical local generator `/generate` uses directly. Either path fills the
+remaining fields — registration, callsign, PIC name, passenger count, cruise speed/altitude, EET,
+endurance, alternates — the same way, in Python, from the same tables, and both persist through
+`FlightPlanRepository.create()` into the `flight_plans` table
+([`core/database/models.py`](../../services/flight_plan_service/core/database/models.py)) before
+returning. Since that table predates the `callsign` column,
+[`main.py`](../../services/flight_plan_service/main.py) runs a one-off ad-hoc migration at
+startup — no Alembic — that adds the column via a raw `ALTER TABLE` if it's missing. In practice
+the whole system runs keyless: the X-Plane plugin's own session-start call, the only place flight
+plans get generated in bulk, uses `/generate` exclusively.
+
+```mermaid
+flowchart TD
+    A["GET /generate/api"] --> B["api_generator: POST /auto/generate,<br/>GET /plan/id"]
+    E["GET /generate"] --> D["generator.py: pick from core/data.py tables"]
+    B --> C{"external call OK?"}
+    C -- "yes" --> R["collapse route nodes into route string"]
+    C -- "no key, timeout, any error" --> D
+    R --> F["fill aircraft, pilot, timing, callsign"]
+    D --> F
+    F --> G[("flight_plans in PostgreSQL")]
+    G --> H["FlightPlanResponse"]
+```
+
+## Who consumes plans
+
+Every AI aircraft's identity traces back to a row in `flight_plans`; the four consumers below just
+read it in different shapes.
+
+- The [Controller HMI](controller_hmi_service.md) — the controller's screen, and the single host
+  the browser ever talks to — proxies `GET /plans` at its own `/strips` endpoint, merging the real
+  rows with in-memory "virtual" arrival strips for aircraft the Arrival Simulator has dispatched
+  but that don't have a DB plan yet.
+- The [Arrival Simulator](arrival_simulator_service.md) — keeps AI arrivals coming down the ILS so
+  the controller always has traffic — treats any plan whose `destination_ICAO` matches the session
+  airport as an inbound
+  ([`core/plan_catalog.py`](../../services/arrival_simulator_service/core/plan_catalog.py)),
+  falling back to a built-in six-aircraft synthetic pool when the DB has none left or the service
+  is unreachable.
+- The [Orchestrator](orchestrator_service.md) — the routing brain — proxies
+  `GET /plans/{registration}` (`api/flight_plans.py`) and folds the result into
+  `get_known_aircraft()`'s three-source merge, tagged `source: "flight_plan"`, alongside
+  PostgreSQL clearances and live Redis state.
+- The X-Plane plugin
+  ([`xplane_plugin/services/flight_plan_service.py`](../../xplane_plugin/services/flight_plan_service.py))
+  doesn't just read plans, it seeds them: at session start,
+  [`ui/windows_manager.py`](../../xplane_plugin/ui/windows_manager.py)'s
+  `_execute_start_from_redis` clears every existing plan and generates a fresh batch — one per
+  aircraft, departure forced to the session's airport — before handing them to `StandAssigner` to
+  spawn the parked fleet at compatible gates.
 
 ## Layout
 
 | Path | Role |
 |---|---|
-| [`core/api_generator.py`](../../services/flight_plan_service/core/api_generator.py) | Generates plans via the flightplandatabase.com API |
-| [`core/generator.py`](../../services/flight_plan_service/core/generator.py) | Local generation fallback |
-| [`core/data.py`](../../services/flight_plan_service/core/data.py) | Static/reference data |
-| [`core/database/`](../../services/flight_plan_service/core/database/) | `connection.py`, `models.py`, `repositories/flight_plan.py` |
-| [`models/schemas.py`](../../services/flight_plan_service/models/schemas.py) | Pydantic schemas |
-| [`api/`](../../services/flight_plan_service/api/) | FastAPI routers |
-
-## Consumers
-
-Consumed by the [orchestrator](orchestrator_service.md) (aircraft identification + agent context),
-the [arrival simulator](arrival_simulator_service.md) (`FLIGHT_PLAN_SERVICE_URL`), the
-[HMI](controller_hmi_service.md), and the X-Plane plugin
-([`xplane_plugin/services/flight_plan_service.py`](../../xplane_plugin/services/flight_plan_service.py)).
+| [`main.py`](../../services/flight_plan_service/main.py) | FastAPI app; creates tables; ad-hoc `callsign` column migration |
+| [`api/routes.py`](../../services/flight_plan_service/api/routes.py) | Health, `/generate` and `/generate/api` routers, plans CRUD, reference data |
+| [`core/api_generator.py`](../../services/flight_plan_service/core/api_generator.py) | flightplandatabase.com client: route generation, node collapsing |
+| [`core/generator.py`](../../services/flight_plan_service/core/generator.py) | Fully offline local generator |
+| [`core/data.py`](../../services/flight_plan_service/core/data.py) | Static tables: aircraft, airports, distances, airlines, pilot names |
+| [`core/database/`](../../services/flight_plan_service/core/database/) | `connection.py` (engine/session), `models.py` (`FlightPlanModel`), `repositories/flight_plan.py` (CRUD) |
+| [`models/schemas.py`](../../services/flight_plan_service/models/schemas.py) | Pydantic `FlightPlanResponse` / `HealthResponse` |
 
 ## Related
-[architecture](../architecture.md) · [orchestrator](orchestrator_service.md) · [arrival_simulator](arrival_simulator_service.md)
+[architecture](../architecture.md) · [controller_hmi](controller_hmi_service.md) · [arrival_simulator](arrival_simulator_service.md) · [orchestrator](orchestrator_service.md) · [index](../index.md)

--- a/openwiki/services/orchestrator_service.md
+++ b/openwiki/services/orchestrator_service.md
@@ -1,84 +1,253 @@
 # Orchestrator Service
 
 **Port 8007:8006** · [`services/orchestrator_service/`](../../services/orchestrator_service/) ·
-the routing brain of AIrport. Largest service. See [architecture](../architecture.md).
+the only service that decides which aircraft, which controller phase, and which pilot agent a
+transmission belongs to. See [architecture](../architecture.md).
 
 ## What it does
 
-The brain of the backend: it receives every transcribed transmission, figures out which
-aircraft it addresses and which phase that aircraft is in (`DEL → GND → TWR`), calls the
-matching pilot agent on Cloud Run with full context, and turns the agent's answer into state
-changes, movement commands and the session debrief.
+The orchestrator is the routing brain — decides which aircraft, which controller phase, which
+pilot agent, and turns the reply into state and motion. Every controller transmission that has
+already been transcribed passes through here before anything answers back or moves; nothing else
+in the stack gets to make that call.
 
 | Relations | Modules |
 |---|---|
-| **Called by** | [ASR](asr_service.md) (dispatch) · [Controller HMI](controller_hmi_service.md) (dispatch/debrief proxy) · [Arrival Simulator](arrival_simulator_service.md) (arrival handoff) · X-Plane plugin |
-| **Calls** | [DEL/GND/TWR agents](../agents.md) · [Flight Plan](flight_plan_service.md) · [Weather](weather_service.md) · [shared taxi_router](../shared.md) · Postgres · Redis (`tts:queue`, move events) |
+| **Called by** | [Controller HMI](controller_hmi_service.md) proxy (`POST /dispatch`) · [Arrival Simulator](arrival_simulator_service.md) (`POST /arrivals/register`) |
+| **Calls** | [Flight Plan](flight_plan_service.md) · [Weather](weather_service.md) · DEL / GND / TWR [pilot agents](../agents.md) on Cloud Run · PostgreSQL · Redis |
 
 **Try it standalone:** <http://localhost:8007/docs> · health `GET /health` — host port is
 **8007**, the container listens on **8006**
 ([why](../guides/configuration.md#host-vs-container-ports)).
 
-## Responsibility
+## What happens on /dispatch
 
-Receives transcribed controller transmissions, identifies the aircraft & callsign, decides which
-controller (DEL/GND/TWR) owns it based on phase, forwards to the matching [agent](../agents.md),
-and returns the readback. Also owns the aircraft state machine, arrival handoffs, debrief
-generation, and a frequency audit.
+[`api/dispatch.py`](../../services/orchestrator_service/api/dispatch.py) receives
+`{session_id, message}`, sent either by the [Controller HMI](controller_hmi_service.md) — the
+controller's screen, and the single host the browser ever talks to — proxying the browser's
+request, or directly by the [ASR service](asr_service.md), which turns controller speech into
+corrected ATC text, when it's configured for server-side dispatch (`ORCHESTRATOR_URL`). Before
+anything else can go wrong, the endpoint appends that exact text to
+`session:{sid}:transcripts` in Redis: whatever happens next — a Cloud Run agent timing out,
+Postgres refusing a write — the debrief will still have the controller's real words.
 
-## API — [`api/`](../../services/orchestrator_service/api/)
+Only then does it hand off to [`runner.py`](../../services/orchestrator_service/runner.py),
+which runs the routing agent in a thread-pool executor (`runner.py` opens its own event loop
+with `asyncio.run`, and a FastAPI request handler is already inside one, so it can't run there
+directly). The agent itself is a Google ADK `Agent` on Gemini (`AGENT_MODEL`, resolved to
+`gemini-3.1-flash-lite` in this stack) driven by a fixed workflow written into its system prompt
+([`agent/prompts.py`](../../services/orchestrator_service/agent/prompts.py)):
 
-| Router | Path prefix | Purpose |
+It first calls `get_known_aircraft()`, which returns a list `runner._fetch_known_aircraft()`
+pre-fetched before the agent ever starts, merged from three sources: PostgreSQL
+`aircraft_clearances` (authoritative — it carries the current phase), the Flight Plan service's
+`GET /plans` (aircraft filed but not yet cleared), and Redis `aircraft:active_set` plus
+`aircraft:state:{reg}` (aircraft alive in the sim right now). Against that merged list the agent
+identifies and corrects the callsign the controller used.
+
+Next it resolves the phase. If the aircraft is already known, the DB's `dependency` column wins
+outright. If not, the prompt falls back to keyword inference: "delivery / clearance / IFR /
+squawk" → DEL, "taxi / pushback / ground" → GND, "ready / lineup / tower / takeoff" → TWR, DEL if
+nothing matches. Before routing anywhere, it checks the message for a handoff phrase — "contact
+ground on 121.9", "contact tower on 118.1" — which short-circuits everything else: the matching
+tool fires and its readback is returned directly, without a pilot agent ever seeing the message
+(next section).
+
+Otherwise, if the destination is GND and the message reads as a taxi clearance, the agent calls
+`get_taxi_route()` first: an A\* search over the airport's taxiway graph, seeded from the
+aircraft's live position in `aircraft:state:{reg}`. Finally `forward_to_agent()` POSTs the
+message — plus DEL flight-plan/ATIS context, or the GND/TWR clearance record with the taxi route
+merged in — to the phase's Cloud Run agent, one of the stateless Gemini pilots that draft the
+ICAO readback — nothing more. Inside that same tool call the reply is logged to
+`session:{sid}:agent_replies`, and — if the pilot just acknowledged a pushback or a taxi
+clearance — handed to the shared taxi router's `dispatch_taxi_plan()` (see [shared](../shared.md)),
+which writes the movement plan to `aircraft:{reg}:move_cmd`.
+
+Once the agent run completes, `runner.py` does the bookkeeping no LLM is trusted with: it upserts
+the DEL clearance fields into `aircraft_clearances` if one was issued — this alone does **not**
+move the phase, see below — and flips `dependency` to GND, TWR, or GND again if one of the
+handoff tools set its flag. Back in `dispatch.py`, the reply is RPUSHed onto `tts:queue`, and the
+endpoint returns `{reply, agent, aircraft_registration, callsign}`.
+
+```mermaid
+flowchart TD
+    A["POST /dispatch: session_id + message"]
+    B["append_transcript to session:{sid}:transcripts"]
+    C["merge known aircraft: Postgres + Flight Plan + Redis"]
+    D["identify / correct callsign"]
+    E["determine phase: DB dependency, else keywords"]
+    F{"handoff phrase?"}
+    G["advance_to_gnd / advance_twr / advance_to_gnd_arrival"]
+    H{"GND taxi clearance?"}
+    I["get_taxi_route: A star from live position"]
+    J["forward_to_agent to DEL / GND / TWR"]
+    K["persist clearance, flip phase, move_cmd, tts:queue"]
+    L["reply + agent + registration + callsign"]
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    F -- yes --> G
+    F -- no --> H
+    G --> L
+    H -- yes --> I
+    H -- no --> J
+    I --> J
+    J --> K
+    K --> L
+```
+
+## The controller-phase state machine
+
+The phase an aircraft is in — APP, DEL, GND, or TWR — lives in exactly one place: the PostgreSQL
+column `aircraft_clearances.dependency`. It isn't cached or mirrored anywhere else; the
+orchestrator owns it outright, and it answers one question — which controller position owns this
+aircraft right now?
+
+Two rules keep it honest. Only three tools ever move it — `advance_to_gnd`, `advance_to_twr`,
+`advance_to_gnd_arrival` — and each fires strictly on an explicit handoff phrase read from the
+transcript. And, easy to miss: **issuing a DEL clearance does not advance the phase.**
+`runner.py` persists the clearance fields the moment DEL replies, but the aircraft stays in DEL
+until the controller actually says "contact ground on {freq}" — a deliberate split between
+*cleared* and *released*.
+
+A departure walks DEL → GND → TWR. An arrival is registered by the Arrival Simulator straight
+into APP (`POST /arrivals/register`), skipping DEL and GND, and only re-enters GND once TWR has
+cleared it to land and the pilot has vacated — the reverse handoff `advance_to_gnd_arrival`
+exists because that transition can start from either APP or TWR.
+
+This is a different bookkeeping problem from the **motion state machine** the X-Plane plugin's
+mover keeps for the same aircraft (`waiting → pushback → taxi_out → done`, or the arrival
+equivalent) — see [xplane](../xplane.md). A controller handoff never moves the aircraft, and a
+completed taxi never changes who owns the frequency; the two machines only meet through the taxi
+router.
+
+```mermaid
+stateDiagram-v2
+    [*] --> DEL
+    [*] --> APP
+    DEL --> GND: contact ground (advance_to_gnd)
+    GND --> TWR: contact tower (advance_twr)
+    APP --> GND: landed + vacated, contact ground (advance_to_gnd_arrival)
+    TWR --> GND: landed + vacated, contact ground (advance_to_gnd_arrival)
+    note right of DEL
+        A DEL clearance alone does NOT
+        advance the phase - only an
+        explicit handoff phrase does.
+    end note
+```
+
+## The routing agent's tools
+
+`orch_agent` ([`agent/agent.py`](../../services/orchestrator_service/agent/agent.py)) is a
+single Google ADK `Agent` wired to six tools; the system prompt is the actual workflow — the
+tools below are just what it's allowed to touch.
+
+| Tool | File | Purpose |
 |---|---|---|
-| [`dispatch.py`](../../services/orchestrator_service/api/dispatch.py) | `/dispatch` | **Main entry.** `POST` a `{session_id, message}`; returns `{reply, agent, aircraft_registration, callsign}`. Runs the LLM orchestrator agent |
-| [`arrivals.py`](../../services/orchestrator_service/api/arrivals.py) | `/arrivals` | Arrival handoffs from the [arrival simulator](arrival_simulator_service.md) |
-| [`events_subscriber.py`](../../services/orchestrator_service/api/events_subscriber.py) | — | Redis pub/sub subscriber for lifecycle events |
-| [`flight_plans.py`](../../services/orchestrator_service/api/flight_plans.py) | `/flight-plans` | Flight-plan lookups |
-| [`aircraft.py`](../../services/orchestrator_service/api/aircraft.py) | `/aircraft` | Aircraft records |
-| [`clearances.py`](../../services/orchestrator_service/api/clearances.py) | `/clearances` | Clearance records |
-| [`weather.py`](../../services/orchestrator_service/api/weather.py) | `/weather` | Weather passthrough to [weather service](weather_service.md) |
-| [`debrief.py`](../../services/orchestrator_service/api/debrief.py) | `/debrief` | Post-session debrief |
+| `get_known_aircraft` | [`tools/aircraft.py`](../../services/orchestrator_service/agent/tools/aircraft.py) | Returns the merged aircraft list already sitting in session state |
+| `get_taxi_route` | [`tools/taxi_route.py`](../../services/orchestrator_service/agent/tools/taxi_route.py) | Extracts destination + via-taxiways from the raw instruction, runs the A\* search |
+| `advance_to_gnd` | [`tools/advance_to_gnd.py`](../../services/orchestrator_service/agent/tools/advance_to_gnd.py) | DEL → GND on a ground-frequency handoff |
+| `advance_to_twr` | [`tools/advance_twr.py`](../../services/orchestrator_service/agent/tools/advance_twr.py) | GND → TWR on a tower-frequency handoff |
+| `advance_to_gnd_arrival` | [`tools/advance_to_gnd_arrival.py`](../../services/orchestrator_service/agent/tools/advance_to_gnd_arrival.py) | APP/TWR → GND, the post-landing reverse handoff |
+| `forward_to_agent` | [`tools/forward.py`](../../services/orchestrator_service/agent/tools/forward.py) | POSTs to the phase's Cloud Run agent; logs the reply and triggers the taxi dispatch |
 
-Entrypoint [`main.py`](../../services/orchestrator_service/main.py); the container listens on 8006
-(`/health` healthcheck). Runtime config in [`config.py`](../../services/orchestrator_service/config.py).
+## Listening to the sim
 
-## Orchestrator agent — [`agent/`](../../services/orchestrator_service/agent/)
+A background asyncio task, started in the FastAPI `lifespan`
+([`main.py`](../../services/orchestrator_service/main.py)) and stopped cleanly on shutdown, keeps
+a second channel open to Redis — the boundary between the Docker backend and the host-side sim
+plugin — that has nothing to do with `/dispatch`.
+[`api/events_subscriber.py`](../../services/orchestrator_service/api/events_subscriber.py)
+psubscribes to `aircraft:*:move_events` and subscribes to `hmi:chat`, and appends every message it
+receives to `session:{sid}:events`, tagged with whatever session is currently active according to
+`airport:session_request`. If the connection drops it retries every 2 seconds, indefinitely.
 
-An adk/Gemini agent that routes. Definition in
-[`agent/agent.py`](../../services/orchestrator_service/agent/agent.py), instruction in
-[`agent/prompts.py`](../../services/orchestrator_service/agent/prompts.py); driven by
-[`runner.py`](../../services/orchestrator_service/runner.py). Tools:
+Why bother: the pilot agents only know what they said. The plugin's mover knows what actually
+happened — whether an aircraft really reached its holding point, whether a taxi command got
+rejected server-side. Without this subscriber the debrief would only ever have the LLM's side of
+the story; with it, the session log also carries the sim's ground truth.
 
-| Tool | Role |
-|---|---|
-| [`tools/aircraft.py`](../../services/orchestrator_service/agent/tools/aircraft.py) | `get_known_aircraft` — list aircraft from Postgres / flight_plan / Redis |
-| [`tools/taxi_route.py`](../../services/orchestrator_service/agent/tools/taxi_route.py) | `get_taxi_route` — A\* route via [taxi_router](../shared.md) from raw instruction text |
-| [`tools/advance_to_gnd.py`](../../services/orchestrator_service/agent/tools/advance_to_gnd.py) | Move aircraft DEL → GND |
-| [`tools/advance_twr.py`](../../services/orchestrator_service/agent/tools/advance_twr.py) | Move aircraft GND → TWR |
-| [`tools/advance_to_gnd_arrival.py`](../../services/orchestrator_service/agent/tools/advance_to_gnd_arrival.py) | Arrival handoff to GND |
-| [`tools/forward.py`](../../services/orchestrator_service/agent/tools/forward.py) | Forward the transmission to the chosen DEL/GND/TWR agent, return the readback |
-| [`tools/confirm.py`](../../services/orchestrator_service/agent/tools/confirm.py) | Confirmation step |
+## The debrief
 
-There is also a separate **debrief agent**
-([`agent/debrief_agent.py`](../../services/orchestrator_service/agent/debrief_agent.py) +
-`debrief_prompt.py`, assembled by
-[`debrief_builder.py`](../../services/orchestrator_service/debrief_builder.py)).
+`POST /debrief/generate` ([`api/debrief.py`](../../services/orchestrator_service/api/debrief.py))
+is where all three Redis session logs and the Postgres clearance rows for a session come back
+together. [`debrief_builder.py`](../../services/orchestrator_service/debrief_builder.py)'s
+`build_timeline()` interleaves `session:{sid}:transcripts`, `:agent_replies`, `:events`, and the
+clearance rows into one chronological text block — pure functions, no I/O, easy to unit-test in
+isolation. In parallel,
+[`frequency_audit.py`](../../services/orchestrator_service/frequency_audit.py)'s
+`audit_frequencies()` re-scans just the transcripts for every frequency the controller read out
+(numeric or spelled out, English or Spanish), infers which service it was meant for from the
+surrounding words, and compares it against the airport's real COM frequencies — a deterministic
+check that catches wrong-controller mistakes an LLM grader might gloss over.
 
-## Data & support
+Both outputs feed
+[`agent/debrief_agent.py`](../../services/orchestrator_service/agent/debrief_agent.py), which is
+deliberately not an ADK agent: a debrief is one structured-JSON request with no tools and no
+memory, so it calls the `google-genai` SDK against Vertex AI directly, asking for a
+JSON-schema-constrained score (overall score, per-category scores, strengths, improvements, an
+instructor summary). `render_markdown()` turns that JSON into the
+Markdown the HMI shows in the debrief modal, with the frequency-audit table spliced in above the
+categories.
 
-- [`db/`](../../services/orchestrator_service/db/) — SQLAlchemy `models.py`, `repository.py`,
-  `connection.py` (PostgreSQL).
-- [`session_log.py`](../../services/orchestrator_service/session_log.py) — records the exact
-  controller transcript per session (captured before dispatch, so a debrief survives agent errors).
-- [`frequency_audit.py`](../../services/orchestrator_service/frequency_audit.py) — audits
-  controller-frequency correctness.
-- [`shared/callbacks.py`](../../services/orchestrator_service/shared/callbacks.py) — adk callbacks.
+```mermaid
+flowchart LR
+    TR["session:{sid}:transcripts"]
+    AR["session:{sid}:agent_replies + events"]
+    CLR["aircraft_clearances rows"]
+    BUILD["debrief_builder: build_timeline"]
+    AUDIT["frequency_audit: audit_frequencies"]
+    AGENT["debrief_agent: Gemini grading"]
+    REPORT["graded report: JSON + Markdown"]
+    TR --> BUILD
+    AR --> BUILD
+    CLR --> BUILD
+    TR --> AUDIT
+    BUILD --> AGENT
+    AUDIT --> AGENT
+    AGENT --> REPORT
+```
 
-## Dispatch flow
+## API surface
 
-`POST /dispatch` → capture transcript (`append_transcript`) → run orchestrator agent in a thread
-executor → agent: get known aircraft → correct callsign → determine controller (DB dependency or
-content fallback) → `forward` to DEL/GND/TWR → return `DispatchResponse`.
+| Router | Prefix | Exposes |
+|---|---|---|
+| [`dispatch.py`](../../services/orchestrator_service/api/dispatch.py) | `/dispatch` | The main entry point — routes a transcript to a pilot agent (above) |
+| [`arrivals.py`](../../services/orchestrator_service/api/arrivals.py) | `/api/v1/orchestrator/arrivals` | Registers an inbound aircraft into APP |
+| [`debrief.py`](../../services/orchestrator_service/api/debrief.py) | `/debrief` | Builds and grades the end-of-session debrief |
+| [`aircraft.py`](../../services/orchestrator_service/api/aircraft.py) | `/aircraft` | Position (Redis), clearance/taxi-route (Postgres), airport graph |
+| [`clearances.py`](../../services/orchestrator_service/api/clearances.py) | `/clearances` | Direct clearance CRUD — mostly a test/seeding surface |
+| [`flight_plans.py`](../../services/orchestrator_service/api/flight_plans.py) | `/flight-plans` | Proxy to the [Flight Plan](flight_plan_service.md) service |
+| [`weather.py`](../../services/orchestrator_service/api/weather.py) | `/atis` | Proxy to the [Weather](weather_service.md) service |
+| [`events_subscriber.py`](../../services/orchestrator_service/api/events_subscriber.py) | — | No HTTP surface — the background sim listener (above) |
+
+## Data, support, tests
+
+[`db/`](../../services/orchestrator_service/db/) is a small SQLAlchemy trio:
+[`connection.py`](../../services/orchestrator_service/db/connection.py) (engine, session,
+`init_db()`), [`models.py`](../../services/orchestrator_service/db/models.py) — a single table,
+`AircraftClearance` → `aircraft_clearances` — and
+[`repository.py`](../../services/orchestrator_service/db/repository.py)'s
+`ClearanceRepository` (`upsert`, `get`, `update_dependency`). That table is the entire durable
+memory of a departure: the DEL clearance fields (`squawk`, `instrumental_departure` — the SID,
+`runway_in_use`, `altimeter`, `destination_icao`, free-text `clearance_text`), a JSONB
+`taxi_route` column the GND agent fills in later, and `dependency` itself, defaulting to `DEL`.
+
+Two more modules exist purely to feed the debrief:
+[`session_log.py`](../../services/orchestrator_service/session_log.py) (the Redis list wrapper
+behind the three `session:{sid}:*` keys) and
+[`shared/callbacks.py`](../../services/orchestrator_service/shared/callbacks.py) (ADK
+`before_agent_callback` / `after_agent_callback` — structured logging of what the agent saw and
+decided, no state mutation).
+
+[`tests/unit/orchestrator/`](../../tests/unit/orchestrator/) is the deepest unit suite in the
+repo: eleven files covering the dispatch and arrivals endpoints, every advance tool, the forward
+tool's Cloud Run call and taxi-dispatch trigger, `get_known_aircraft` and `get_taxi_route`, the
+events subscriber, the repository, the runner's post-agent persistence logic, the frequency
+audit, and the session log — a reflection of how much of the orchestrator's correctness lives in
+deterministic Python around the LLM call, not in the call itself.
 
 ## Related
-[architecture](../architecture.md) · [agents](../agents.md) · [shared](../shared.md) · [asr](asr_service.md) · [arrival_simulator](arrival_simulator_service.md)
+[architecture](../architecture.md) · [agents](../agents.md) · [shared](../shared.md) · [asr](asr_service.md) · [index](../index.md)

--- a/openwiki/services/weather_service.md
+++ b/openwiki/services/weather_service.md
@@ -1,41 +1,91 @@
 # Weather Service
 
-**Port 8004:8000** · [`services/weather_service/`](../../services/weather_service/) · METAR, TAF
-and ATIS. Health: `/api/v1/weather/health`. Backed by PostgreSQL. See [architecture](../architecture.md).
+**Port 8004:8000** · [`services/weather_service/`](../../services/weather_service/) ·
+real METAR/TAF in, the session's ATIS out. Health: `/api/v1/weather/health`. See
+[architecture](../architecture.md).
 
 ## What it does
 
-Real weather for the session: fetches METAR/TAF from aviationweather.gov, computes the
-flight category (VFR/MVFR/IFR/LIFR), and generates the ATIS broadcast that both the pilot
-agents and the controller read.
+Fetches real METAR/TAF and generates the ATIS the whole session keys off: every other component
+that needs current conditions — or the runway in use — asks this service, not
+aviationweather.gov directly.
 
 | Relations | Modules |
 |---|---|
-| **Called by** | [Controller HMI](controller_hmi_service.md) · [Orchestrator](orchestrator_service.md) (weather passthrough for agent context) |
-| **Calls** | PostgreSQL (ATIS history) · aviationweather.gov (external) |
+| **Called by** | [Controller HMI](controller_hmi_service.md) (ATIS/weather panel, proxied) · [Orchestrator](orchestrator_service.md) (weather context fetched before forwarding to the DEL agent) |
+| **Calls** | aviationweather.gov (external, METAR/TAF) · PostgreSQL (ATIS history) |
 
 **Try it standalone:** <http://localhost:8004/docs> · health `GET /api/v1/weather/health`.
 
-## Responsibility
+## From METAR to ATIS
 
-Fetch real weather (METAR/TAF) and generate the **ATIS** broadcast used by the ATC agents and HMI.
+Two thin layers sit around one real upstream API. `core/metar_taf_fetcher.py` is a small,
+key-less client with a 10 s timeout that hits `/api/data/metar` and `/api/data/taf` on
+aviationweather.gov; `api/routes.py` exposes both as pass-through endpoints
+(`/metar/{icao}`, `/metar/{icao}/raw`, `/taf/{icao}`, `/taf/{icao}/raw`) that reshape the JSON —
+or hand back the raw string — without ever touching the database.
+
+The real work happens one layer up, in `core/atis_generator.py`. `ATISGenerator.generate()`
+fetches the current METAR for the requested ICAO and parses wind direction/speed/gust,
+visibility, cloud layers and QNH out of the raw fields (parsing that used to live in a separate
+helper module; now it's inline here, and duplicated — lightly — in `routes.py`'s own `/metar`
+handler). From wind alone it picks the runway: `_select_runway_from_wind` scores every runway
+heading against the wind and keeps whichever is closest to a pure headwind. Once a runway is
+chosen it picks an approach type — ILS first, then VOR, then RNAV — from a small hard-coded
+`AIRPORT_DATA` table covering eleven Spanish airports (LEST, LEBL, LEMD, LECO, LEVX, LEGE, LEPA,
+LEVC, LEAL, LEZL, LEMG); anything else falls back to a generic two-runway default. QNH drives a
+five-step lookup for transition level — FL65 when pressure is high, stepping up to FL90 as QNH
+drops below 978 hPa — and an in-memory counter per ICAO hands out a sequential ATIS letter with
+its phonetic name ("information ALFA"), wrapping back to A after Z. ATC can override the
+auto-picked runway, approach, QFE and remarks through query params on `GET /atis/{icao}`; a
+`preview=true` flag runs the same generation without saving to PostgreSQL or advancing the letter —
+the HMI's own `/atis/generate` proxy exposes that same flag to the ATC-facing form.
+
+```mermaid
+flowchart LR
+    AWX["aviationweather.gov"] --> FETCH["fetch METAR/TAF"]
+    FETCH --> PARSE["parse wind, vis, clouds, QNH"]
+    PARSE --> RWY["runway by max headwind"]
+    RWY --> APP["approach type + transition level"]
+    APP --> TXT["ATIS text + sequential letter"]
+    TXT --> DB[("PostgreSQL history")]
+    TXT --> HMI["HMI weather panel"]
+    TXT --> ORCH["orchestrator DEL context"]
+```
+
+Every non-preview call persists through `ATISRepository` into the `atis_broadcasts` table;
+`/atis/{icao}/latest` and `/atis/{icao}/history` read it back. That's the only weather data this
+service stores — raw METAR and TAF are fetched fresh on every call and never written to the
+database.
+
+## Why it matters in a session
+
+The quiet load-bearing output here isn't the METAR, it's the runway. Because
+`_select_runway_from_wind` runs before anything else in `generate()`, whichever runway wins the
+headwind score becomes the `arrival_runway`/`departure_runway` baked into that ATIS broadcast, and
+everything downstream reads it off the text instead of recomputing it: the DEL agent's clearance
+readback names that runway, the ATIS the HMI panel and pilot agents quote is the same one, and it
+holds until ATC overrides it or a fresh letter is generated. Get the runway decision wrong and the
+whole session's clearances point at the wrong end of the airport.
+
+One honest caveat: this decision doesn't reach every corner of the sim. The
+[Arrival Simulator](arrival_simulator_service.md) is currently hard-coded to LEST runway 17
+geometry — spawn point, ~166° heading, the E3 vacate exit — regardless of which runway the ATIS
+actually selected from the wind. Only the controller-facing clearance text follows the weather;
+the simulated arrival traffic itself does not.
 
 ## Layout
 
 | Path | Role |
 |---|---|
-| [`main.py`](../../services/weather_service/main.py) | FastAPI entrypoint |
-| [`api/routes.py`](../../services/weather_service/api/routes.py) | Weather / ATIS endpoints |
-| [`core/metar_taf_fetcher.py`](../../services/weather_service/core/metar_taf_fetcher.py) | Fetches METAR/TAF from external sources |
-| [`metar_taf.py`](../../services/weather_service/metar_taf.py) | METAR/TAF parsing helpers |
-| [`core/atis_generator.py`](../../services/weather_service/core/atis_generator.py) | Builds the ATIS broadcast text |
-| [`core/database/`](../../services/weather_service/core/database/) | `connection.py`, `models.py`, `repositories/atis.py` (persist ATIS) |
+| [`main.py`](../../services/weather_service/main.py) | FastAPI entrypoint; creates DB tables on startup |
+| [`api/routes.py`](../../services/weather_service/api/routes.py) | Health, ATIS, METAR, TAF endpoints |
+| [`core/metar_taf_fetcher.py`](../../services/weather_service/core/metar_taf_fetcher.py) | Thin client over aviationweather.gov (`/api/data/metar`, `/api/data/taf`) |
+| [`core/atis_generator.py`](../../services/weather_service/core/atis_generator.py) | Parses METAR, picks runway/approach/transition level, builds ATIS text |
+| [`core/database/models.py`](../../services/weather_service/core/database/models.py) | `ATISModel` → `atis_broadcasts` table |
+| [`core/database/repositories/atis.py`](../../services/weather_service/core/database/repositories/atis.py) | ATIS CRUD (`create`, `get_latest_by_icao`, `get_all_by_icao`, ...) |
+| [`core/database/connection.py`](../../services/weather_service/core/database/connection.py) | SQLAlchemy engine/session; `check_connection` backs the health check |
 | [`models/schemas.py`](../../services/weather_service/models/schemas.py) | Pydantic request/response schemas |
 
-## Consumers
-
-The [orchestrator](orchestrator_service.md) pulls weather (its `api/weather.py` passthrough) to
-provide agents with conditions; the [HMI](controller_hmi_service.md) shows ATIS.
-
 ## Related
-[architecture](../architecture.md) · [orchestrator](orchestrator_service.md) · [flight_plan](flight_plan_service.md)
+[architecture](../architecture.md) · [controller_hmi](controller_hmi_service.md) · [orchestrator](orchestrator_service.md) · [arrival_simulator](arrival_simulator_service.md) · [index](../index.md)

--- a/openwiki/shared.md
+++ b/openwiki/shared.md
@@ -1,65 +1,164 @@
 # Shared package (`shared/`)
 
-Cross-service models and services imported by multiple microservices (the orchestrator, arrival
-simulator, and tests all depend on it). Source under [`shared/`](../shared/). See
-[architecture](architecture.md).
+Not a service — no port; imported as a package by the backend services and the X-Plane plugin.
+Source under [`shared/`](../shared/).
 
 ## What it does
 
-The common library of the backend: the data models every service agrees on (aircraft,
-phases, communications), the **A\* taxi router** that turns a taxi clearance into a
-runnable route, and the Redis-backed aircraft state store. It is not a service — it has no
-port; services import it as a package.
+`shared/` is the backend's common library — models, geo, state stores, and the A\* taxi router.
+Every service that needs to route an aircraft on the ground or persist its state draws from this
+one package instead of re-implementing it.
 
-| Relations | Modules |
+| Consumed by | For |
 |---|---|
-| **Imported by** | [Orchestrator](services/orchestrator_service.md) (taxi routing, state) · [Arrival Simulator](services/arrival_simulator_service.md) (state, geo) · the test suite |
-| **Feeds** | the [X-Plane plugin](xplane.md), indirectly — `dispatch_taxi_plan` publishes the move plan to Redis, which the in-sim mover consumes |
+| [Orchestrator](services/orchestrator_service.md) | the taxi router (`dispatch_taxi_plan`, `compute_taxi_route`), state reads |
+| [Arrival Simulator](services/arrival_simulator_service.md) | `geo.py`, and writing the same `move_cmd` contract the taxi router writes |
+| [Controller HMI](services/controller_hmi_service.md) | indirectly — reads what `shared/` writes to Redis (`hmi:chat`, `aircraft:state:{reg}`), no direct import |
+| [X-Plane plugin](xplane.md) | `AircraftStateStore`, `AirportDataStore`, `StandAssigner`, `AircraftTracker` |
 
-## Models — [`shared/models/`](../shared/models/)
+## From readback to route: the taxi router
 
-| Module | Purpose |
+The design point behind every module in
+[`shared/services/taxi_router/`](../shared/services/taxi_router/): **the LLM never parses
+taxiways — deterministic parsers do.** The GND pilot agent's only job is producing and
+acknowledging ICAO phraseology; every taxiway letter, holding point, and pushback heading that
+reaches a `move_cmd` is extracted, merged, and routed by plain Python, unit-tested under
+[`tests/taxi_router/`](../tests/taxi_router/). A hallucinated waypoint can't move an aircraft —
+the LLM never gets a chance to name one.
+
+One controller instruction and one pilot readback go in:
+
+- [`destination_parser.extract_destination`](../shared/services/taxi_router/destination_parser.py)
+  reads the **controller's** words for where the taxi ends — holding point, runway, or stand —
+  trying the most specific pattern first ("holding short of runway 17L" before the generic
+  "runway 17" fallback). It never looks at the pilot's readback or the database's
+  `runway_in_use`; if the controller named no endpoint, the last via-point becomes the
+  destination.
+- [`readback_parser`](../shared/services/taxi_router/readback_parser.py) reads the **pilot's**
+  readback: `extract_taxiway_tokens` collapses phonetic spelling ("bravo", "golf one zero") into
+  codes (`B`, `G10`); `parse_pushback_direction` turns "face north" or "face 090" into a heading.
+- [`merge_constraints`](../shared/services/taxi_router/constraints.py) reconciles both lists —
+  the pilot's order wins (ICAO requires reading the clearance back), but any taxiway the
+  controller named that the readback dropped is spliced back in at the position that keeps
+  progression monotonic. Nothing the controller instructed is allowed to silently vanish from the
+  route.
+- `router.py` loads the airport graph straight from Redis — `AirportDataStore().load()` reads
+  `airport:current:*` — into [`plugins/GND/graph.py`](../plugins/GND/graph.py)'s `AirportGraph`,
+  a `networkx.DiGraph` weighted by Haversine distance. `resolve_point` turns a spoken token into a
+  graph node: runway designator, taxiway letter, or stand id, in that order.
+- `find_route_from_position` snaps the aircraft's live GPS position (read from
+  `aircraft:state:{reg}`) to the nearest node in the graph; `find_route_via` then forces the path
+  through every merged via-point in order, stitching each leg with `nx.astar_path`. The same
+  Haversine edge weights double as an admissible heuristic, so A\* returns the same optimal path
+  Dijkstra would while exploring less of the graph.
+- `plan_pushback_leg` computes the reverse-and-pivot geometry off the stand: a back-step distance
+  clamped between `PUSHBACK_MIN_DIST_M`/`PUSHBACK_MAX_DIST_M`, the final heading the aircraft will
+  face, and a pivot rate — the mover executes this as reverse-then-pivot before joining the taxi
+  waypoints.
+- `dispatch_taxi_plan` assembles whatever legs the clearance actually contains — pushback only,
+  waypoints only, or both — into one versioned plan and writes `aircraft:{reg}:move_cmd` as JSON
+  with a TTL sized to the plan's own ETA. When `find_route_via` can't connect the via-points,
+  there is no `move_cmd`. `_shorten_reason` turns the graph's internal error into a short
+  pilot-facing phrase instead ("taxiway B not found", "no route available", "position off the
+  movement area"), and the router publishes it as a pilot-voice rejection — to `hmi:chat` for the
+  transcript, to `tts:queue` so it is actually spoken, and to `aircraft:{reg}:last_error` (TTL 5
+  min) for whoever is debugging.
+
+```mermaid
+flowchart LR
+    IN["controller instruction + pilot readback"]
+    DP["destination_parser"]
+    RP["readback_parser"]
+    MC["merge_constraints"]
+    GRAPH["AirportGraph from airport:current:*"]
+    RES["resolve_point"]
+    ASTAR["find_route_via - A* via nx.astar_path"]
+    PB["plan_pushback_leg"]
+    DISP["dispatch_taxi_plan"]
+    MOVE["aircraft:{reg}:move_cmd"]
+    REJ["unroutable clearance"]
+    CHAT["hmi:chat"]
+    ERR["aircraft:{reg}:last_error"]
+
+    IN --> DP
+    IN --> RP
+    DP --> MC
+    RP --> MC
+    MC --> RES
+    GRAPH --> RES
+    RES --> ASTAR
+    ASTAR --> PB
+    PB --> DISP
+    DISP --> MOVE
+    ASTAR --> REJ
+    REJ --> CHAT
+    REJ --> ERR
+```
+
+## dispatch_taxi_plan: the handover
+
+A `move_cmd` payload is a small envelope regardless of who wrote it: `version`, `plan_id`,
+`started_at`, `delay_before_start_s`, and a `legs` list, each leg naming its own `mode`. The taxi
+router emits `pushback` and `waypoints` legs (with a taxiway sequence and `speed_kts`); the
+[Arrival Simulator](services/arrival_simulator_service.md) writes the same envelope shape with
+`approach`, `landing_roll`, and `vacate` legs instead. The plugin's `AircraftMover` reads
+`aircraft:{reg}:move_cmd` and drives whichever legs it finds by branching on `mode` — it doesn't
+know or care whether the taxi router or the arrival simulator produced the plan, only that the
+shape matches. For taxi clearances specifically, `shared/` owns the writer side: `dispatch_taxi_plan`
+is the only thing that puts a `move_cmd` there. The return direction — motion milestones on
+`aircraft:{reg}:move_events` — is published by the plugin mover on the other side of the
+boundary; nothing in `shared/` writes or reads that channel (`config.py` defines the key template
+alongside `move_cmd`'s, but only `move_cmd` is ever set from here). Execution detail — the
+pushback → taxi state machine, the phase strings — lives on [xplane](xplane.md); the full key
+contract is on [architecture](architecture.md#the-redis-contract).
+
+## State in two tempos: aircraft_state_store
+
+[`AircraftStateStore.update()`](../shared/services/aircraft_state_store.py) writes the same
+[`AircraftState`](../shared/models/aircraft_state.py) snapshot twice, on purpose, in one
+pipelined Redis call. For *now*: a hash at `aircraft:state:{reg}` (TTL 1 hour), the registration
+added to `aircraft:active_set`, and the dict PUBLISHed on `aircraft:updates` — this is what the
+HMI's ground radar and the taxi router's own position lookup read. For *history*: the same
+snapshot becomes an InfluxDB point (`to_influx_point()`, measurement `aircraft_state`, tagged by
+`session_id`/`registration`), buffered in memory and flushed every 20 points instead of written
+one at a time (and force-flushed when `AircraftTracker.stop()` ends the session).
+`query_replay(session_id)` reads InfluxDB back — filtered by session and optionally by
+registration — for the post-session debrief. Why both stores exist alongside PostgreSQL is on
+[architecture](architecture.md#three-data-stores-three-jobs).
+
+## The rest of the toolbox
+
+| Module | Role |
 |---|---|
-| [`phases.py`](../shared/models/phases.py) | `Phase` enum + `ARRIVAL_PHASES` / `AIRBORNE_PHASES` sets. Drives the DEL→GND→TWR state machine (departure + arrival phase strings, lowercase to match the mover/state store) |
-| [`aircraft.py`](../shared/models/aircraft.py) | Aircraft model |
-| [`aircraft_state.py`](../shared/models/aircraft_state.py) | Aircraft state representation |
-| [`airport.py`](../shared/models/airport.py) | Airport model |
-| [`communications.py`](../shared/models/communications.py) | Communication / transmission model |
-| [`command_parser.py`](../shared/models/command_parser.py) | Parses ATC commands |
+| [`airport_data_store.py`](../shared/services/airport_data_store.py) | The parsed airport graph (nodes/edges/stands/runways) + stand occupancy + `session:current`, all under Redis `airport:current:*` |
+| [`stand_assigner.py`](../shared/services/stand_assigner.py) | Matches each flight plan to a free, compatible stand at session start — checks ICAO width code and props/jets vs. gate-only airline traffic |
+| [`geo.py`](../shared/services/geo.py) | Pure geodesy, no dependencies: `haversine`, `bearing`, `advance`, `project_on_localizer`. Imported directly by the plugin's mover and by the arrival simulator; the taxi router keeps its own small `haversine`/`advance` duplicates in `router.py`/`pushback.py` rather than importing it |
+| [`aircraft_tracker.py`](../shared/services/aircraft_tracker.py) | In-sim 2 Hz dataref reader feeding `AircraftStateStore`; imports `XPPython3` directly, so it only runs inside X-Plane |
+| [`models/aircraft_state.py`](../shared/models/aircraft_state.py) | The `AircraftState` dataclass — `to_dict()` for the Redis hash, `to_influx_point()` for history |
+| [`models/phases.py`](../shared/models/phases.py) | The **motion** phase enum — `parked`, `pushback`, `taxi_out`, `approach`, `landing_roll`, `vacating`, and the rest of what `AircraftMover` and `AircraftStateStore` emit. This is *not* the controller-phase state machine (`APP`/`DEL`/`GND`/`TWR`, owned by the orchestrator in PostgreSQL) — see [architecture](architecture.md#two-state-machines-not-one) for the distinction |
 
-## Services — [`shared/services/`](../shared/services/)
+## One graph, two consumers
 
-| Module | Purpose |
-|---|---|
-| [`taxi_router/`](../shared/services/taxi_router/) | **A\* taxi routing** package (see below) |
-| [`aircraft_state_store.py`](../shared/services/aircraft_state_store.py) | Aircraft state persistence (Redis-backed): phase, position, per-aircraft records |
-| [`aircraft_tracker.py`](../shared/services/aircraft_tracker.py) | Tracks live aircraft |
-| [`airport_data_store.py`](../shared/services/airport_data_store.py) | Loads/serves airport data (taxiways, stands) |
-| [`geo.py`](../shared/services/geo.py) | Geographic helpers (distance, bearings) |
+There is exactly one `AirportGraph` class:
+[`plugins/GND/graph.py`](../plugins/GND/graph.py), a `networkx.DiGraph` built from parsed apt.dat
+data — nodes, edges, stands, runway thresholds — with lookup indices for taxiway letters, stand
+ids, and node names. It lives under the in-sim plugin tree, since apt.dat parsing only happens on
+the host where X-Plane's scenery files are, but the backend doesn't keep its own copy. `router.py`'s
+`_load_graph()` inserts `plugins/GND` onto `sys.path` — the module "is not a package", per the
+code's own comment — and imports `graph` directly, then builds `AirportGraph(data=...)` from
+whatever `AirportDataStore.load()` returned. Same class, two callers: the in-sim/dev tooling that
+produced the JSON in the first place, and the backend taxi router that resolves and routes over
+it. The apt.dat parsing story itself — row codes, active-zone filtering — lives on
+[xplane](xplane.md).
 
-## taxi_router (A\* routing)
+## Tests
 
-[`shared/services/taxi_router/`](../shared/services/taxi_router/) computes A\* taxi routes with
-controller/pilot constraints, plans the pushback leg, and dispatches multi-leg move commands to
-the plugin. Public API ([`__init__.py`](../shared/services/taxi_router/__init__.py)):
-
-| Symbol | Role |
-|---|---|
-| `compute_taxi_route` | A\* route over the airport taxiway graph |
-| `dispatch_taxi_plan` | Sends the multi-leg move plan (to the plugin via Redis) |
-| `plan_pushback_leg`, `PushbackLeg` | Pushback geometry before taxi |
-| `extract_destination` | Regex parse of the destination (holding point / runway) from instruction text |
-| `extract_taxiway_tokens`, `parse_pushback_direction` | Parse "via" taxiways & pushback direction from readback |
-| `merge_constraints` | Merge controller + pilot constraints |
-| Errors | `TaxiRouterError`, `UnknownTaxiwayError`, `RouteNotFoundError`, `InvalidPushbackError` |
-
-The orchestrator's `get_taxi_route` tool
-([`agent/tools/taxi_route.py`](../services/orchestrator_service/agent/tools/taxi_route.py)) wraps
-this: it extracts destination + via taxiways from the raw instruction (so the LLM doesn't parse
-them), loads the airport graph, and returns waypoints + taxiway sequence + total distance.
-
-Well covered by tests under [`tests/taxi_router/`](../tests/taxi_router/) (graph construction,
-token resolution, routing e2e, pushback leg).
+[`tests/taxi_router/`](../tests/taxi_router/) runs against real airport data — LEBL's parsed
+graph, committed as a fixture and regenerated via `python -m plugins.GND.data_parser LEBL`. It is
+split into `graph_construction/` (building `AirportGraph` from a JSON file or a dict),
+`token_resolution/` (`resolve_point`, `extract_destination`, `extract_taxiway_tokens`,
+`merge_constraints`), and `taxi_routing/` (end-to-end routing and the pushback leg), plus a
+root-level `test_hmi_chat.py` for the rejection path.
 
 ## Related
-[index](index.md) · [architecture](architecture.md) · [orchestrator](services/orchestrator_service.md) · [xplane](xplane.md)
+[architecture](architecture.md) · [xplane](xplane.md) · [orchestrator](services/orchestrator_service.md) · [arrival simulator](services/arrival_simulator_service.md) · [index](index.md)

--- a/openwiki/xplane.md
+++ b/openwiki/xplane.md
@@ -1,57 +1,215 @@
 # X-Plane integration
 
-Two parts: the **in-sim plugin** ([`xplane_plugin/`](../xplane_plugin/)) that runs inside X-Plane
-12 via XPPython3, and the **deployable plugin files** ([`plugins/`](../plugins/)) that you copy
-into the simulator. See [architecture](architecture.md) for where this sits in the pipeline.
+Two source trees, one job: put the controller's clearances into motion and give every parked or
+airborne aircraft a voice. The development tree is [`xplane_plugin/`](../xplane_plugin/); what you
+actually copy into X-Plane is [`plugins/`](../plugins/). See [architecture](architecture.md) for
+where this sits in the voice → motion pipeline, and
+[X-Plane Plugin Setup](guides/xplane-plugin-setup.md) to install it.
 
 ## What it does
 
-Everything that happens **inside the simulator**: spawning the aircraft objects, taxiing
-them along the routes the controller cleared, and speaking each pilot readback with
-X-Plane's built-in TTS. Install it once ([X-Plane Plugin Setup](guides/xplane-plugin-setup.md))
-and start the backend before flying.
+**Everything inside the simulator: spawn, move, speak.** The plugin is the only part of AIrport
+that runs inside X-Plane 12's own process, on the host, never inside Docker — and that shapes how
+it talks to everything else. It exposes no port and answers no HTTP request; it is a Redis
+**client**, not a server. Every command it obeys arrives as a key it reads; everything it reports
+leaves as a key it writes or an event it publishes. There is no dedicated TTS microservice to route
+speech through — `services/tts_service/` is an empty placeholder — every line a pilot speaks in an
+AIrport session is synthesized right here.
 
-| Relations | Modules |
+| Relations | Redis keys |
 |---|---|
-| **Consumes** | multi-leg move plans from Redis (published by [shared taxi_router](shared.md) `dispatch_taxi_plan`) |
-| **Calls** | [Orchestrator](services/orchestrator_service.md) (host port `8007`) · [Controller HMI](services/controller_hmi_service.md) · [Flight Plan](services/flight_plan_service.md) |
+| **Consumes** | `aircraft:{reg}:move_cmd` · `aircraft:spawn_request:{reg}` · `tts:queue` · `airport:session_request` |
+| **Produces** | `aircraft:state:{reg}` · `aircraft:{reg}:move_events` · `aircraft:updates` |
 
-## `plugins/` — what you install into X-Plane
+## Two directories, one plugin
 
-Per [`README.md`](../README.md), copy these into
-`<X-Plane 12>/Resources/plugins/PythonPlugins/`:
+[`xplane_plugin/`](../xplane_plugin/) is the development source tree: `services/` (mover, spawner,
+and thin HTTP clients to the airport/flight-plan/HMI/user backends), `communication/` (TTS text
+shaping), and `ui/windows_manager.py`. The actual XPPython3 entry point is
+[`airport_plugin/PI_userInterface.py`](../xplane_plugin/airport_plugin/PI_userInterface.py) — a few
+lines that instantiate one `WindowManager` and forward `XPluginStart` / `XPluginStop` to its
+`register_plugin()` / `cleanup()`.
 
-| Path | Role |
+[`plugins/`](../plugins/) is what you copy into `<X-Plane 12>/Resources/plugins/PythonPlugins/` —
+see [X-Plane Plugin Setup](guides/xplane-plugin-setup.md) for install steps. `PI_` is XPPython3's
+entry-point convention: every top-level file it loads as a plugin is named that way.
+[`plugins/PI_spawn_obj.py`](../plugins/PI_spawn_obj.py) is an early throwaway spike — it hardcodes
+one `.obj` path and one `(lat, lon)` and spawns a single aircraft on `XPluginEnable`; nothing in the
+session flow touches it. What matters is [`plugins/GND/`](../plugins/GND/): `data_parser.py` turns
+apt.dat rows into typed records, and `graph.py`'s `AirportGraph` turns those into a routable
+networkx graph. The backend taxi router doesn't reimplement any of this — its `_load_graph()` pushes
+`plugins/GND` onto `sys.path` and imports `graph.AirportGraph` directly, the same file the plugin
+runs. One implementation, two consumers; see [shared](shared.md) for what the backend does with it.
+
+| Module | Role |
 |---|---|
-| [`plugins/PI_spawn_obj.py`](../plugins/PI_spawn_obj.py) | XPPython3 plugin entry (`PI_` prefix) — spawns aircraft objects in the sim |
-| [`plugins/GND/`](../plugins/GND/) | Ground routing: `data_parser`, `graph`, `models.py` — parses the airport and builds the taxi graph used in-sim |
+| [`ui/windows_manager.py`](../xplane_plugin/ui/windows_manager.py) | Session conductor — starts/stops sessions from `airport:session_request`, drains `tts:queue` |
+| [`communication/__init__.py`](../xplane_plugin/communication/__init__.py) | `speak()`: airline callword + NATO phonetic expansion, then `xp.speakString` |
+| [`services/aircraft_mover.py`](../xplane_plugin/services/aircraft_mover.py) | ≈690 lines — the motion engine, one `_PlanState` per aircraft |
+| [`services/aircraft_spawner.py`](../xplane_plugin/services/aircraft_spawner.py) | Places `.obj` scenery instances at a stand, or in the air for arrivals |
+| [`services/hmi_service.py`](../xplane_plugin/services/hmi_service.py) | HTTP client to the HMI (pushes the detected ICAO) — does not speak |
 
-Dependencies are installed into X-Plane's bundled Python via
-[`docs/install/install_dependencies.bat`](../docs/install/install_dependencies.bat) (wraps
-[`install_xppython3.ps1`](../docs/install/install_xppython3.ps1)).
+## Session lifecycle: from button to fleet
 
-## `xplane_plugin/` — plugin source (development tree)
+A session starts as a hash, not a request. The HMI's setup page `HSET`s `airport:session_request`
+with `status=pending` plus the chosen `icao` and `aircraft_count`, and `WindowManager`'s 2-second
+poll loop (`_poll_redis`) is the only thing watching that key — nothing else in the system can kick
+off a session. The moment it sees `pending` it flips `status` to `starting`, so a second poll a
+moment later can't run the sequence twice, then does the work on the X-Plane thread: load the
+airport (download and parse apt.dat, write the graph to `airport:current:*`), pull flight plans
+from the [Flight Plan service](services/flight_plan_service.md), let `StandAssigner` match each
+aircraft to a size- and type-compatible gate, spawn the parked fleet, and bring `AircraftTracker`
+and `AircraftMover` online. The last write flips `status` to `active` with the new `session_id` —
+the HMI's cue to stop showing the setup screen.
 
-| Path | Role |
-|---|---|
-| [`services/aircraft_mover.py`](../xplane_plugin/services/aircraft_mover.py) | Moves aircraft along the dispatched multi-leg plan (emits phase strings like `pushback`, `taxi_out`, `holding` — matches [`shared/models/phases.py`](../shared/models/phases.py)) |
-| [`services/aircraft_spawner.py`](../xplane_plugin/services/aircraft_spawner.py) | Spawns aircraft objects |
-| [`services/aircraft_obj_mapper.py`](../xplane_plugin/services/aircraft_obj_mapper.py) | Maps aircraft types → X-Plane objects |
-| [`services/airport_service.py`](../xplane_plugin/services/airport_service.py) | Airport data access in-sim |
-| [`services/flight_plan_service.py`](../xplane_plugin/services/flight_plan_service.py) | Talks to the [flight plan service](services/flight_plan_service.md) |
-| [`services/hmi_service.py`](../xplane_plugin/services/hmi_service.py) | Talks to the [HMI](services/controller_hmi_service.md); drives readback speech (X-Plane built-in TTS) |
-| [`services/user_service.py`](../xplane_plugin/services/user_service.py) | User/session helpers |
-| [`airport_plugin/PI_userInterface.py`](../xplane_plugin/airport_plugin/PI_userInterface.py) | In-sim UI plugin |
-| [`ui/windows_manager.py`](../xplane_plugin/ui/windows_manager.py) | Manages plugin windows |
-| `communication/`, `xplane_integration/`, `utils/`, `images/` | Support packages |
+```mermaid
+sequenceDiagram
+    autonumber
+    participant H as HMI setup page
+    participant R as Redis
+    participant WM as WindowManager
+    participant FP as Flight Plan service
+    participant SIM as Spawner + Tracker + Mover
+    H->>R: HSET airport:session_request status=pending
+    WM->>R: poll every 2 s
+    R-->>WM: status=pending, icao, aircraft_count
+    WM->>R: HSET status=starting
+    WM->>WM: load apt.dat, write airport:current:*
+    WM->>FP: generate_multiple(aircraft_count, icao)
+    FP-->>WM: flight plans
+    WM->>WM: StandAssigner picks compatible stands
+    WM->>SIM: spawn parked fleet
+    WM->>SIM: start tracker 2 Hz + mover
+    WM->>R: HSET status=active, session_id
+```
 
-There is a plugin-specific readme: [`xplane_plugin/PLUGIN_README.md`](../xplane_plugin/PLUGIN_README.md).
+Stopping runs the same hash backwards: the HMI sets `status=stop_pending`, the next poll tears the
+session down in order — mover, tracker, state store, spawner, then the `session:current` row — and
+deletes `airport:session_request` so a stale status never confuses the next read. Anything that
+fails partway (no `.dat` for the ICAO, the flight-plan service unreachable, no compatible stand
+left) writes `status=error` and stops there instead of leaving a half-built session.
 
-## How motion arrives
+## The polling loop
 
-The orchestrator's [taxi_router](shared.md) computes an A\* route and calls `dispatch_taxi_plan`,
-which pushes a multi-leg move plan (via Redis) that `aircraft_mover` consumes in-sim to move the
-aircraft and advance its phase. TTS readback is spoken through X-Plane's built-in speech.
+Three independent clocks drive the plugin, none risking a blocking call on X-Plane's render thread.
+`WindowManager`'s 2-second loop does double duty — the same tick that checks
+`airport:session_request` also `LPOP`s `tts:queue` until empty, so session control and speech share
+one Redis round trip. `AircraftMover` runs two loops of its own: a 1-second scan of
+`aircraft:*:move_cmd` and `aircraft:spawn_request:*` that picks up new plans, and a per-frame tick
+(scheduled at `interval=-1`, so every rendered frame) that integrates whatever plans are already
+running. State only leaves the mover through `_maybe_publish_state`, throttled to roughly one
+`HSET aircraft:state:{reg}` every 0.5 s no matter how fast frames arrive.
+
+```mermaid
+flowchart LR
+    WM[WindowManager] -- "LPOP tts:queue every 2 s" --> SPK[speak]
+    SPK --> TTS[xp.speakString]
+    MV[AircraftMover] -- "scan aircraft:*:move_cmd every 1 s" --> ING[ingest plan]
+    MV -- "HSET aircraft:state:{reg} ~every 0.5 s" --> RD[(Redis)]
+    MV -- "PUBLISH move_events" --> SUB[orchestrator / arrival sim]
+```
+
+Polling instead of subscribing is deliberate: a blocking socket callback has no place in a flight
+loop, and polling shrugs off either side restarting — kill the backend mid-taxi and the mover keeps
+flying the plan it already loaded; bring it back and the next scan resumes from whatever is in
+Redis. The one thing the plugin pushes unprompted is `aircraft:{reg}:move_events` — motion
+milestones are occasional enough that pub/sub costs nothing, and the orchestrator needs them
+immediately. `windows_manager.py` forces `REDIS_HOST=localhost` at import time for the reason this
+whole design exists: the plugin runs on the host, inside X-Plane, never inside Docker.
+
+## How an aircraft moves
+
+This is the motion state machine [architecture](architecture.md) promises — owned entirely here,
+never to be confused with the controller-phase state machine the orchestrator keeps in PostgreSQL.
+Move plans are versioned, multi-leg JSON: the taxi router's `dispatch_taxi_plan` (see
+[shared](shared.md)) writes a `version: 2` plan to `aircraft:{reg}:move_cmd` — a `plan_id`, an
+optional `delay_before_start_s`, and an ordered list of `legs`, each with its own `mode`:
+`pushback`, `waypoints`, `straight` (legacy, kept for the standalone `test_move_*.py` scripts),
+`approach`, `landing_roll`, `vacate`, `taxi_in`. `AircraftMover` keeps one `_PlanState` per
+registration and steps through the legs in order, and it owns the aircraft's position outright — no
+autopilot, no X-Plane flight model involved. Every frame it computes a bearing and a step distance
+with the same great-circle helpers the arrival simulator uses (`advance`, `bearing`, `haversine`,
+all in [`shared/services/geo.py`](../shared/services/geo.py)), then re-plants the aircraft with
+`xp.instanceSetPosition` (re-probing the terrain each frame so ground traffic never clips through
+hilly scenery). These are scenery **instances**, created once with `xp.createInstance` at spawn
+time — not X-Plane AI aircraft, not multiplayer slots. `AircraftSpawner` picks the `.obj` from
+aircraft type plus the airline prefix of the callsign, probes the terrain under a parked aircraft
+so it sits on the ground, and for an arrival spawned mid-air via `spawn_request` skips the probe and
+places it at the given MSL altitude with `on_ground=False` instead.
+
+`waiting` and `done` never leave this file: while a plan waits out its `delay_before_start_s` the
+phase it actually publishes is `parked`, and once the last leg finishes, `_finalise` swaps `done`
+for whatever real phase the aircraft was last in — `final_phase`, defaulting to `holding`, or
+`parked` once an arrival's `taxi_in` leg has stopped it at the stand — before the terminal `HSET`.
+Every other phase string matches [`shared/models/phases.py`](../shared/models/phases.py) exactly,
+because the HMI and the orchestrator both read it as ground truth.
+
+```mermaid
+stateDiagram-v2
+    [*] --> waiting
+    waiting --> pushback: plan_accepted
+    state pushback {
+        reverse --> pivot
+    }
+    pushback --> taxi_out: taxi_started
+    taxi_out --> done: reached_end
+    done --> [*]
+
+    [*] --> approach
+    note right of approach: request_landing at 4 NM final
+    approach --> landing_roll: touchdown
+    landing_roll --> vacating: rolling_out
+    vacating --> taxi_in
+    taxi_in --> parked: reached_end
+    parked --> [*]
+```
+
+Pushback is two sub-phases folded into one leg: `reverse` walks the aircraft tail-first along the
+parked heading plus 180°, for the leg's `distance_m`, then `pivot` holds position and rotates onto
+`final_heading_deg` — matching real ICAO pushback regardless of how the stand sits in the taxi
+graph. On the arrival side, `approach` re-bears toward the runway threshold every single frame (a
+true great-circle nav, not a straight line drawn once) and fires `request_landing` once inside
+`request_landing_at_nm` of the threshold — 4 NM, set by the
+[Arrival Simulator](services/arrival_simulator_service.md)'s planner — before `landing_roll` takes
+over on `touchdown`. A plan that loses its Redis key mid-flight, from any phase, ends the same way:
+`_finalise(..., event="cancelled")`.
+
+## Reading the airport: apt.dat
+
+Every session starts by turning a scenery file into a graph.
+[`plugins/GND/data_parser.py`](../plugins/GND/data_parser.py) — called from the plugin's
+`AirportService.load_airport_data` and, standalone, from the command line — reads the airport's
+`.dat` file and classifies each row by its apt.dat 1200-spec row code:
+
+| Row code | Data | Parsed into |
+|---|---|---|
+| `1201` | Taxi route nodes (lat/lon, usage, name) | `TaxiNode` |
+| `1202` | Taxi route edges (one-way/two-way, taxiway id) | `TaxiEdge` |
+| `1300` / `1301` | Stand position + heading, then stand metadata (ICAO width code, operation type) | `Stand` |
+| `100` | Runway ends, both thresholds | `Runway` |
+| `1050`-`1056` (legacy `50`-`56` fallback) | COM frequencies — ATIS, GND, TWR, APP, … | `ComFrequency` |
+
+The result is written to `{ICAO}_graph.json` and, through `AirportDataStore.store`, into Redis
+under `airport:current:*` (`nodes`, `edges`, `stands`, `runways`, `com_frequencies`, with stand
+occupancy tracked separately). [`plugins/GND/graph.py`](../plugins/GND/graph.py)'s `AirportGraph`
+loads that same shape — from the JSON file standalone, or from the Redis dict in the backend — into
+a `networkx.DiGraph` with haversine-metre edge weights, then indexes nodes by taxiway letter and
+stand id so a controller-spoken token resolves to a node: `resolve_point` tries runway designator,
+then taxiway letter, then stand id, then node name, in that order. `find_route_via` runs A\* leg by
+leg between the via-points in the order the controller named them, so a route "via Bravo, Delta" can
+never backtrack once it has already passed Bravo. It's consumed on both sides of the Redis boundary
+— in-sim by this plugin, and by the backend taxi router for the exact same graph (see
+[shared](shared.md)).
+
+## Superseded prototypes
+
+Two older trees still carry real code but sit outside the active pipeline, kept for history and not
+wired into `docker-compose.yml`. Root-level [`transcription/`](../transcription/) was an earlier
+standalone Whisper transcription service — its own Dockerfile, the same callsign-correction and
+phonetics ideas — superseded by [`services/asr_service`](services/asr_service.md).
+[`services/pilots_communication/`](../services/pilots_communication/) was an earlier ASR-plus-forward
+prototype: a `/process` endpoint that transcribed audio and forwarded it straight to a DEL/GND/TWR
+agent, before the orchestrator existed to sit in between.
 
 ## Related
-[index](index.md) · [architecture](architecture.md) · [shared](shared.md) · [orchestrator](services/orchestrator_service.md)
+[architecture](architecture.md) · [shared](shared.md) · [arrival simulator](services/arrival_simulator_service.md) · [X-Plane Plugin Setup](guides/xplane-plugin-setup.md) · [index](index.md)


### PR DESCRIPTION
Closes #44.

## What

- All 12 `openwiki/` reference pages rewritten in English with a narrative "how it works" style and **22 Mermaid diagrams** (sequence diagrams, state machines, flowcharts).
- `openwiki/architecture.md` is the new hub: the end-to-end voice→motion sequence, the Redis boundary (key polling vs pub/sub, with cadences on every edge), the full Redis key contract, the two state machines, service topology, and the three data stores.
- Per-component depth: orchestrator (`/dispatch` decision flow, controller-phase state machine APP/DEL/GND/TWR, debrief assembly), xplane (session lifecycle, polling loop, motion state machine, apt.dat parsing), shared (taxi-router pipeline: readback → parsers → A\* → `move_cmd`), ASR (correction pipeline as wired today), agents, HMI, arrival simulator, flight plan, weather, data-and-testing.

## Accuracy fixes over the old wiki

- TTS is driven by the plugin's `windows_manager` draining `tts:queue` — not `hmi_service`.
- The plugin **polls** Redis keys for commands; pub/sub flows outbound only (`move_events`, `hmi:chat`).
- Two distinct state machines (controller phase in Postgres vs motion in the mover) — previously conflated into one list.
- The pilot agents define `tools=[]` and are invoked via plain HTTP POST (no A2A protocol).
- ASR: the LLM entity-mapping step (`llm_map_entities`) is wired but **dormant in production** — the browser never sends session context, so real PTT traffic runs only the deterministic stages. Documented explicitly.
- Real ATIS table name is `atis_broadcasts`; TWR's `clearance_type` never reaches the HTTP response; `ARRIVAL_INTERVAL_S` is dead config; the new `benchmark_asr.py` and `judge_*` evaluation scripts are documented.

## Notes for merging

- Includes two small guide updates (`cloud-agents-deployment`, `configuration`) reflecting the `GEMINI_MODEL` default `gemini-3.1-flash-lite`. The corresponding `docker-compose.yml` / `.env.example` migration is still uncommitted in the working tree — land it on `main` alongside or before this PR so docs and code agree.
- Page filenames are unchanged, so `scripts/build_wiki.py` mapping stays intact. Verified locally: 21 wiki pages + `_Sidebar.md` build cleanly and no Mermaid fence gets mangled by the link rewriter.
- After merging: run the manual **Publish Wiki** workflow to sync the GitHub Wiki.
