### PR TITLE
fix(ci): enable a real coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,12 @@ jobs:
             "pytest-cov>=5" "respx>=0.20" "fastapi>=0.110" \
             "sqlalchemy>=2.0" httpx redis pydantic networkx psycopg2-binary
 
-      # Coverage is informational for now: --cov-fail-under=0 overrides the
-      # fail_under=70 gate in pyproject.toml so the build never fails on the
-      # coverage number while we establish a baseline.
-      - name: Run test suite (coverage informational)
-        run: pytest --cov --cov-report=xml --cov-report=term --cov-fail-under=0
+      # No --cov-fail-under override here: `fail_under` in pyproject.toml is
+      # the single source of truth for the gate. It sits two points below the
+      # measured baseline and is raised in follow-up PRs towards 70% of the
+      # full scope — see issue #47.
+      - name: Run test suite
+        run: pytest --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage report
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,21 +78,19 @@ filterwarnings = [
 # (aircraft_mover FSM, debrief endpoint, shared/services/aircraft_*) are
 # tracked but excluded from the fail_under threshold since they are out of
 # scope for the current phase — see memoria 5.3.3 for the deferred items.
+#
+# `source` must list packages or DIRECTORIES only. Single .py file paths are
+# not valid entries: coverage treats them as module names, warns
+# "Module ... was never imported", and silently drops them from the report —
+# which is what used to happen to debrief_builder, runner, session_log,
+# frequency_audit, config, event_bridge, arrival_planner, runway_config,
+# phases and geo. Scope is therefore expressed as directories here and
+# narrowed in `omit` below.
 source = [
-    "services/orchestrator_service/agent",
-    "services/orchestrator_service/api",
-    "services/orchestrator_service/db",
-    "services/orchestrator_service/frequency_audit.py",
-    "services/orchestrator_service/runner.py",
-    "services/orchestrator_service/session_log.py",
-    "services/orchestrator_service/debrief_builder.py",
-    "services/orchestrator_service/config.py",
-    "services/arrival_simulator_service/core/event_bridge.py",
-    "services/arrival_simulator_service/core/arrival_planner.py",
-    "services/arrival_simulator_service/core/runway_config.py",
-    "services/arrival_simulator_service/core/phases.py",
-    "services/arrival_simulator_service/core/geo.py",
-    "shared/services/taxi_router",
+    "services/orchestrator_service",
+    "services/arrival_simulator_service/core",
+    "shared/services",
+    "shared/models",
 ]
 omit = [
     "*/__pycache__/*",
@@ -101,13 +99,26 @@ omit = [
     "*/agent/prompts.py",
     "*/agent/debrief_agent.py",
     "*/agent/debrief_prompt.py",
-    "*/agent/tools/confirm.py",
     "*/api/aircraft.py",
     "*/api/clearances.py",
     "*/api/debrief.py",
     "*/api/flight_plans.py",
     "*/api/weather.py",
     "*/shared/callbacks.py",
+    # Pulled in by the directory-level `source` entries above but out of scope
+    # for this phase: no test battery covers them yet. Several are also
+    # deletion candidates under issue #46.
+    "*/arrival_simulator_service/core/plan_catalog.py",
+    "*/arrival_simulator_service/core/scheduler.py",
+    "*/shared/services/aircraft_state_store.py",
+    "*/shared/services/aircraft_tracker.py",
+    "*/shared/services/airport_data_store.py",
+    "*/shared/services/stand_assigner.py",
+    "*/shared/models/aircraft.py",
+    "*/shared/models/aircraft_state.py",
+    "*/shared/models/airport.py",
+    "*/shared/models/command_parser.py",
+    "*/shared/models/communications.py",
     "tests/*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,4 +129,8 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "if __name__ == .__main__.:",
 ]
-fail_under = 70
+# Baseline measured on CI at 79% over 1364 statements (PR #80), with the
+# `source` scope corrected above. The gate sits two points below it to absorb
+# line-count noise; raise it as coverage improves. The old 70% target was set
+# against the broken scope and is already cleared.
+fail_under = 77


### PR DESCRIPTION
Closes #47.

## The problem behind the problem

`ci.yml` overriding `fail_under` with `--cov-fail-under=0` is only half of it. `[tool.coverage.run] source` accepts **packages and directories only**, but ten of the fifteen entries were single `.py` file paths. Coverage treated those as module names, warned `Module ... was never imported`, and dropped them from the report entirely:

`debrief_builder` · `runner` · `session_log` · `frequency_audit` · `config` · `event_bridge` · `arrival_planner` · `runway_config` · `phases` · `geo`

All ten have tests. None of them counted. The last two were also stale paths — they live in `shared/models/` and `shared/services/`, not under `services/arrival_simulator_service/core/`.

So the 72% on `main` was measured over roughly half the intended scope. Turning the gate on against that number would have locked in a meaningless figure.

## What this does

1. **First commit** — scope expressed as directories, narrowed in `omit`. Report now covers 1364 statements instead of 773, with zero `never imported` warnings. Local total: **79%**.
2. **Second commit** (after reading this PR's CI number) — set `fail_under` to baseline − 2 and drop `--cov-fail-under=0` from `ci.yml`, making `pyproject.toml` the single source of truth.

Newly in scope and deliberately omitted for now, all untested and several of them deletion candidates under #46: `plan_catalog.py`, `scheduler.py`, `shared/services/aircraft_*`, `shared/services/airport_data_store.py`, `stand_assigner.py`, and five `shared/models/*` modules.

## Acceptance criteria

- [ ] Coverage baseline measured and noted on #47
- [ ] `ci.yml` no longer uses `--cov-fail-under=0`; effective gate ≥ baseline − 2
- [ ] CI green with the new gate