### PR TITLE
Phase 0 (#59): recreate lost HMI HTML entry points and pin the DOM contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,10 +215,13 @@ __marimo__/
 # proyect
 
 *.html
+!services/controller_hmi_service/static/**/*.html
+!services/controller_hmi_service/frontend/*.html
 .env
 *.dat
 *.json
 !openwiki/.last-update.json
+!services/controller_hmi_service/frontend/**/*.json
 *.iso
 
 # custom

--- a/services/controller_hmi_service/static/index.html
+++ b/services/controller_hmi_service/static/index.html
@@ -1,0 +1,406 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AIrport TWR — Controller HMI</title>
+    <link rel="stylesheet" href="css/efs.css">
+    <link rel="stylesheet" href="css/debrief.css">
+</head>
+<body>
+
+    <!-- ================= Header ================= -->
+    <header id="header">
+        <div class="header-left">
+            <h1>AIrport TWR</h1>
+            <span id="airport-badge" class="badge airport-badge">----</span>
+        </div>
+        <div class="header-right">
+            <div id="stopwatch-widget" title="Stopwatch">
+                <span class="sw-dot"></span>
+                <span class="sw-display" id="sw-display">00:00</span>
+                <button class="sw-btn" id="sw-toggle" title="Start / stop">&#9654;</button>
+                <button class="sw-btn" id="sw-reset" title="Reset">&#8634;</button>
+            </div>
+            <span id="utc-clock" class="clock">--:--:--Z</span>
+            <button id="atis-btn" onclick="AtisModal.open()">ATIS</button>
+            <button id="end-session-btn">END SESSION</button>
+        </div>
+    </header>
+
+    <!-- ================= Main layout ================= -->
+    <div id="twr-layout">
+
+        <!-- ---- Left panel: dashboard + strips + wind ---- -->
+        <div id="left-panel">
+
+            <div id="dashboard-superior">
+                <div id="dash-pressure" class="dash-block">
+                    <div class="dash-pressure-item">
+                        <label>QNH</label>
+                        <span id="qnh-value" class="pressure-value">----</span>
+                        <span class="pressure-unit">hPa</span>
+                    </div>
+                    <div class="dash-pressure-item">
+                        <label>QFE</label>
+                        <span id="qfe-value" class="pressure-value">----</span>
+                        <span class="pressure-unit">hPa</span>
+                    </div>
+                    <span class="elev-badge">ELEV 1211 FT</span>
+                </div>
+
+                <div id="dash-metar" class="dash-block">
+                    <div class="dash-metar-header">
+                        <span class="dash-label">METAR</span>
+                        <span id="wx-flight-cat" class="flight-cat-badge">--</span>
+                    </div>
+                    <span id="wx-raw-metar" class="raw-metar-mini">--</span>
+                    <div class="dash-metar-icons">
+                        <div class="metar-icon-item" title="Clouds">
+                            <svg class="metar-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.5 19a4.5 4.5 0 100-9 6 6 0 10-11.6 2A4 4 0 007 19h10.5z"/></svg>
+                            <span id="metar-clouds-text" class="metar-icon-label">--</span>
+                        </div>
+                        <div class="metar-icon-item" title="Visibility">
+                            <svg class="metar-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+                            <span id="metar-vis-text" class="metar-icon-label">--</span>
+                            <div class="vis-bar-container"><div id="metar-vis-bar" class="vis-bar-fill"></div></div>
+                        </div>
+                        <div class="metar-icon-item" title="Wind">
+                            <svg class="metar-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9.6 4.6A2 2 0 1111 8H2m10.6 11.4A2 2 0 1014 16H2m15.7-8.3A2.5 2.5 0 1119.5 12H2"/></svg>
+                            <span id="metar-wind-text" class="metar-icon-label">--</span>
+                        </div>
+                        <div class="metar-icon-item" title="Weather">
+                            <svg class="metar-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 13v8m-8-8v8m4-6v8m8-13a4.5 4.5 0 00-4-6.5 6 6 0 00-11.6 2A4 4 0 005 13h15z"/></svg>
+                            <span id="metar-wx-text" class="metar-icon-label">NIL</span>
+                        </div>
+                        <div class="metar-icon-item" title="Temperature / Dewpoint">
+                            <svg class="metar-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 14.76V3.5a2.5 2.5 0 00-5 0v11.26a4.5 4.5 0 105 0z"/></svg>
+                            <span id="metar-temp-text" class="metar-icon-label">--/--</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="dash-taf" class="dash-block">
+                    <div class="dash-taf-header">
+                        <span class="dash-label">TAF</span>
+                        <span id="taf-validity" class="taf-validity-badge">--</span>
+                    </div>
+                    <span id="wx-raw-taf" class="raw-metar-mini">--</span>
+                    <div id="wx-decoded-taf" class="taf-mini-content"></div>
+                </div>
+            </div>
+
+            <div id="rh-dash" class="resize-handle resize-handle--horizontal"></div>
+
+            <div id="strips-columns">
+                <div class="strip-column">
+                    <div class="strip-col-header pretaxi-header">
+                        <span class="col-title">Pre-Taxi</span>
+                        <span class="col-desc">Clearance / Pushback</span>
+                        <span id="count-pretaxi" class="col-count">0</span>
+                    </div>
+                    <div id="strips-pretaxi" class="strip-col-body"></div>
+                </div>
+                <div class="strip-column">
+                    <div class="strip-col-header taxi-header">
+                        <span class="col-title">Taxi</span>
+                        <span class="col-desc">Moving to RWY</span>
+                        <span id="count-taxi" class="col-count">0</span>
+                    </div>
+                    <div id="strips-taxi" class="strip-col-body"></div>
+                </div>
+                <div class="strip-column">
+                    <div class="strip-col-header runway-header">
+                        <span class="col-title">Runway</span>
+                        <span class="col-desc">Line-up / Cleared</span>
+                        <span id="count-runway" class="col-count">0</span>
+                    </div>
+                    <div id="strips-runway" class="strip-col-body"></div>
+                </div>
+                <div class="strip-column">
+                    <div class="strip-col-header arrivals-header">
+                        <span class="col-title">Arrivals</span>
+                        <span class="col-desc">Approach / Landed</span>
+                        <span id="count-arrivals" class="col-count">0</span>
+                    </div>
+                    <div id="strips-arrivals" class="strip-col-body"></div>
+                </div>
+            </div>
+
+            <div id="rh-wind" class="resize-handle resize-handle--horizontal"></div>
+
+            <div id="bottom-bar">
+                <div id="wind-safety-widget">
+                    <div class="wind-widget-header">
+                        <span class="module-title">Wind &amp; Safety</span>
+                    </div>
+                    <div id="wind-pairs-container" class="wind-pairs-container"></div>
+                </div>
+                <div id="rwy-sequence-panel">
+                    <div class="rwy-seq-header">
+                        <span class="module-title">Runway Sequence</span>
+                    </div>
+                    <div class="rwy-seq-body">
+                        <div class="rwy-seq-section">
+                            <div class="rwy-seq-section-title arr-title">ARRIVALS</div>
+                            <div id="rwy-seq-arrivals" class="rwy-seq-list"></div>
+                        </div>
+                        <div class="rwy-seq-section">
+                            <div class="rwy-seq-section-title dep-title">DEPARTURES</div>
+                            <div id="rwy-seq-departures" class="rwy-seq-list"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="rh-lr" class="resize-handle resize-handle--vertical"></div>
+
+        <!-- ---- Right panel: SMR + lighting + comms ---- -->
+        <div id="right-panel">
+
+            <div id="smr-panel">
+                <div class="smr-header">
+                    <span id="smr-airport" class="smr-airport-label">----</span>
+                    <div id="lvp-indicator" class="lvp-indicator lvp-off" title="Low Visibility Procedures">
+                        <span class="lvp-light"></span>
+                        <span class="lvp-label">LVP</span>
+                    </div>
+                </div>
+                <div id="smr-map" class="smr-map-container"></div>
+                <div id="rimcas-alert" class="rimcas-alert hidden">RIMCAS &mdash; RUNWAY INCURSION</div>
+            </div>
+
+            <div id="lighting-panel">
+                <div class="lighting-header">
+                    <span class="module-title">Lighting</span>
+                </div>
+                <div class="lighting-controls">
+                    <div class="lighting-row">
+                        <label>PAPI</label>
+                        <div class="papi-slider-container">
+                            <input id="papi-slider" class="papi-slider" type="range" min="1" max="5" value="3">
+                            <span id="papi-value" class="papi-value">3</span>
+                        </div>
+                    </div>
+                    <div class="lighting-row">
+                        <label>STOPBAR</label>
+                        <button id="stopbar-btn" class="stopbar-btn stopbar-on">ON</button>
+                    </div>
+                    <div class="lighting-row">
+                        <label>RWY LIGHTS</label>
+                        <button id="rwy-lights-btn" class="stopbar-btn stopbar-on">ON</button>
+                    </div>
+                    <div class="lighting-row">
+                        <label>APPROACH</label>
+                        <button id="approach-lights-btn" class="stopbar-btn stopbar-off">OFF</button>
+                    </div>
+                </div>
+            </div>
+
+            <div id="rh-comms" class="resize-handle resize-handle--horizontal"></div>
+
+            <div id="comms-panel">
+                <div class="comms-header">
+                    <span class="module-title">Comms</span>
+                    <div class="ptt-controls">
+                        <span id="ptt-led" class="ptt-led ptt-idle"></span>
+                        <span id="ptt-state-label" class="ptt-state-label ptt-label-idle">IDLE</span>
+                        <span id="ptt-key-badge" class="ptt-key-badge">Space</span>
+                        <button id="comms-gear-btn" class="comms-gear-btn" title="Audio settings" onclick="Ptt.toggleConfig()">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 11-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 11-4 0v-.09a1.65 1.65 0 00-1-1.51 1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 11-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 110-4h.09a1.65 1.65 0 001.51-1 1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 112.83-2.83l.06.06a1.65 1.65 0 001.82.33h.01a1.65 1.65 0 001-1.51V3a2 2 0 114 0v.09a1.65 1.65 0 001 1.51h.01a1.65 1.65 0 001.82-.33l.06-.06a2 2 0 112.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82v.01a1.65 1.65 0 001.51 1H21a2 2 0 110 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+                        </button>
+                    </div>
+                </div>
+
+                <div id="chat-filter-bar">
+                    <button class="chat-filter-btn active" data-filter="all">ALL</button>
+                    <button class="chat-filter-btn" data-filter="DEL">DEL<span class="chat-filter-freq">121.805</span></button>
+                    <button class="chat-filter-btn" data-filter="GND">GND<span class="chat-filter-freq">121.700</span></button>
+                    <button class="chat-filter-btn" data-filter="TWR">TWR<span class="chat-filter-freq">118.100</span></button>
+                </div>
+
+                <div id="chat-log"></div>
+
+                <div id="comms-config" class="hidden">
+                    <div class="cc-field">
+                        <span class="cc-label">Microphone</span>
+                        <select id="cc-mic" class="cc-select"></select>
+                    </div>
+                    <div class="cc-field">
+                        <span class="cc-label">Output</span>
+                        <select id="cc-out" class="cc-select"></select>
+                    </div>
+                    <div class="cc-field">
+                        <span class="cc-label">PTT Key</span>
+                        <div class="cc-ptt-row">
+                            <span id="cc-ptt-key" class="cc-ptt-badge">Space</span>
+                            <button class="cc-btn-capture" onclick="Ptt.capturePttKey()">CAPTURE</button>
+                        </div>
+                    </div>
+                    <div class="cc-actions">
+                        <button class="cc-btn-save" onclick="Ptt.saveQuickConfig()">SAVE</button>
+                        <button class="cc-btn-cancel" onclick="Ptt.toggleConfig()">CANCEL</button>
+                    </div>
+                </div>
+
+                <div id="ptt-status-bar">
+                    <span id="ptt-status-text">Presiona PTT para transmitir...</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- ================= Status bar ================= -->
+    <div id="status-bar">
+        <span id="last-refresh">Last refresh: --:--:--Z</span>
+        <span id="connection-status" class="status-indicator disconnected">CONNECTING</span>
+    </div>
+
+    <!-- ================= ATIS modal ================= -->
+    <div id="atis-overlay" class="atis-overlay" onclick="AtisModal.onOverlayClick(event)">
+        <div class="atis-modal">
+            <div class="atis-modal-header">
+                <span class="atis-modal-title">ATIS</span>
+                <button class="atis-close-btn" onclick="AtisModal.close()">&#10005;</button>
+            </div>
+            <div class="atis-modal-body">
+                <div class="atis-col-left">
+                    <div class="atis-row">
+                        <span class="atis-label-inline">Information</span>
+                        <input id="atis-letter-field" class="atis-input-short" readonly>
+                        <span class="atis-label-inline">Station</span>
+                        <input id="atis-metar-station" class="atis-input-rwy" placeholder="ICAO">
+                    </div>
+                    <div class="atis-section-bar">RUNWAYS IN USE</div>
+                    <div class="atis-row atis-rwy-row">
+                        <svg class="atis-plane-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M21 16v-2l-8-5V3.5a1.5 1.5 0 00-3 0V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5l8 2.5z"/></svg>
+                        <span class="atis-rwy-label">Arrival</span>
+                        <input id="atis-arrival-rwy" class="atis-input-rwy" placeholder="--">
+                    </div>
+                    <div class="atis-row atis-rwy-row">
+                        <svg class="atis-plane-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M21 16v-2l-8-5V3.5a1.5 1.5 0 00-3 0V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5l8 2.5z"/></svg>
+                        <span class="atis-rwy-label">Departure</span>
+                        <input id="atis-dep-rwy" class="atis-input-rwy" placeholder="--">
+                    </div>
+                    <div class="atis-section-bar">TRANSITION</div>
+                    <div class="atis-row atis-transition-row">
+                        <label class="atis-checkbox-label">
+                            <input id="atis-tl-chk" type="checkbox" checked> TL
+                        </label>
+                        <div class="atis-fl-row">
+                            <span class="atis-fl-prefix">FL</span>
+                            <input id="atis-fl-val" class="atis-input-fl" readonly>
+                        </div>
+                        <label class="atis-checkbox-label">
+                            <input id="atis-ta-chk" type="checkbox" checked> TA
+                        </label>
+                        <div class="atis-fl-row">
+                            <input id="atis-alt-val" class="atis-input-fl" readonly>
+                            <span class="atis-fl-suffix">ft</span>
+                        </div>
+                    </div>
+                    <div class="atis-row atis-row-qfe">
+                        <span class="atis-label-inline">QFE</span>
+                        <input id="atis-qfe" class="atis-input-short" placeholder="--">
+                        <span class="atis-label-inline">ATC Position</span>
+                        <input id="atis-atc-pos" class="atis-input-full" placeholder="e.g. Santiago Tower">
+                    </div>
+                    <div class="atis-section-bar">BROADCAST TEXT</div>
+                    <textarea id="atis-text-output" class="atis-text-output" readonly></textarea>
+                </div>
+                <div class="atis-col-right">
+                    <span class="atis-remarks-label">Remarks</span>
+                    <textarea id="atis-remarks" class="atis-remarks-area" placeholder="RMK..."></textarea>
+                    <label class="atis-checkbox-label">
+                        <input id="atis-active-chk" type="checkbox" checked> ATIS active
+                    </label>
+                </div>
+            </div>
+            <div class="atis-modal-footer">
+                <button class="atis-btn-cancel" onclick="AtisModal.close()">CANCEL</button>
+                <button class="atis-btn-send" onclick="AtisModal.send()">SEND</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- ================= Debrief modal ================= -->
+    <div id="debrief-modal" class="debrief-hidden">
+        <div class="debrief-card">
+            <div class="debrief-header">
+                <h2>Instructor Debrief</h2>
+                <button id="debrief-close">&#10005;</button>
+            </div>
+            <div id="debrief-body" class="debrief-body"></div>
+        </div>
+    </div>
+
+    <!-- Runtime config generated by main.py (window.HMI_CONFIG) -->
+    <script src="config.js"></script>
+    <script src="js/weather.js"></script>
+    <script src="js/wind.js"></script>
+    <script src="js/efs.js"></script>
+    <script src="js/resize.js"></script>
+    <script src="js/atis.js"></script>
+    <script src="js/debrief.js"></script>
+    <script src="js/ptt.js"></script>
+    <script src="js/chat.js"></script>
+    <script src="js/app.js"></script>
+
+    <!-- Header widgets (stopwatch + end-session). Kept inline until the
+         TypeScript migration moves them into their own module. -->
+    <script>
+        (function () {
+            'use strict';
+
+            // --- Stopwatch ---
+            var swSeconds = 0;
+            var swTimer = null;
+            var swDisplay = document.getElementById('sw-display');
+            var swWidget = document.getElementById('stopwatch-widget');
+            var swDot = swWidget.querySelector('.sw-dot');
+
+            function swRender() {
+                var m = String(Math.floor(swSeconds / 60)).padStart(2, '0');
+                var s = String(swSeconds % 60).padStart(2, '0');
+                swDisplay.textContent = m + ':' + s;
+            }
+
+            document.getElementById('sw-toggle').addEventListener('click', function () {
+                if (swTimer) {
+                    clearInterval(swTimer);
+                    swTimer = null;
+                    swWidget.classList.remove('sw-active');
+                    swDot.classList.remove('sw-running');
+                    this.innerHTML = '&#9654;';
+                } else {
+                    swTimer = setInterval(function () { swSeconds++; swRender(); }, 1000);
+                    swWidget.classList.add('sw-active');
+                    swDot.classList.add('sw-running');
+                    this.innerHTML = '&#10074;&#10074;';
+                }
+            });
+
+            document.getElementById('sw-reset').addEventListener('click', function () {
+                swSeconds = 0;
+                swRender();
+            });
+
+            // --- End session: stop backend session, then instructor debrief ---
+            document.getElementById('end-session-btn').addEventListener('click', function () {
+                var btn = this;
+                btn.disabled = true;
+                fetch('/api/v1/plugin/session/stop', { method: 'POST' })
+                    .catch(function () { /* stop is best-effort */ })
+                    .then(function () {
+                        var icao = document.getElementById('airport-badge').textContent.trim();
+                        return Debrief.openAndGenerate(Ptt.getSessionId(), icao === '----' ? '' : icao);
+                    })
+                    .then(function () { return Debrief.waitClose(); })
+                    .then(function () { window.location.href = '/setup'; })
+                    .catch(function () { btn.disabled = false; });
+            });
+        })();
+    </script>
+</body>
+</html>

--- a/services/controller_hmi_service/static/js/chat.js
+++ b/services/controller_hmi_service/static/js/chat.js
@@ -1,0 +1,63 @@
+// chat.js -- Receive-only WebSocket client for the controller chat panel.
+//
+// The backend (api/chat.py) subscribes to the Redis `hmi:chat` Pub/Sub
+// channel and fans every payload out over this WebSocket. Payload shape
+// (shared/services/taxi_router/hmi_chat.py):
+//   { ts, session_id, sender: "pilot", callsign, registration, kind, text }
+// Anything sent by the client is discarded server-side, so this module
+// only listens and renders each line through Ptt.addAgentMessage().
+
+(function () {
+    'use strict';
+
+    var RECONNECT_MIN_MS = 1000;
+    var RECONNECT_MAX_MS = 15000;
+
+    var _reconnectMs = RECONNECT_MIN_MS;
+
+    function _wsUrl() {
+        var proto = location.protocol === 'https:' ? 'wss' : 'ws';
+        return proto + '://' + location.host + '/api/v1/plugin/chat/stream';
+    }
+
+    function _onMessage(event) {
+        var payload;
+        try {
+            payload = JSON.parse(event.data);
+        } catch (_) {
+            return; // ignore malformed payloads
+        }
+        if (!payload || typeof payload.text !== 'string' || !payload.text) return;
+
+        var callsign = payload.callsign || payload.sender || 'PILOT';
+        if (typeof Ptt !== 'undefined' && Ptt.addAgentMessage) {
+            Ptt.addAgentMessage(String(callsign), payload.text);
+        }
+    }
+
+    function _connect() {
+        var ws;
+        try {
+            ws = new WebSocket(_wsUrl());
+        } catch (_) {
+            _scheduleReconnect();
+            return;
+        }
+
+        ws.onopen = function () {
+            _reconnectMs = RECONNECT_MIN_MS;
+        };
+        ws.onmessage = _onMessage;
+        ws.onclose = _scheduleReconnect;
+        ws.onerror = function () {
+            ws.close();
+        };
+    }
+
+    function _scheduleReconnect() {
+        setTimeout(_connect, _reconnectMs);
+        _reconnectMs = Math.min(_reconnectMs * 2, RECONNECT_MAX_MS);
+    }
+
+    document.addEventListener('DOMContentLoaded', _connect);
+})();

--- a/services/controller_hmi_service/static/setup.html
+++ b/services/controller_hmi_service/static/setup.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AIrport TWR — Session Setup</title>
+    <link rel="stylesheet" href="css/setup.css">
+    <link rel="stylesheet" href="css/asr.css">
+</head>
+<body>
+
+    <canvas id="radar-bg"></canvas>
+
+    <div id="app">
+
+        <!-- ================= Welcome ================= -->
+        <section id="screen-welcome" class="screen active">
+            <div class="card">
+                <div class="card-header">
+                    <div>
+                        <div class="card-title">AIrport TWR</div>
+                        <div class="card-subtitle">Controller Workstation</div>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div class="airport-block">
+                        <span id="welcome-icao" class="icao-display">----</span>
+                        <div class="airport-meta">
+                            <span id="welcome-airport-name" class="airport-name">No airport detected</span>
+                            <div class="status-row">
+                                <span id="welcome-status-dot" class="status-dot"></span>
+                                <span id="welcome-status-text" class="status-text">Waiting for X-Plane...</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="btn-group">
+                        <button class="btn btn-primary" onclick="App.showLogin()">Login</button>
+                        <button class="btn btn-secondary" onclick="App.showRegister()">Register</button>
+                    </div>
+                    <div class="footer-text">ATC Simulation Environment</div>
+                </div>
+            </div>
+        </section>
+
+        <!-- ================= Login ================= -->
+        <section id="screen-login" class="screen">
+            <div class="card">
+                <div class="card-header">
+                    <button class="btn-back" onclick="App.showWelcome()">&#8249;</button>
+                    <div>
+                        <div class="card-title">Login</div>
+                        <div class="card-subtitle">Controller Access</div>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <form id="login-form" onsubmit="App.submitLogin(event)">
+                        <div class="card-body" style="padding:0">
+                            <div class="field">
+                                <label class="label" for="login-username">Username</label>
+                                <input id="login-username" class="input" type="text" autocomplete="username" required>
+                            </div>
+                            <div class="field">
+                                <label class="label" for="login-password">Password</label>
+                                <input id="login-password" class="input" type="password" autocomplete="current-password" required>
+                            </div>
+                            <div id="login-error" class="error-msg hidden"></div>
+                            <button id="login-btn" class="btn btn-primary" type="submit" data-label="Login">Login</button>
+                            <div class="link-row">No account? <a class="link" onclick="App.showRegister()">Register</a></div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </section>
+
+        <!-- ================= Register ================= -->
+        <section id="screen-register" class="screen">
+            <div class="card">
+                <div class="card-header">
+                    <button class="btn-back" onclick="App.showWelcome()">&#8249;</button>
+                    <div>
+                        <div class="card-title">Register</div>
+                        <div class="card-subtitle">New Controller</div>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <form id="register-form" onsubmit="App.submitRegister(event)">
+                        <div class="card-body" style="padding:0">
+                            <div class="field">
+                                <label class="label" for="register-username">Username</label>
+                                <input id="register-username" class="input" type="text" autocomplete="username" required>
+                            </div>
+                            <div class="field">
+                                <label class="label" for="register-password">Password</label>
+                                <input id="register-password" class="input" type="password" autocomplete="new-password" required>
+                            </div>
+                            <div class="field">
+                                <label class="label" for="register-confirm">Confirm password</label>
+                                <input id="register-confirm" class="input" type="password" autocomplete="new-password" required>
+                            </div>
+                            <div id="register-error" class="error-msg hidden"></div>
+                            <button id="register-btn" class="btn btn-primary" type="submit" data-label="Register">Register</button>
+                            <div class="link-row">Already registered? <a class="link" onclick="App.showLogin()">Login</a></div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </section>
+
+        <!-- ================= Session setup ================= -->
+        <section id="screen-session" class="screen">
+            <div class="card">
+                <div class="card-header">
+                    <button class="btn-back" onclick="App.showWelcome()">&#8249;</button>
+                    <div>
+                        <div class="card-title">Session Setup</div>
+                        <div class="card-subtitle">Airport <span id="session-icao-label">----</span></div>
+                    </div>
+                    <button class="btn-gear" title="ASR settings" onclick="App.showAsr()">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 11-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 11-4 0v-.09a1.65 1.65 0 00-1-1.51 1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 11-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 110-4h.09a1.65 1.65 0 001.51-1 1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 112.83-2.83l.06.06a1.65 1.65 0 001.82.33h.01a1.65 1.65 0 001-1.51V3a2 2 0 114 0v.09a1.65 1.65 0 001 1.51h.01a1.65 1.65 0 001.82-.33l.06-.06a2 2 0 112.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82v.01a1.65 1.65 0 001.51 1H21a2 2 0 110 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+                    </button>
+                </div>
+                <div class="card-body">
+                    <div class="field">
+                        <label class="label" for="session-type">Session type</label>
+                        <select id="session-type" class="input">
+                            <option value="departures">Departures</option>
+                            <option value="arrivals">Arrivals</option>
+                            <option value="mixed">Mixed</option>
+                        </select>
+                    </div>
+                    <div class="field">
+                        <label class="label" for="session-weather">Weather</label>
+                        <select id="session-weather" class="input">
+                            <option value="real">Real weather</option>
+                            <option value="clear">Clear</option>
+                            <option value="stormy">Stormy</option>
+                        </select>
+                    </div>
+                    <div class="field">
+                        <label class="label" for="session-aircraft">Aircraft count</label>
+                        <input id="session-aircraft" class="input" type="number" min="1" max="50" value="5">
+                    </div>
+                    <div class="field">
+                        <label class="label" for="session-complexity">Complexity</label>
+                        <select id="session-complexity" class="input">
+                            <option value="low">Low</option>
+                            <option value="medium" selected>Medium</option>
+                            <option value="high">High</option>
+                        </select>
+                    </div>
+                    <div id="session-error" class="error-msg hidden"></div>
+                    <button id="start-btn" class="btn btn-success" data-label="Start Session" onclick="App.submitStartSession()">Start Session</button>
+                </div>
+            </div>
+        </section>
+
+        <!-- ================= ASR settings ================= -->
+        <section id="screen-asr" class="screen">
+            <div class="card card-wide">
+                <div class="card-header">
+                    <button class="btn-back" onclick="Asr.teardown(); App.showSession()">&#8249;</button>
+                    <div>
+                        <div class="card-title">ASR Settings</div>
+                        <div class="card-subtitle">Speech Recognition</div>
+                    </div>
+                </div>
+                <div class="card-body asr-body">
+                    <div class="asr-top-grid">
+                        <div class="asr-card">
+                            <div class="asr-card-header">
+                                <svg class="asr-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2M12 19v4M8 23h8"/></svg>
+                                <span class="asr-card-title">Audio Devices</span>
+                            </div>
+                            <div class="field">
+                                <label class="label" for="asr-input-device">Input (microphone)</label>
+                                <select id="asr-input-device" class="input" onchange="Asr.onInputDeviceChange()"></select>
+                            </div>
+                            <div class="field">
+                                <label class="label" for="asr-output-device">Output (speakers)</label>
+                                <select id="asr-output-device" class="input"></select>
+                            </div>
+                            <div class="vu-wrap">
+                                <span class="vu-label">MIC</span>
+                                <div class="vu-track"><div id="asr-vu-bar" class="vu-bar"></div></div>
+                                <span id="asr-vu-hint" class="vu-hint">&mdash;</span>
+                            </div>
+                        </div>
+                        <div class="asr-card">
+                            <div class="asr-card-header">
+                                <svg class="asr-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="10" rx="2"/><path d="M6 11v2M10 10v4M14 11v2M18 10v4"/></svg>
+                                <span class="asr-card-title">Push-To-Talk</span>
+                            </div>
+                            <div class="field">
+                                <span class="label">PTT key</span>
+                                <button id="asr-ptt-btn" class="ptt-key" data-key="Space" onclick="Asr.capturePtt()">Space</button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="asr-card">
+                        <div class="asr-card-header">
+                            <svg class="asr-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="6" width="18" height="12" rx="2"/><circle cx="8" cy="12" r="1.5" fill="currentColor" stroke="none"/><circle cx="16" cy="12" r="1.5" fill="currentColor" stroke="none"/></svg>
+                            <span class="asr-card-title">AI Backend</span>
+                        </div>
+                        <div class="asr-backend-layout">
+                            <div class="asr-backend-left">
+                                <div class="asr-toggle-row">
+                                    <label class="asr-toggle-opt">
+                                        <input type="radio" name="asr-backend" value="ollama" checked onchange="Asr.switchBackend(this.value)"> Ollama (local)
+                                    </label>
+                                    <label class="asr-toggle-opt">
+                                        <input type="radio" name="asr-backend" value="api" onchange="Asr.switchBackend(this.value)"> ASR API
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="asr-backend-right">
+                                <div id="asr-sec-ollama" class="asr-backend-sec">
+                                    <div class="field">
+                                        <label class="label" for="asr-ollama-url">Ollama URL</label>
+                                        <input id="asr-ollama-url" class="input" type="text" placeholder="http://localhost:11434">
+                                    </div>
+                                    <div class="field">
+                                        <label class="label" for="asr-ollama-model">Model</label>
+                                        <div class="asr-refresh-row">
+                                            <span id="asr-ollama-led" class="status-led"></span>
+                                            <select id="asr-ollama-model" class="input"></select>
+                                            <button class="btn-refresh" type="button" onclick="Asr.reloadOllamaModels()">Refresh</button>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div id="asr-sec-api" class="asr-backend-sec hidden">
+                                    <div class="field">
+                                        <label class="label" for="asr-api-key">API key</label>
+                                        <input id="asr-api-key" class="input" type="password" autocomplete="off">
+                                    </div>
+                                    <div class="asr-inline-row">
+                                        <div class="field" style="flex:1">
+                                            <label class="label" for="asr-api-base">Base URL</label>
+                                            <input id="asr-api-base" class="input" type="text" placeholder="https://...">
+                                        </div>
+                                        <div class="field">
+                                            <label class="label" for="asr-api-model">Model</label>
+                                            <select id="asr-api-model" class="input">
+                                                <option value="medium">Whisper medium</option>
+                                                <option value="large">Whisper large</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div id="asr-error" class="error-msg hidden"></div>
+                    <button class="btn btn-primary" onclick="Asr.saveConfig()">Save Settings</button>
+                </div>
+            </div>
+        </section>
+    </div>
+
+    <!-- Runtime config generated by main.py (window.HMI_CONFIG) -->
+    <script src="config.js"></script>
+    <script src="js/radar.js"></script>
+    <script src="js/asr.js"></script>
+    <script src="js/setup.js"></script>
+</body>
+</html>

--- a/tests/unit/controller_hmi/test_dom_contract.py
+++ b/tests/unit/controller_hmi/test_dom_contract.py
@@ -1,0 +1,201 @@
+"""DOM-contract regression test for the controller HMI frontend.
+
+The HMI HTML files were once lost because ``*.html`` was gitignored, and the
+JS ↔ HTML contract (element ids, class hooks, inline ``on*=`` handlers) only
+exists implicitly. This test pins that contract:
+
+1. Every id/class literal the JS looks up must exist in ``index.html`` or
+   ``setup.html`` — unless the element is created by JS at runtime
+   (explicit allowlist below).
+2. Every function referenced from an inline ``on*=`` attribute in the HTML
+   must exist in the public surface of the JS module that defines it.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+STATIC_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "services"
+    / "controller_hmi_service"
+    / "static"
+)
+
+HTML_FILES = [STATIC_DIR / "index.html", STATIC_DIR / "setup.html"]
+JS_DIR = STATIC_DIR / "js"
+
+# Ids the JS looks up but creates itself at runtime (never in the HTML).
+JS_CREATED_IDS = {
+    "smr-svg",            # app.js renderSMRFromData builds the SVG
+    "smr-ils-group",      # inside the JS-built SVG
+    "smr-aircraft-group",  # inside the JS-built SVG
+    "smr-runway-rect",    # inside the JS-built SVG
+    "chat-typing",        # ptt.js typing indicator, transient
+}
+
+# Id prefixes generated dynamically (per-runway widgets, alerts, screens).
+DYNAMIC_ID_PREFIXES = ("xw-", "tw-", "hw-", "rwy-alert-", "screen-")
+
+# Class selectors the JS queries but renders itself at runtime.
+JS_CREATED_CLASSES = {
+    "flight-strip", "fs-label", "strips-empty",
+    "wind-dial", "wind-pair-card", "limit-bar-fill",
+    "wind-arrow", "wind-arrow-tip", "wind-gust-arc", "wind-speed-svg",
+    "smr-label-bg", "smr-label-line", "smr-label-text",
+    "smr-stand", "smr-stand-label", "smr-twy-label-bg", "smr-aircraft-dot",
+    "rwy-seq-item", "taf-group", "chat-msg", "chat-bubble",
+    "screen",  # static in HTML but also toggled generically
+}
+
+# Inline-handler globals -> the JS file whose public surface must expose them.
+MODULE_FILES = {
+    "App": "setup.js",
+    "Asr": "asr.js",
+    "AtisModal": "atis.js",
+    "Ptt": "ptt.js",
+    "Debrief": "debrief.js",
+}
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"missing file: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _html_sources():
+    return {p.name: _read(p) for p in HTML_FILES}
+
+
+def _js_sources():
+    files = sorted(JS_DIR.glob("*.js"))
+    assert files, f"no JS files found in {JS_DIR}"
+    return {p.name: _read(p) for p in files}
+
+
+def _all_html() -> str:
+    return "\n".join(_html_sources().values())
+
+
+# ---------------------------------------------------------------------------
+# 1. getElementById literals
+# ---------------------------------------------------------------------------
+
+def _collect_id_literals():
+    ids = {}
+    pattern = re.compile(r"getElementById\(\s*['\"]([A-Za-z0-9_-]+)['\"]\s*\)")
+    for name, src in _js_sources().items():
+        for match in pattern.finditer(src):
+            ids.setdefault(match.group(1), set()).add(name)
+    return ids
+
+
+def test_every_js_id_lookup_resolves_in_html():
+    html = _all_html()
+    missing = []
+    for element_id, sources in sorted(_collect_id_literals().items()):
+        if element_id in JS_CREATED_IDS:
+            continue
+        if element_id.startswith(DYNAMIC_ID_PREFIXES):
+            continue
+        if f'id="{element_id}"' not in html:
+            missing.append(f"{element_id}  (used by {', '.join(sorted(sources))})")
+    assert not missing, (
+        "JS looks up ids that no HTML file defines:\n  " + "\n  ".join(missing)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. querySelector('#id' / '.class') literals
+# ---------------------------------------------------------------------------
+
+def _collect_selector_literals():
+    selectors = {}
+    pattern = re.compile(
+        r"querySelector(?:All)?\(\s*['\"]([#.][A-Za-z0-9_-]+)['\"]\s*\)"
+    )
+    for name, src in _js_sources().items():
+        for match in pattern.finditer(src):
+            selectors.setdefault(match.group(1), set()).add(name)
+    return selectors
+
+
+def test_every_js_selector_resolves_in_html():
+    html = _all_html()
+    missing = []
+    for selector, sources in sorted(_collect_selector_literals().items()):
+        token = selector[1:]
+        if selector.startswith("#"):
+            if token in JS_CREATED_IDS or token.startswith(DYNAMIC_ID_PREFIXES):
+                continue
+            found = f'id="{token}"' in html
+        else:
+            if token in JS_CREATED_CLASSES:
+                continue
+            found = re.search(
+                rf'class="[^"]*\b{re.escape(token)}\b[^"]*"', html
+            ) is not None
+        if not found:
+            missing.append(f"{selector}  (used by {', '.join(sorted(sources))})")
+    assert not missing, (
+        "JS queries selectors that no HTML file defines:\n  " + "\n  ".join(missing)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Inline on*= handlers -> JS public surface
+# ---------------------------------------------------------------------------
+
+def _collect_inline_handlers():
+    handlers = {}
+    attr_pattern = re.compile(r'\son[a-z]+="([^"]+)"')
+    call_pattern = re.compile(r"\b([A-Z][A-Za-z]*)\.([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+    for name, src in _html_sources().items():
+        for attr in attr_pattern.finditer(src):
+            for call in call_pattern.finditer(attr.group(1)):
+                handlers.setdefault(call.groups(), set()).add(name)
+    return handlers
+
+
+def test_inline_handlers_exist_in_js_public_surface():
+    js = _js_sources()
+    handlers = _collect_inline_handlers()
+    assert handlers, "no inline handlers found — HTML wiring unexpectedly empty"
+
+    missing = []
+    for (module, method), sources in sorted(handlers.items()):
+        js_file = MODULE_FILES.get(module)
+        if js_file is None:
+            missing.append(
+                f"{module}.{method}  (unknown module, used by {', '.join(sorted(sources))})"
+            )
+            continue
+        src = js[js_file]
+        defined = re.search(rf"\b{re.escape(method)}\b", src) is not None
+        if not defined:
+            missing.append(
+                f"{module}.{method}  (not found in {js_file}, "
+                f"used by {', '.join(sorted(sources))})"
+            )
+    assert not missing, (
+        "HTML inline handlers reference undefined JS functions:\n  "
+        + "\n  ".join(missing)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Script tags reference existing files
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("html_file", HTML_FILES, ids=lambda p: p.name)
+def test_script_tags_reference_existing_files(html_file: Path):
+    src = _read(html_file)
+    for match in re.finditer(r'<script\s+src="([^"]+)"', src):
+        ref = match.group(1)
+        if ref == "config.js":
+            # Generated by main.py at startup; may not exist in a fresh clone.
+            continue
+        assert (STATIC_DIR / ref).exists(), (
+            f"{html_file.name} references missing script: {ref}"
+        )


### PR DESCRIPTION
## Summary

First PR of epic #59 (migrate the controller HMI to TypeScript). Before any tooling can land, the app has to work from a fresh clone — and it currently cannot: the HMI HTML entry points were never committed (unanchored `*.html` at `.gitignore:217`) and no copy survived on disk. `main.py:59` returns a 404 for `/setup`, and `StaticFiles(html=True)` has no `index.html` to serve.

## Changes

- **`.gitignore`**: negations so `services/controller_hmi_service/static/**/*.html` and future `frontend/**/*.json` (Phase 1: `package.json`, `tsconfig.json`) are tracked. The unanchored `*.html` / `*.json` rules stay for the rest of the repo.
- **`static/index.html`** (recreated): full TWR workstation — header (stopwatch, UTC clock, ATIS button, end-session), weather dashboard (QNH/QFE, METAR icons, TAF), 4 EFS strip columns, wind + runway-sequence bottom bar, SMR panel with LVP/RIMCAS, lighting controls, comms/PTT chat panel with DEL/GND/TWR filters, ATIS and debrief modals, and the 4 resize handles `resize.js` expects. Inline `on*=` handlers restored (they are the only callers of the IIFE modules' public APIs; Phase 3 replaces them with `addEventListener`).
- **`static/setup.html`** (recreated): welcome / login / register / session / ASR-settings screens plus the decorative radar canvas (`radar.js`).
- **`static/js/chat.js`** (new): receive-only WebSocket client for `/api/v1/plugin/chat/stream` — the lost HTML held this inline. Maps the `hmi:chat` payload (`shared/services/taxi_router/hmi_chat.py`) to `Ptt.addAgentMessage()`, with capped-backoff reconnect.
- **`tests/unit/controller_hmi/test_dom_contract.py`** (new): pins the JS ↔ HTML contract so the HTML can never silently rot again — every `getElementById`/`querySelector` literal must resolve in the HTML (explicit allowlist for JS-created elements), every inline handler must exist in its module's public surface, every `<script src>` must exist.

## Verification

- `pytest tests/unit` → **184 passed** (5 new DOM-contract tests included).
- FastAPI TestClient smoke: `/`, `/setup`, `/setup.html`, `/config.js` all 200 with the expected content.
- Full compose smoke test (strips drag&drop, SMR, PTT round-trip, WS chat, ATIS, debrief) pending a Docker session — tracked in the epic checklist.

## Notes

- Cosmetic fidelity to the lost original is best-effort: the functional contract is test-enforced; layout follows `efs.css`/`setup.css` selector structure.
- Stopwatch + end-session logic (referenced only by CSS, so it lived inline in the lost HTML) is recreated as a small inline script in `index.html`; Phase 3 moves it into a module.

Part of #59.