### PR TITLE
fix(security): restrict CORS to a configurable origin allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,3 +128,4 @@ ASR_WORKERS=1
 # LOG_LEVEL=info
 # AGENT_MODEL=gemini-3.1-flash-lite   # Cloud Run agents; compose derives it from GEMINI_MODEL
 # DEBRIEF_MODEL=gemini-3.1-flash-lite # orchestrator debrief agent (falls back to AGENT_MODEL)
+# CORS_ORIGINS=http://localhost:8005  # comma-separated allowed origins; defaults to the local HMI origin

--- a/services/arrival_simulator_service/main.py
+++ b/services/arrival_simulator_service/main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -28,9 +29,11 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+_cors_origins = [o.strip() for o in os.environ.get("CORS_ORIGINS", "http://localhost:8005").split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/asr_service/main.py
+++ b/services/asr_service/main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -33,9 +34,11 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+_cors_origins = [o.strip() for o in os.environ.get("CORS_ORIGINS", "http://localhost:8005").split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/controller_hmi_service/main.py
+++ b/services/controller_hmi_service/main.py
@@ -38,9 +38,11 @@ app = FastAPI(
     redoc_url="/redoc",
 )
 
+_cors_origins = [o.strip() for o in os.environ.get("CORS_ORIGINS", "http://localhost:8005").split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/flight_plan_service/main.py
+++ b/services/flight_plan_service/main.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -43,9 +44,11 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+_cors_origins = [o.strip() for o in os.environ.get("CORS_ORIGINS", "http://localhost:8005").split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/orchestrator_service/main.py
+++ b/services/orchestrator_service/main.py
@@ -37,9 +37,11 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+_cors_origins = [o.strip() for o in os.environ.get("CORS_ORIGINS", "http://localhost:8005").split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/weather_service/main.py
+++ b/services/weather_service/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -16,9 +18,11 @@ app = FastAPI(
     redoc_url="/redoc",
 )
 
+_cors_origins = [o.strip() for o in os.environ.get("CORS_ORIGINS", "http://localhost:8005").split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/tests/unit/test_cors_config.py
+++ b/tests/unit/test_cors_config.py
@@ -1,0 +1,72 @@
+"""Regression test for issue #61: no service may pair a wildcard CORS origin
+with allow_credentials=True (invalid per the CORS spec, and Starlette's
+workaround for it lets any origin call the API with credentials).
+
+This scans each service's main.py source rather than importing the modules
+directly: weather_service and flight_plan_service run live DB calls
+(Base.metadata.create_all, a raw ALTER TABLE check) at import time, not in
+their FastAPI lifespan, so importing them requires a real Postgres
+connection that isn't available in the unit test environment.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+SERVICE_MAIN_FILES = [
+    _REPO_ROOT / "services" / "orchestrator_service" / "main.py",
+    _REPO_ROOT / "services" / "controller_hmi_service" / "main.py",
+    _REPO_ROOT / "services" / "asr_service" / "main.py",
+    _REPO_ROOT / "services" / "weather_service" / "main.py",
+    _REPO_ROOT / "services" / "flight_plan_service" / "main.py",
+    _REPO_ROOT / "services" / "arrival_simulator_service" / "main.py",
+]
+
+
+def _find_cors_middleware_call(tree: ast.Module) -> ast.Call | None:
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_middleware"
+            and node.args
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == "CORSMiddleware"
+        ):
+            return node
+    return None
+
+
+def _keyword_value(call: ast.Call, name: str):
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+@pytest.mark.parametrize("main_py", SERVICE_MAIN_FILES, ids=lambda p: p.parent.name)
+def test_no_wildcard_origin_with_credentials(main_py: Path):
+    assert main_py.exists(), f"expected service entrypoint at {main_py}"
+    tree = ast.parse(main_py.read_text(encoding="utf-8"), filename=str(main_py))
+
+    call = _find_cors_middleware_call(tree)
+    assert call is not None, f"{main_py} does not configure CORSMiddleware"
+
+    allow_origins = _keyword_value(call, "allow_origins")
+    assert allow_origins is not None, f"{main_py}: CORSMiddleware missing allow_origins"
+
+    is_wildcard_literal = (
+        isinstance(allow_origins, ast.List)
+        and len(allow_origins.elts) == 1
+        and isinstance(allow_origins.elts[0], ast.Constant)
+        and allow_origins.elts[0].value == "*"
+    )
+    assert not is_wildcard_literal, (
+        f"{main_py}: allow_origins is hardcoded to ['*'] combined with allow_credentials — "
+        "must come from config (e.g. the CORS_ORIGINS env var)"
+    )


### PR DESCRIPTION
## Summary
- Every service (`orchestrator_service`, `controller_hmi_service`, `asr_service`, `weather_service`, `flight_plan_service`, `arrival_simulator_service`) paired `allow_origins=["*"]` with `allow_credentials=True`, which is invalid per the CORS spec — Starlette works around it by echoing back whatever `Origin` header the browser sends, so any site open in a browser could call these local APIs with credentials.
- Origins are now read from a new `CORS_ORIGINS` env var (comma-separated), defaulting to the local HMI origin (`http://localhost:8005`).
- Documented the new var in `.env.example`.
- Added `tests/unit/test_cors_config.py`, a static AST-based regression test asserting no service hardcodes `allow_origins=["*"]` alongside credentials.

Closes #61

## Test plan
- [x] `pytest tests/unit/test_cors_config.py` passes (6/6)
- [x] Full `pytest tests/unit` suite passes (179 passed, 2 pre-existing xfails unrelated to this change)
- [x] `grep -rn 'allow_origins=\["\*"\]' services/` returns no matches
- [ ] Manual smoke test: HMI (`http://localhost:8005`) still reaches orchestrator/asr/weather/flight-plan/arrival-simulator through docker-compose