### PR TITLE
Phase 3a (#59): Vitest + pure-logic extraction (first 53 frontend tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build

--- a/services/controller_hmi_service/frontend/package-lock.json
+++ b/services/controller_hmi_service/frontend/package-lock.json
@@ -11,10 +11,12 @@
         "@eslint/js": "^9.18.0",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.0",
+        "happy-dom": "^20.11.1",
         "prettier": "^3.4.0",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.20.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=22"
@@ -672,6 +674,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
@@ -1081,6 +1090,31 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1094,6 +1128,33 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.66.0",
@@ -1377,6 +1438,119 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -1440,6 +1614,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1458,6 +1642,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1466,6 +1663,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1512,6 +1719,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1549,6 +1763,26 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1767,6 +2001,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1775,6 +2019,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1906,6 +2160,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/has-flag": {
@@ -2076,6 +2349,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2121,6 +2404,20 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2204,6 +2501,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2382,6 +2686,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2391,6 +2702,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -2418,6 +2743,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2433,6 +2775,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2498,6 +2850,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -2584,6 +2943,106 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2600,6 +3059,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -2608,6 +3084,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yocto-queue": {

--- a/services/controller_hmi_service/frontend/package.json
+++ b/services/controller_hmi_service/frontend/package.json
@@ -14,15 +14,19 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
     "format": "prettier --write \"src/**/*.{ts,js,css}\" \"*.html\"",
-    "format:check": "prettier --check \"src/**/*.{ts,js,css}\" \"*.html\""
+    "format:check": "prettier --check \"src/**/*.{ts,js,css}\" \"*.html\"",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.0",
+    "happy-dom": "^20.11.1",
     "prettier": "^3.4.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.20.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/services/controller_hmi_service/frontend/src/efs/format.test.ts
+++ b/services/controller_hmi_service/frontend/src/efs/format.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatFL, formatSpeed, formatTime, generateSquawk, truncateRoute } from './format';
+
+describe('formatFL', () => {
+  it('renders flight levels at/above 10000 ft', () => {
+    expect(formatFL(35000)).toBe('F350');
+    expect(formatFL(10000)).toBe('F100');
+  });
+
+  it('renders altitudes below 10000 ft with A prefix and 3 digits', () => {
+    expect(formatFL(4500)).toBe('A045');
+    expect(formatFL(900)).toBe('A009');
+  });
+
+  it('falls back for missing values', () => {
+    expect(formatFL(undefined)).toBe('----');
+    expect(formatFL(0)).toBe('----');
+  });
+});
+
+describe('formatSpeed', () => {
+  it('zero-pads to 4 digits with N prefix', () => {
+    expect(formatSpeed(460)).toBe('N0460');
+    expect(formatSpeed(85)).toBe('N0085');
+  });
+
+  it('falls back for missing values', () => {
+    expect(formatSpeed(undefined)).toBe('-----');
+  });
+});
+
+describe('formatTime', () => {
+  it('renders hhmm numbers as hh:mm', () => {
+    expect(formatTime(1430)).toBe('14:30');
+    expect(formatTime(905)).toBe('09:05');
+  });
+
+  it('renders midnight (0) and missing differently', () => {
+    expect(formatTime(0)).toBe('00:00');
+    expect(formatTime(undefined)).toBe('--:--');
+  });
+});
+
+describe('generateSquawk', () => {
+  it('is deterministic per registration', () => {
+    expect(generateSquawk('EC-ABC')).toBe(generateSquawk('EC-ABC'));
+  });
+
+  it('produces 4 digits, each 0-7', () => {
+    for (const reg of ['EC-ABC', 'N12345', 'D-AIBL', 'G-EZTH']) {
+      const sq = generateSquawk(reg);
+      expect(sq).toMatch(/^[0-7]{4}$/);
+    }
+  });
+
+  it('differs across registrations (hash actually varies)', () => {
+    expect(generateSquawk('EC-AAA')).not.toBe(generateSquawk('EC-ZZZ'));
+  });
+});
+
+describe('truncateRoute', () => {
+  it('returns DCT for empty routes', () => {
+    expect(truncateRoute(undefined, 10)).toBe('DCT');
+    expect(truncateRoute('', 10)).toBe('DCT');
+  });
+
+  it('keeps short routes and truncates long ones with ellipsis', () => {
+    expect(truncateRoute('DCT ROSTO', 20)).toBe('DCT ROSTO');
+    expect(truncateRoute('ABCDEFGHIJ', 4)).toBe('ABCD...');
+  });
+});

--- a/services/controller_hmi_service/frontend/src/efs/format.ts
+++ b/services/controller_hmi_service/frontend/src/efs/format.ts
@@ -1,0 +1,44 @@
+// Pure formatting helpers for flight strips and SMR labels.
+
+/** ICAO-style level: F<hundreds> at/above 10000 ft, A<hundreds> below. */
+export function formatFL(feet: number | undefined): string {
+  if (!feet) return '----';
+  if (feet >= 10000) return 'F' + Math.round(feet / 100);
+  return 'A' + String(Math.round(feet / 100)).padStart(3, '0');
+}
+
+/** N-prefixed 4-digit speed (e.g. N0460). */
+export function formatSpeed(knots: number | undefined): string {
+  if (!knots) return '-----';
+  return 'N' + String(knots).padStart(4, '0');
+}
+
+/** hhmm number → "hh:mm". */
+export function formatTime(hhmm: number | undefined): string {
+  if (!hhmm && hhmm !== 0) return '--:--';
+  const s = String(Math.floor(hhmm)).padStart(4, '0');
+  return s.slice(0, 2) + ':' + s.slice(2, 4);
+}
+
+/** Deterministic hash-based squawk from a registration (digits 0-7 only). */
+export function generateSquawk(reg: string): string {
+  let hash = 0;
+  for (let i = 0; i < reg.length; i++) {
+    hash = (hash << 5) - hash + reg.charCodeAt(i);
+    hash |= 0;
+  }
+  const code = (Math.abs(hash) % 7000) + 1000;
+  const str = String(code);
+  let result = '';
+  for (let j = 0; j < 4; j++) {
+    const d = parseInt(str[j] ?? '0') || 0;
+    result += Math.min(d, 7);
+  }
+  return result;
+}
+
+export function truncateRoute(route: string | undefined, maxLen: number): string {
+  if (!route) return 'DCT';
+  if (route.length <= maxLen) return route;
+  return route.substring(0, maxLen) + '...';
+}

--- a/services/controller_hmi_service/frontend/src/efs/ordering.test.ts
+++ b/services/controller_hmi_service/frontend/src/efs/ordering.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FlightPlan } from '../types/api';
+import { moveInOrder, sortByUserOrder, sortFlightPlans } from './ordering';
+
+const plan = (reg: string, extra: Partial<FlightPlan> = {}): FlightPlan => ({
+  aircraft_registration: reg,
+  ...extra,
+});
+
+describe('sortFlightPlans', () => {
+  const plans = [
+    plan('EC-CCC', { departure_time: 1200, destination_ICAO: 'LEMD' }),
+    plan('EC-AAA', { departure_time: 900, destination_ICAO: 'LFPG' }),
+    plan('EC-BBB', { departure_time: 1030, destination_ICAO: 'EGLL' }),
+  ];
+
+  it('sorts by departure time', () => {
+    expect(sortFlightPlans(plans, 'departure_time').map((p) => p.aircraft_registration)).toEqual([
+      'EC-AAA',
+      'EC-BBB',
+      'EC-CCC',
+    ]);
+  });
+
+  it('sorts by callsign (registration)', () => {
+    expect(sortFlightPlans(plans, 'callsign').map((p) => p.aircraft_registration)).toEqual([
+      'EC-AAA',
+      'EC-BBB',
+      'EC-CCC',
+    ]);
+  });
+
+  it('sorts by destination', () => {
+    expect(sortFlightPlans(plans, 'destination').map((p) => p.aircraft_registration)).toEqual([
+      'EC-BBB',
+      'EC-CCC',
+      'EC-AAA',
+    ]);
+  });
+
+  it('unknown key keeps the original order and does not mutate', () => {
+    const copy = plans.slice();
+    expect(sortFlightPlans(plans, 'nope')).toEqual(copy);
+    expect(plans).toEqual(copy);
+  });
+});
+
+describe('sortByUserOrder', () => {
+  it('orders by the user list, unknown regs go last', () => {
+    const plans = [plan('B'), plan('C'), plan('A')];
+    const out = sortByUserOrder(plans, ['A', 'B']);
+    expect(out.map((p) => p.aircraft_registration)).toEqual(['A', 'B', 'C']);
+  });
+});
+
+describe('moveInOrder', () => {
+  it('inserts before the target', () => {
+    expect(moveInOrder(['A', 'B', 'C'], 'C', 'A', true)).toEqual(['C', 'A', 'B']);
+  });
+
+  it('inserts after the target', () => {
+    expect(moveInOrder(['A', 'B', 'C'], 'A', 'C', false)).toEqual(['B', 'C', 'A']);
+  });
+
+  it('appends when the target is unknown', () => {
+    expect(moveInOrder(['A', 'B'], 'A', 'Z', true)).toEqual(['B', 'A']);
+  });
+
+  it('does not mutate the input array', () => {
+    const order = ['A', 'B'];
+    moveInOrder(order, 'B', 'A', true);
+    expect(order).toEqual(['A', 'B']);
+  });
+});

--- a/services/controller_hmi_service/frontend/src/efs/ordering.ts
+++ b/services/controller_hmi_service/frontend/src/efs/ordering.ts
@@ -1,0 +1,50 @@
+// Pure ordering helpers for flight strips.
+
+import type { FlightPlan } from '../types/api';
+
+export function sortFlightPlans(plans: FlightPlan[], sortBy: string): FlightPlan[] {
+  return plans.slice().sort((a, b) => {
+    switch (sortBy) {
+      case 'departure_time':
+        return (a.departure_time ?? 0) - (b.departure_time ?? 0);
+      case 'callsign':
+        return a.aircraft_registration.localeCompare(b.aircraft_registration);
+      case 'destination':
+        return (a.destination_ICAO ?? '').localeCompare(b.destination_ICAO ?? '');
+      default:
+        return 0;
+    }
+  });
+}
+
+/** Sort one column's plans by a user-defined registration order; plans not
+ * in the order list keep their relative position at the end. */
+export function sortByUserOrder(plans: FlightPlan[], order: string[]): FlightPlan[] {
+  return plans.slice().sort((a, b) => {
+    let ai = order.indexOf(a.aircraft_registration);
+    let bi = order.indexOf(b.aircraft_registration);
+    if (ai === -1) ai = Infinity;
+    if (bi === -1) bi = Infinity;
+    return ai - bi;
+  });
+}
+
+/** Insert dragReg into order relative to targetReg (before/after), removing
+ * any previous occurrence. Returns a new array. */
+export function moveInOrder(
+  order: string[],
+  dragReg: string,
+  targetReg: string,
+  insertBefore: boolean,
+): string[] {
+  const next = order.filter((r) => r !== dragReg);
+  const idx = next.indexOf(targetReg);
+  if (idx === -1) {
+    next.push(dragReg);
+  } else if (insertBefore) {
+    next.splice(idx, 0, dragReg);
+  } else {
+    next.splice(idx + 1, 0, dragReg);
+  }
+  return next;
+}

--- a/services/controller_hmi_service/frontend/src/legacy/app.ts
+++ b/services/controller_hmi_service/frontend/src/legacy/app.ts
@@ -9,6 +9,15 @@ import {
   getWeather,
 } from '../api/client';
 import { getSmrLabelOffset, getStripLabel, setSmrLabelOffset } from '../lib/storage';
+import {
+  bearingDeg,
+  computeSmrBounds,
+  geoToSVG,
+  leaderAttachPoint,
+  projectGeoFromBearing,
+  type Point,
+  type SmrBounds,
+} from '../smr/projection';
 import type {
   AircraftPosition,
   AirportGraph,
@@ -171,23 +180,8 @@ function loadTaf(): void {
 // SMR Map (Surface Movement Radar) - Real Data
 // ============================================
 
-interface SmrBounds {
-  minLat: number;
-  maxLat: number;
-  minLon: number;
-  maxLon: number;
-  cosLat: number;
-}
-
-interface Point {
-  x: number;
-  y: number;
-}
-
 let smrGraph: AirportGraph | null = null; // Airport graph data from API
 let smrBounds: SmrBounds | null = null;
-const SMR_PADDING = 5;
-const SMR_SIZE = 100;
 
 // Pan & Zoom state
 let smrViewBox = { x: 0, y: 0, w: 100, h: 100 };
@@ -227,72 +221,12 @@ function initSMRMap(): void {
 }
 
 function computeSMRBounds(): void {
-  if (!smrGraph) return;
-  const lats: number[] = [];
-  const lons: number[] = [];
-
-  // Nodes (keyed by id)
-  Object.values(smrGraph.nodes).forEach((n) => {
-    lats.push(n.lat);
-    lons.push(n.lon);
-  });
-
-  // Stands
-  smrGraph.stands.forEach((s) => {
-    lats.push(s.lat);
-    lons.push(s.lon);
-  });
-
-  // Runway endpoints
-  smrGraph.runways.forEach((r) => {
-    lats.push(r.end1.lat, r.end2.lat);
-    lons.push(r.end1.lon, r.end2.lon);
-  });
-
-  if (lats.length === 0) return;
-
-  const minLat = Math.min(...lats);
-  const maxLat = Math.max(...lats);
-  const minLon = Math.min(...lons);
-  const maxLon = Math.max(...lons);
-
-  // Add margin
-  const latMargin = (maxLat - minLat) * 0.08;
-  const lonMargin = (maxLon - minLon) * 0.08;
-
-  // Cosine correction: at this latitude, 1° lon is shorter than 1° lat
-  const centerLat = (minLat + maxLat) / 2;
-  const cosLat = Math.cos((centerLat * Math.PI) / 180);
-
-  smrBounds = {
-    minLat: minLat - latMargin,
-    maxLat: maxLat + latMargin,
-    minLon: minLon - lonMargin,
-    maxLon: maxLon + lonMargin,
-    cosLat,
-  };
+  smrBounds = smrGraph ? computeSmrBounds(smrGraph) : null;
 }
 
-// Convert GPS lat/lon to SVG x/y (0-100 viewBox) with correct 2D projection
-function geoToSVG(lat: number, lon: number): Point {
-  if (!smrBounds) return { x: 50, y: 50 };
-
-  const dLat = smrBounds.maxLat - smrBounds.minLat;
-  const dLon = (smrBounds.maxLon - smrBounds.minLon) * smrBounds.cosLat;
-
-  // Fit proportionally inside the viewBox (preserve aspect ratio)
-  const usable = SMR_SIZE - 2 * SMR_PADDING;
-  const scale = usable / Math.max(dLat, dLon);
-
-  const mapW = dLon * scale;
-  const mapH = dLat * scale;
-  const offX = SMR_PADDING + (usable - mapW) / 2;
-  const offY = SMR_PADDING + (usable - mapH) / 2;
-
-  const x = offX + (lon - smrBounds.minLon) * smrBounds.cosLat * scale;
-  // Invert Y: north (high lat) = top
-  const y = offY + (smrBounds.maxLat - lat) * scale;
-  return { x, y };
+// Convert GPS lat/lon to SVG x/y using the current bounds
+function toSVG(lat: number, lon: number): Point {
+  return geoToSVG(smrBounds, lat, lon);
 }
 
 function renderSMRFromData(): void {
@@ -313,8 +247,8 @@ function renderSMRFromData(): void {
 
   // --- Runways ---
   smrGraph.runways.forEach((rwy) => {
-    const p1 = geoToSVG(rwy.end1.lat, rwy.end1.lon);
-    const p2 = geoToSVG(rwy.end2.lat, rwy.end2.lon);
+    const p1 = toSVG(rwy.end1.lat, rwy.end1.lon);
+    const p2 = toSVG(rwy.end2.lat, rwy.end2.lon);
 
     // Thick runway strip
     svg +=
@@ -348,8 +282,8 @@ function renderSMRFromData(): void {
     const n2 = smrGraph!.nodes[edge.to];
     if (!n1 || !n2) return;
 
-    const p1 = geoToSVG(n1.lat, n1.lon);
-    const p2 = geoToSVG(n2.lat, n2.lon);
+    const p1 = toSVG(n1.lat, n1.lon);
+    const p2 = toSVG(n2.lat, n2.lon);
 
     const isRunway = edge.category === 'runway';
 
@@ -376,7 +310,7 @@ function renderSMRFromData(): void {
     if (/^Node\s+\d+$/.test(n.name)) return;
     if (n.name.indexOf('_') !== -1) return;
     if (n.name.length > 4) return;
-    const pn = geoToSVG(n.lat, n.lon);
+    const pn = toSVG(n.lat, n.lon);
     const entry = (labelByName[n.name] ??= { sx: 0, sy: 0, n: 0 });
     entry.sx += pn.x;
     entry.sy += pn.y;
@@ -403,7 +337,7 @@ function renderSMRFromData(): void {
 
   // --- Stands / Gates ---
   smrGraph.stands.forEach((stand) => {
-    const p = geoToSVG(stand.lat, stand.lon);
+    const p = toSVG(stand.lat, stand.lon);
 
     const isMil = stand.name.indexOf('Mil') !== -1;
     const isGA =
@@ -429,7 +363,7 @@ function renderSMRFromData(): void {
   // --- Taxi nodes (dim dots) ---
   Object.keys(smrGraph.nodes).forEach((id) => {
     const n = smrGraph!.nodes[id]!;
-    const p = geoToSVG(n.lat, n.lon);
+    const p = toSVG(n.lat, n.lon);
     svg += '<circle cx="' + p.x + '" cy="' + p.y + '" r="0.3" data-base-r="0.3" fill="#1a2a3a" opacity="0.2"/>';
   });
 
@@ -474,14 +408,9 @@ function autoFitSMRView(): void {
     const ends = _findRunwayEnds(activeILSRunway);
     if (ends) {
       const { threshold, otherEnd } = ends;
-      const l1 = (otherEnd.lat * Math.PI) / 180;
-      const l2 = (threshold.lat * Math.PI) / 180;
-      const dl = ((threshold.lon - otherEnd.lon) * Math.PI) / 180;
-      const by = Math.sin(dl) * Math.cos(l2);
-      const bx = Math.cos(l1) * Math.sin(l2) - Math.sin(l1) * Math.cos(l2) * Math.cos(dl);
-      const brDeg = ((Math.atan2(by, bx) * 180) / Math.PI + 360) % 360;
-      const endGeo = _projectGeoFromBearing(threshold.lat, threshold.lon, brDeg, ILS_RANGE_NM);
-      const endSvg = geoToSVG(endGeo.lat, endGeo.lon);
+      const brDeg = bearingDeg(otherEnd.lat, otherEnd.lon, threshold.lat, threshold.lon);
+      const endGeo = projectGeoFromBearing(threshold.lat, threshold.lon, brDeg, ILS_RANGE_NM);
+      const endSvg = toSVG(endGeo.lat, endGeo.lon);
       const pad = 5;
       minX = Math.min(minX, endSvg.x - pad);
       minY = Math.min(minY, endSvg.y - pad);
@@ -509,19 +438,6 @@ function autoFitSMRView(): void {
   }
 }
 
-function _projectGeoFromBearing(
-  lat: number,
-  lon: number,
-  bearingDeg: number,
-  distNm: number,
-): { lat: number; lon: number } {
-  const br = (bearingDeg * Math.PI) / 180;
-  const dLat = (distNm / 60) * Math.cos(br);
-  const latRad = (lat * Math.PI) / 180;
-  const dLon = ((distNm / 60) * Math.sin(br)) / Math.cos(latRad);
-  return { lat: lat + dLat, lon: lon + dLon };
-}
-
 function drawILSCenterline(): void {
   const group = document.getElementById('smr-ils-group');
   if (!group) return;
@@ -533,17 +449,12 @@ function drawILSCenterline(): void {
   const { threshold, otherEnd } = ends;
 
   // Bearing from otherEnd -> threshold = landing direction
-  const lat1 = (otherEnd.lat * Math.PI) / 180;
-  const lat2 = (threshold.lat * Math.PI) / 180;
-  const dLonRad = ((threshold.lon - otherEnd.lon) * Math.PI) / 180;
-  const y = Math.sin(dLonRad) * Math.cos(lat2);
-  const x = Math.cos(lat1) * Math.sin(lat2) - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLonRad);
-  const bearingDeg = ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
-  const perpDeg = (bearingDeg + 90) % 360;
+  const landingBrg = bearingDeg(otherEnd.lat, otherEnd.lon, threshold.lat, threshold.lon);
+  const perpDeg = (landingBrg + 90) % 360;
 
-  const thrSvg = geoToSVG(threshold.lat, threshold.lon);
-  const endGeo = _projectGeoFromBearing(threshold.lat, threshold.lon, bearingDeg, ILS_RANGE_NM);
-  const endSvg = geoToSVG(endGeo.lat, endGeo.lon);
+  const thrSvg = toSVG(threshold.lat, threshold.lon);
+  const endGeo = projectGeoFromBearing(threshold.lat, threshold.lon, landingBrg, ILS_RANGE_NM);
+  const endSvg = toSVG(endGeo.lat, endGeo.lon);
 
   let svg =
     '<line x1="' + thrSvg.x + '" y1="' + thrSvg.y +
@@ -552,11 +463,11 @@ function drawILSCenterline(): void {
     ' vector-effect="non-scaling-stroke" opacity="0.85"/>';
 
   for (let n = ILS_TICK_NM; n <= ILS_RANGE_NM; n += ILS_TICK_NM) {
-    const c = _projectGeoFromBearing(threshold.lat, threshold.lon, bearingDeg, n);
-    const a = _projectGeoFromBearing(c.lat, c.lon, perpDeg, ILS_TICK_HALF_NM);
-    const b = _projectGeoFromBearing(c.lat, c.lon, perpDeg, -ILS_TICK_HALF_NM);
-    const pa = geoToSVG(a.lat, a.lon);
-    const pb = geoToSVG(b.lat, b.lon);
+    const c = projectGeoFromBearing(threshold.lat, threshold.lon, landingBrg, n);
+    const a = projectGeoFromBearing(c.lat, c.lon, perpDeg, ILS_TICK_HALF_NM);
+    const b = projectGeoFromBearing(c.lat, c.lon, perpDeg, -ILS_TICK_HALF_NM);
+    const pa = toSVG(a.lat, a.lon);
+    const pb = toSVG(b.lat, b.lon);
     svg +=
       '<line x1="' + pa.x + '" y1="' + pa.y +
       '" x2="' + pb.x + '" y2="' + pb.y +
@@ -795,78 +706,6 @@ function applySMRViewBox(): void {
 
 // --- Aurora-style HMI ground label for SMR ---
 
-// Return the point on the box boundary nearest to (dotX,dotY) by ray-casting
-// from the box centre toward the dot and finding the first edge intersection.
-function leaderAttachPoint(
-  dotX: number,
-  dotY: number,
-  boxX: number,
-  boxY: number,
-  boxW: number,
-  boxH: number,
-): Point {
-  const cx = boxX + boxW / 2;
-  const cy = boxY + boxH / 2;
-  const vx = dotX - cx;
-  const vy = dotY - cy;
-  if (vx === 0 && vy === 0) return { x: boxX, y: cy };
-
-  let tMin = Infinity,
-    bestX = boxX,
-    bestY = cy;
-  let t: number, iy: number, ix: number;
-
-  // Left edge
-  if (vx !== 0) {
-    t = (boxX - cx) / vx;
-    if (t > 0) {
-      iy = cy + t * vy;
-      if (iy >= boxY && iy <= boxY + boxH && t < tMin) {
-        tMin = t;
-        bestX = boxX;
-        bestY = iy;
-      }
-    }
-  }
-  // Right edge
-  if (vx !== 0) {
-    t = (boxX + boxW - cx) / vx;
-    if (t > 0) {
-      iy = cy + t * vy;
-      if (iy >= boxY && iy <= boxY + boxH && t < tMin) {
-        tMin = t;
-        bestX = boxX + boxW;
-        bestY = iy;
-      }
-    }
-  }
-  // Top edge
-  if (vy !== 0) {
-    t = (boxY - cy) / vy;
-    if (t > 0) {
-      ix = cx + t * vx;
-      if (ix >= boxX && ix <= boxX + boxW && t < tMin) {
-        tMin = t;
-        bestX = ix;
-        bestY = boxY;
-      }
-    }
-  }
-  // Bottom edge
-  if (vy !== 0) {
-    t = (boxY + boxH - cy) / vy;
-    if (t > 0) {
-      ix = cx + t * vx;
-      if (ix >= boxX && ix <= boxX + boxW && t < tMin) {
-        tMin = t;
-        bestX = ix;
-        bestY = boxY + boxH;
-      }
-    }
-  }
-  return { x: bestX, y: bestY };
-}
-
 const smrLabelOffsets: Record<string, { ox: number; oy: number }> = {}; // persisted user-drag offsets
 let _smrLabelDragState: {
   reg: string;
@@ -1077,7 +916,7 @@ export function updateSMRAircraft(plans: FlightPlan[]): void {
   const runwayPositions: Point[] = [];
 
   smrGraph.stands.forEach((s) => {
-    standPositions.push(geoToSVG(s.lat, s.lon));
+    standPositions.push(toSVG(s.lat, s.lon));
   });
 
   // Collect unique taxiway node positions
@@ -1087,7 +926,7 @@ export function updateSMRAircraft(plans: FlightPlan[]): void {
       if (!seenTaxiNodes[edge.from]) {
         const n = smrGraph!.nodes[edge.from];
         if (n) {
-          taxiPositions.push(geoToSVG(n.lat, n.lon));
+          taxiPositions.push(toSVG(n.lat, n.lon));
           seenTaxiNodes[edge.from] = true;
         }
       }
@@ -1096,8 +935,8 @@ export function updateSMRAircraft(plans: FlightPlan[]): void {
 
   // Interpolated positions along runway
   smrGraph.runways.forEach((rwy) => {
-    const p1 = geoToSVG(rwy.end1.lat, rwy.end1.lon);
-    const p2 = geoToSVG(rwy.end2.lat, rwy.end2.lon);
+    const p1 = toSVG(rwy.end1.lat, rwy.end1.lon);
+    const p2 = toSVG(rwy.end2.lat, rwy.end2.lon);
     for (let t = 0.2; t <= 0.8; t += 0.1) {
       runwayPositions.push({
         x: p1.x + (p2.x - p1.x) * t,
@@ -1120,7 +959,7 @@ export function updateSMRAircraft(plans: FlightPlan[]): void {
     // 1) Preferred: live lat/lon from the Redis state store
     const live = livePositions[reg];
     if (live && isFinite(live.latitude) && isFinite(live.longitude)) {
-      pos = geoToSVG(live.latitude, live.longitude);
+      pos = toSVG(live.latitude, live.longitude);
     }
     // 2) Fallback: place by column index when no live position is available
     else if (column === 'PRE_TAXI' && standPositions.length > 0) {

--- a/services/controller_hmi_service/frontend/src/legacy/efs.ts
+++ b/services/controller_hmi_service/frontend/src/legacy/efs.ts
@@ -1,6 +1,8 @@
 // efs.ts — 4-column electronic flight strips with drag & drop.
 
 import { getStripStates as fetchStripStates, patchStripState } from '../api/client';
+import { formatFL, formatSpeed, formatTime, generateSquawk, truncateRoute } from '../efs/format';
+import { moveInOrder, sortByUserOrder, sortFlightPlans } from '../efs/ordering';
 import { getStripLabel, setStripLabel } from '../lib/storage';
 import type { FlightPlan, StripColumn, StripStates } from '../types/api';
 import { currentICAO, flightPlans, rerenderStrips, updateSMRAircraft } from './app';
@@ -62,15 +64,7 @@ function _moveOrder(
     const order = stripOrder[col];
     if (order) stripOrder[col] = order.filter((r) => r !== dragReg);
   }
-  const order = (stripOrder[targetColumn] ??= []);
-  const idx = order.indexOf(targetReg);
-  if (idx === -1) {
-    order.push(dragReg);
-  } else if (insertBefore) {
-    order.splice(idx, 0, dragReg);
-  } else {
-    order.splice(idx + 1, 0, dragReg);
-  }
+  stripOrder[targetColumn] = moveInOrder(stripOrder[targetColumn] ?? [], dragReg, targetReg, insertBefore);
 }
 
 // ---- Load strip states from server ----
@@ -155,14 +149,7 @@ export function renderFlightStrips(plans: FlightPlan[]): void {
 
   // Sort each column by user-defined order, new arrivals go to the end
   COLUMNS.forEach((col) => {
-    const order = stripOrder[col] || [];
-    byColumn[col].sort((a, b) => {
-      let ai = order.indexOf(a.aircraft_registration);
-      let bi = order.indexOf(b.aircraft_registration);
-      if (ai === -1) ai = Infinity;
-      if (bi === -1) bi = Infinity;
-      return ai - bi;
-    });
+    byColumn[col] = sortByUserOrder(byColumn[col], stripOrder[col] || []);
   });
 
   // Render each column in order
@@ -208,24 +195,7 @@ function emptyState(): string {
   );
 }
 
-// ---- Format helpers ----
-
-export function formatFL(feet: number | undefined): string {
-  if (!feet) return '----';
-  if (feet >= 10000) return 'F' + Math.round(feet / 100);
-  return 'A' + String(Math.round(feet / 100)).padStart(3, '0');
-}
-
-export function formatSpeed(knots: number | undefined): string {
-  if (!knots) return '-----';
-  return 'N' + String(knots).padStart(4, '0');
-}
-
-export function formatTime(hhmm: number | undefined): string {
-  if (!hhmm && hhmm !== 0) return '--:--';
-  const s = String(Math.floor(hhmm)).padStart(4, '0');
-  return s.slice(0, 2) + ':' + s.slice(2, 4);
-}
+// Format helpers now live in src/efs/format.ts (re-exported below).
 
 // ---- Create Strip Card (IVAO paper-strip grid) ----
 
@@ -374,30 +344,6 @@ function createStripElement(plan: FlightPlan, phase: string, isArrival: boolean)
   return strip;
 }
 
-export function generateSquawk(reg: string): string {
-  // Simple hash-based squawk code from registration
-  let hash = 0;
-  for (let i = 0; i < reg.length; i++) {
-    hash = (hash << 5) - hash + reg.charCodeAt(i);
-    hash |= 0;
-  }
-  const code = (Math.abs(hash) % 7000) + 1000;
-  // Ensure valid squawk (digits 0-7 only)
-  const str = String(code);
-  let result = '';
-  for (let j = 0; j < 4; j++) {
-    const d = parseInt(str[j] ?? '0') || 0;
-    result += Math.min(d, 7);
-  }
-  return result;
-}
-
-export function truncateRoute(route: string | undefined, maxLen: number): string {
-  if (!route) return 'DCT';
-  if (route.length <= maxLen) return route;
-  return route.substring(0, maxLen) + '...';
-}
-
 function _initDropZones(): void {
   Object.keys(COLUMN_DEFAULT_PHASE).forEach((colId) => {
     const col = document.getElementById(colId);
@@ -439,17 +385,5 @@ function _initDropZones(): void {
   });
 }
 
-export function sortFlightPlans(plans: FlightPlan[], sortBy: string): FlightPlan[] {
-  return plans.slice().sort((a, b) => {
-    switch (sortBy) {
-      case 'departure_time':
-        return (a.departure_time ?? 0) - (b.departure_time ?? 0);
-      case 'callsign':
-        return a.aircraft_registration.localeCompare(b.aircraft_registration);
-      case 'destination':
-        return (a.destination_ICAO ?? '').localeCompare(b.destination_ICAO ?? '');
-      default:
-        return 0;
-    }
-  });
-}
+// Re-export the pure helpers so existing importers keep one entry point.
+export { formatFL, formatSpeed, formatTime, generateSquawk, truncateRoute, sortFlightPlans };

--- a/services/controller_hmi_service/frontend/src/legacy/weather.ts
+++ b/services/controller_hmi_service/frontend/src/legacy/weather.ts
@@ -1,6 +1,7 @@
 // weather.ts — METAR & TAF rendering + Dashboard Superior.
 
 import type { Metar } from '../types/api';
+import { extractTafPortion, parseTaf, type TafGroup } from '../weather/taf';
 
 // ---- METAR ----
 
@@ -127,41 +128,13 @@ function renderMetarIcons(metar: Metar): void {
 
 // ---- TAF ----
 
-interface TafGroup {
-  wind: string | null;
-  vis: string | null;
-  clouds: string | null;
-  wx: string | null;
-  type?: string;
-}
-
-interface ParsedTaf {
-  validity: string | null;
-  base: TafGroup | null;
-  tempMax: string | null;
-  tempMin: string | null;
-  changes: TafGroup[];
-}
-
 export function renderTafModule(rawTaf: string | null): void {
   const rawEl = document.getElementById('wx-raw-taf');
   const decodedEl = document.getElementById('wx-decoded-taf');
   const validityEl = document.getElementById('taf-validity');
 
   // Extract only the TAF portion (discard any METAR lines mixed in)
-  if (rawTaf) {
-    // Try to find "TAF" or "TAF AMD" at start of line or string
-    const tafMatch = rawTaf.match(/(^|\n)(TAF\s)/);
-    if (tafMatch && tafMatch.index !== undefined) {
-      rawTaf = rawTaf.substring(tafMatch.index + (tafMatch[1] ? tafMatch[1].length : 0));
-    } else {
-      // Fallback: find any occurrence of "TAF "
-      const idx = rawTaf.indexOf('TAF ');
-      if (idx !== -1) {
-        rawTaf = rawTaf.substring(idx);
-      }
-    }
-  }
+  if (rawTaf) rawTaf = extractTafPortion(rawTaf);
 
   if (rawEl) rawEl.textContent = rawTaf || 'No TAF available';
   if (!decodedEl || !rawTaf) return;
@@ -198,85 +171,6 @@ function tafLine(grp: TafGroup): string {
   if (grp.clouds) parts.push(grp.clouds);
   if (grp.wx) parts.push(grp.wx);
   return '<span>' + parts.join(' | ') + '</span>';
-}
-
-// ---- TAF Parser ----
-
-export function parseTaf(raw: string | null): ParsedTaf {
-  const result: ParsedTaf = { validity: null, base: null, tempMax: null, tempMin: null, changes: [] };
-  if (!raw) return result;
-
-  const text = raw.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim();
-
-  const valMatch = text.match(/\b(\d{4}\/\d{4})\b/);
-  if (valMatch && valMatch[1]) {
-    const v = valMatch[1];
-    result.validity =
-      v.slice(0, 2) + 'd ' + v.slice(2, 4) + 'Z → ' + v.slice(5, 7) + 'd ' + v.slice(7, 9) + 'Z';
-  }
-
-  const txMatch = text.match(/TX(\d{2})\/(\d{4}Z)/);
-  if (txMatch) result.tempMax = txMatch[1] + '°C @ ' + txMatch[2];
-
-  const tnMatch = text.match(/TN(\d{2})\/(\d{4}Z)/);
-  if (tnMatch) result.tempMin = tnMatch[1] + '°C @ ' + tnMatch[2];
-
-  const parts = text.split(/\s+(TEMPO|BECMG|FM\d{6}|PROB\d{2}\s+TEMPO|PROB\d{2})\s+/);
-
-  if (parts[0]) {
-    result.base = parseWeatherTokens(parts[0]);
-  }
-
-  for (let i = 1; i < parts.length; i += 2) {
-    const type = parts[i];
-    const content = parts[i + 1] || '';
-    const chg = parseWeatherTokens(content);
-    chg.type = type;
-    if (chg.wind || chg.vis || chg.clouds || chg.wx) {
-      result.changes.push(chg);
-    }
-  }
-
-  return result;
-}
-
-function parseWeatherTokens(text: string): TafGroup {
-  const r: TafGroup = { wind: null, vis: null, clouds: null, wx: null };
-
-  const wm = text.match(/(VRB|\d{3})(\d{2,3})(G(\d{2,3}))?KT/);
-  if (wm) {
-    const dir = wm[1] === 'VRB' ? 'VRB' : wm[1] + '°';
-    const gust = wm[4] ? ' G' + wm[4] : '';
-    r.wind = dir + '/' + wm[2] + 'kt' + gust;
-  }
-
-  if (text.indexOf('CAVOK') !== -1) {
-    r.vis = 'CAVOK';
-  } else {
-    const vm = text.match(/\b(\d{4})\b/);
-    if (vm && vm[1] && parseInt(vm[1]) <= 9999) {
-      const m = parseInt(vm[1]);
-      r.vis = m >= 9999 ? '>10 km' : (m / 1000).toFixed(1) + ' km';
-    }
-  }
-
-  const cloudMatches = text.match(/(FEW|SCT|BKN|OVC)(\d{3})/g);
-  if (cloudMatches) {
-    r.clouds = cloudMatches
-      .map((c) => {
-        const cov = c.slice(0, 3);
-        const alt = parseInt(c.slice(3)) * 100;
-        return cov + ' ' + alt + 'ft';
-      })
-      .join(' ');
-  }
-
-  const wxPatterns = text.match(/[-+]?(RA|SN|DZ|FG|BR|HZ|TS|SH|GR|SQ|FC|SS|DS|FZ|MI|PR|BC|BL|DR|VC)+/g);
-  if (wxPatterns) {
-    r.wx = wxPatterns.join(' ');
-  }
-
-  return r;
 }
 
 // ---- Helpers ----

--- a/services/controller_hmi_service/frontend/src/legacy/wind.ts
+++ b/services/controller_hmi_service/frontend/src/legacy/wind.ts
@@ -1,6 +1,7 @@
 // wind.ts — paired runway wind widget with safety alerts.
 
 import type { Metar } from '../types/api';
+import { checkWindLimits, computeWindComponents } from '../wind/calc';
 
 export interface RunwayGroup {
   hdg: number;
@@ -327,11 +328,7 @@ function updateCardWind(card: HTMLElement, rwyHdg: number): void {
   if (speedSvg) speedSvg.textContent = windState.hasData ? String(speed) : '--';
 
   // Wind components for this runway heading
-  const angleDiff = ((dir - rwyHdg) * Math.PI) / 180;
-  const headwind = Math.round(speed * Math.cos(angleDiff));
-  const crosswind = Math.round(Math.abs(speed * Math.sin(angleDiff)));
-  const tailwind = headwind < 0 ? Math.abs(headwind) : 0;
-  const hwDisplay = headwind >= 0 ? headwind : 0;
+  const { crosswind, tailwind, hwDisplay } = computeWindComponents(dir, speed, rwyHdg);
 
   // Update XW bar
   updateLimitBar('xw-' + rwyHdg, crosswind, windState.XW_LIMIT);
@@ -350,9 +347,9 @@ function updateCardWind(card: HTMLElement, rwyHdg: number): void {
 
   const alertEl = document.getElementById('rwy-alert-' + rwyHdg);
   if (alertEl) {
-    if (crosswind > windState.XW_LIMIT || tailwind > windState.TW_LIMIT) {
-      const msg = crosswind > windState.XW_LIMIT ? 'XW LIMIT EXCEEDED' : 'TW LIMIT EXCEEDED';
-      alertEl.textContent = msg;
+    const limits = checkWindLimits(crosswind, tailwind, windState.XW_LIMIT, windState.TW_LIMIT);
+    if (limits.exceeded) {
+      alertEl.textContent = limits.message ?? '';
       alertEl.classList.remove('hidden');
     } else {
       alertEl.classList.add('hidden');

--- a/services/controller_hmi_service/frontend/src/smr/projection.test.ts
+++ b/services/controller_hmi_service/frontend/src/smr/projection.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AirportGraph } from '../types/api';
+import {
+  bearingDeg,
+  computeSmrBounds,
+  geoToSVG,
+  leaderAttachPoint,
+  projectGeoFromBearing,
+} from './projection';
+
+// Minimal graph around Santiago (LEST-ish latitudes) — a 0.02° square.
+const GRAPH: AirportGraph = {
+  nodes: {
+    n1: { lat: 42.89, lon: -8.43 },
+    n2: { lat: 42.91, lon: -8.41 },
+  },
+  edges: [{ from: 'n1', to: 'n2' }],
+  stands: [{ name: 'S1', lat: 42.9, lon: -8.42 }],
+  runways: [
+    {
+      end1: { designator: '17', lat: 42.9118, lon: -8.4203 },
+      end2: { designator: '35', lat: 42.8895, lon: -8.4143 },
+    },
+  ],
+};
+
+describe('computeSmrBounds', () => {
+  it('wraps all coordinates with an 8% margin and cosine correction', () => {
+    const b = computeSmrBounds(GRAPH)!;
+    expect(b).not.toBeNull();
+    expect(b.minLat).toBeLessThan(42.89);
+    expect(b.maxLat).toBeGreaterThan(42.91);
+    expect(b.minLon).toBeLessThan(-8.43);
+    expect(b.maxLon).toBeGreaterThan(-8.41);
+    expect(b.cosLat).toBeCloseTo(Math.cos((42.9 * Math.PI) / 180), 3);
+  });
+
+  it('returns null for an empty graph', () => {
+    expect(computeSmrBounds({ nodes: {}, edges: [], stands: [], runways: [] })).toBeNull();
+  });
+});
+
+describe('geoToSVG', () => {
+  const bounds = computeSmrBounds(GRAPH)!;
+
+  it('falls back to the viewBox centre without bounds', () => {
+    expect(geoToSVG(null, 42.9, -8.42)).toEqual({ x: 50, y: 50 });
+  });
+
+  it('maps the bounds centre to the viewBox centre', () => {
+    const p = geoToSVG(bounds, (bounds.minLat + bounds.maxLat) / 2, (bounds.minLon + bounds.maxLon) / 2);
+    expect(p.x).toBeCloseTo(50, 5);
+    expect(p.y).toBeCloseTo(50, 5);
+  });
+
+  it('maps north to the top (higher latitude → smaller y)', () => {
+    const north = geoToSVG(bounds, 42.91, -8.42);
+    const south = geoToSVG(bounds, 42.89, -8.42);
+    expect(north.y).toBeLessThan(south.y);
+  });
+
+  it('keeps every graph coordinate inside the padded viewBox', () => {
+    for (const n of Object.values(GRAPH.nodes)) {
+      const p = geoToSVG(bounds, n.lat, n.lon);
+      expect(p.x).toBeGreaterThanOrEqual(0);
+      expect(p.x).toBeLessThanOrEqual(100);
+      expect(p.y).toBeGreaterThanOrEqual(0);
+      expect(p.y).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
+describe('bearingDeg', () => {
+  it('is 0 due north and 90 due east', () => {
+    expect(bearingDeg(42.9, -8.42, 43.0, -8.42)).toBeCloseTo(0, 0);
+    expect(bearingDeg(0, 0, 0, 1)).toBeCloseTo(90, 0);
+  });
+
+  it('matches the runway 17 orientation (~south-southeast)', () => {
+    const brg = bearingDeg(
+      GRAPH.runways[0]!.end2.lat,
+      GRAPH.runways[0]!.end2.lon,
+      GRAPH.runways[0]!.end1.lat,
+      GRAPH.runways[0]!.end1.lon,
+    );
+    // end2 (35) → end1 (17): flying towards ~350°, i.e. landing runway 35's
+    // reciprocal; the value must sit in the north-west quadrant
+    expect(brg).toBeGreaterThan(340);
+    expect(brg).toBeLessThan(360);
+  });
+});
+
+describe('projectGeoFromBearing', () => {
+  it('moves ~1/60 degree of latitude per NM going north', () => {
+    const p = projectGeoFromBearing(42.9, -8.42, 0, 6);
+    expect(p.lat).toBeCloseTo(42.9 + 0.1, 5);
+    expect(p.lon).toBeCloseTo(-8.42, 5);
+  });
+
+  it('round-trips: out along a bearing and back along the reciprocal', () => {
+    const out = projectGeoFromBearing(42.9, -8.42, 73, 5);
+    const back = projectGeoFromBearing(out.lat, out.lon, (73 + 180) % 360, 5);
+    expect(back.lat).toBeCloseTo(42.9, 3);
+    expect(back.lon).toBeCloseTo(-8.42, 3);
+  });
+});
+
+describe('leaderAttachPoint', () => {
+  // Box: x=10..20, y=10..14
+  it('attaches to the left edge when the dot is left of the box', () => {
+    const p = leaderAttachPoint(0, 12, 10, 10, 10, 4);
+    expect(p.x).toBeCloseTo(10, 5);
+    expect(p.y).toBeGreaterThanOrEqual(10);
+    expect(p.y).toBeLessThanOrEqual(14);
+  });
+
+  it('attaches to the top edge when the dot is above the box', () => {
+    const p = leaderAttachPoint(15, 0, 10, 10, 10, 4);
+    expect(p.y).toBeCloseTo(10, 5);
+    expect(p.x).toBeGreaterThanOrEqual(10);
+    expect(p.x).toBeLessThanOrEqual(20);
+  });
+
+  it('degenerates gracefully when the dot is at the box centre', () => {
+    const p = leaderAttachPoint(15, 12, 10, 10, 10, 4);
+    expect(p).toEqual({ x: 10, y: 12 });
+  });
+});

--- a/services/controller_hmi_service/frontend/src/smr/projection.ts
+++ b/services/controller_hmi_service/frontend/src/smr/projection.ts
@@ -1,0 +1,172 @@
+// Pure geographic → SVG projection math for the SMR ground radar.
+// No DOM, no module state — everything takes explicit inputs.
+
+import type { AirportGraph } from '../types/api';
+
+export interface SmrBounds {
+  minLat: number;
+  maxLat: number;
+  minLon: number;
+  maxLon: number;
+  cosLat: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export const SMR_PADDING = 5;
+export const SMR_SIZE = 100;
+
+/** Bounding box of every node/stand/runway end, with margin and the
+ * cosine-of-latitude correction used by the projection. */
+export function computeSmrBounds(graph: AirportGraph): SmrBounds | null {
+  const lats: number[] = [];
+  const lons: number[] = [];
+
+  Object.values(graph.nodes).forEach((n) => {
+    lats.push(n.lat);
+    lons.push(n.lon);
+  });
+  graph.stands.forEach((s) => {
+    lats.push(s.lat);
+    lons.push(s.lon);
+  });
+  graph.runways.forEach((r) => {
+    lats.push(r.end1.lat, r.end2.lat);
+    lons.push(r.end1.lon, r.end2.lon);
+  });
+
+  if (lats.length === 0) return null;
+
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const minLon = Math.min(...lons);
+  const maxLon = Math.max(...lons);
+
+  const latMargin = (maxLat - minLat) * 0.08;
+  const lonMargin = (maxLon - minLon) * 0.08;
+
+  // Cosine correction: at this latitude, 1° lon is shorter than 1° lat
+  const centerLat = (minLat + maxLat) / 2;
+  const cosLat = Math.cos((centerLat * Math.PI) / 180);
+
+  return {
+    minLat: minLat - latMargin,
+    maxLat: maxLat + latMargin,
+    minLon: minLon - lonMargin,
+    maxLon: maxLon + lonMargin,
+    cosLat,
+  };
+}
+
+/** Convert GPS lat/lon to SVG x/y (0-100 viewBox), preserving aspect ratio.
+ * North (high latitude) maps to the top. */
+export function geoToSVG(bounds: SmrBounds | null, lat: number, lon: number): Point {
+  if (!bounds) return { x: 50, y: 50 };
+
+  const dLat = bounds.maxLat - bounds.minLat;
+  const dLon = (bounds.maxLon - bounds.minLon) * bounds.cosLat;
+
+  const usable = SMR_SIZE - 2 * SMR_PADDING;
+  const scale = usable / Math.max(dLat, dLon);
+
+  const mapW = dLon * scale;
+  const mapH = dLat * scale;
+  const offX = SMR_PADDING + (usable - mapW) / 2;
+  const offY = SMR_PADDING + (usable - mapH) / 2;
+
+  const x = offX + (lon - bounds.minLon) * bounds.cosLat * scale;
+  const y = offY + (bounds.maxLat - lat) * scale;
+  return { x, y };
+}
+
+/** Project a new geographic point from (lat, lon) along a bearing for a
+ * distance in nautical miles (flat-earth approximation, fine at SMR range). */
+export function projectGeoFromBearing(
+  lat: number,
+  lon: number,
+  bearingDeg: number,
+  distNm: number,
+): { lat: number; lon: number } {
+  const br = (bearingDeg * Math.PI) / 180;
+  const dLat = (distNm / 60) * Math.cos(br);
+  const latRad = (lat * Math.PI) / 180;
+  const dLon = ((distNm / 60) * Math.sin(br)) / Math.cos(latRad);
+  return { lat: lat + dLat, lon: lon + dLon };
+}
+
+/** Great-circle initial bearing (degrees 0-360) from point 1 to point 2. */
+export function bearingDeg(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const l1 = (lat1 * Math.PI) / 180;
+  const l2 = (lat2 * Math.PI) / 180;
+  const dl = ((lon2 - lon1) * Math.PI) / 180;
+  const y = Math.sin(dl) * Math.cos(l2);
+  const x = Math.cos(l1) * Math.sin(l2) - Math.sin(l1) * Math.cos(l2) * Math.cos(dl);
+  return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+}
+
+/** Point on the label-box boundary nearest to the aircraft dot, found by
+ * ray-casting from the box centre toward the dot. */
+export function leaderAttachPoint(
+  dotX: number,
+  dotY: number,
+  boxX: number,
+  boxY: number,
+  boxW: number,
+  boxH: number,
+): Point {
+  const cx = boxX + boxW / 2;
+  const cy = boxY + boxH / 2;
+  const vx = dotX - cx;
+  const vy = dotY - cy;
+  if (vx === 0 && vy === 0) return { x: boxX, y: cy };
+
+  let tMin = Infinity,
+    bestX = boxX,
+    bestY = cy;
+  let t: number, iy: number, ix: number;
+
+  if (vx !== 0) {
+    t = (boxX - cx) / vx;
+    if (t > 0) {
+      iy = cy + t * vy;
+      if (iy >= boxY && iy <= boxY + boxH && t < tMin) {
+        tMin = t;
+        bestX = boxX;
+        bestY = iy;
+      }
+    }
+    t = (boxX + boxW - cx) / vx;
+    if (t > 0) {
+      iy = cy + t * vy;
+      if (iy >= boxY && iy <= boxY + boxH && t < tMin) {
+        tMin = t;
+        bestX = boxX + boxW;
+        bestY = iy;
+      }
+    }
+  }
+  if (vy !== 0) {
+    t = (boxY - cy) / vy;
+    if (t > 0) {
+      ix = cx + t * vx;
+      if (ix >= boxX && ix <= boxX + boxW && t < tMin) {
+        tMin = t;
+        bestX = ix;
+        bestY = boxY;
+      }
+    }
+    t = (boxY + boxH - cy) / vy;
+    if (t > 0) {
+      ix = cx + t * vx;
+      if (ix >= boxX && ix <= boxX + boxW && t < tMin) {
+        tMin = t;
+        bestX = ix;
+        bestY = boxY + boxH;
+      }
+    }
+  }
+  return { x: bestX, y: bestY };
+}

--- a/services/controller_hmi_service/frontend/src/weather/taf.test.ts
+++ b/services/controller_hmi_service/frontend/src/weather/taf.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractTafPortion, parseTaf, parseWeatherTokens } from './taf';
+
+const LEST_TAF =
+  'TAF LEST 041100Z 0412/0512 17010KT 9999 SCT020 BKN035 ' +
+  'TX18/0414Z TN09/0506Z ' +
+  'TEMPO 0412/0418 17015G25KT 4000 RA BKN012 ' +
+  'BECMG 0418/0420 25008KT CAVOK';
+
+describe('extractTafPortion', () => {
+  it('strips METAR noise before the TAF token', () => {
+    const mixed = 'METAR LEST 041030Z 17008KT 9999 FEW020\n' + LEST_TAF;
+    expect(extractTafPortion(mixed).startsWith('TAF LEST')).toBe(true);
+  });
+
+  it('returns the input unchanged when no TAF token exists', () => {
+    expect(extractTafPortion('no forecast here')).toBe('no forecast here');
+  });
+});
+
+describe('parseTaf', () => {
+  const parsed = parseTaf(LEST_TAF);
+
+  it('extracts the validity window', () => {
+    expect(parsed.validity).toBe('04d 12Z → 05d 12Z');
+  });
+
+  it('extracts TX/TN', () => {
+    expect(parsed.tempMax).toBe('18°C @ 0414Z');
+    expect(parsed.tempMin).toBe('09°C @ 0506Z');
+  });
+
+  it('parses the base group', () => {
+    expect(parsed.base?.wind).toBe('170°/10kt');
+    expect(parsed.base?.clouds).toBe('SCT 2000ft BKN 3500ft');
+  });
+
+  it('parses TEMPO and BECMG change groups in order', () => {
+    expect(parsed.changes).toHaveLength(2);
+    expect(parsed.changes[0]?.type).toBe('TEMPO');
+    expect(parsed.changes[0]?.wind).toBe('170°/15kt G25');
+    // Known quirk inherited from the original parser: the change-group time
+    // window (0412/0418) matches the 4-digit visibility regex before the
+    // real visibility token (4000) does. Pinned here so a future fix is a
+    // conscious behavior change, not an accident.
+    expect(parsed.changes[0]?.vis).toBe('0.4 km');
+    expect(parsed.changes[0]?.wx).toContain('RA');
+    expect(parsed.changes[1]?.type).toBe('BECMG');
+    expect(parsed.changes[1]?.vis).toBe('CAVOK');
+  });
+
+  it('handles null input', () => {
+    const empty = parseTaf(null);
+    expect(empty.base).toBeNull();
+    expect(empty.changes).toEqual([]);
+  });
+});
+
+describe('parseWeatherTokens', () => {
+  it('parses variable wind', () => {
+    expect(parseWeatherTokens('VRB03KT 9999').wind).toBe('VRB/03kt');
+  });
+
+  it('parses CAVOK over numeric visibility', () => {
+    expect(parseWeatherTokens('25010KT CAVOK').vis).toBe('CAVOK');
+  });
+
+  it('renders 9999 as >10 km', () => {
+    expect(parseWeatherTokens('25010KT 9999').vis).toBe('>10 km');
+  });
+
+  it('collects weather phenomena with intensity prefix', () => {
+    expect(parseWeatherTokens('17015KT 2000 -RA BR').wx).toContain('-RA');
+  });
+});

--- a/services/controller_hmi_service/frontend/src/weather/taf.ts
+++ b/services/controller_hmi_service/frontend/src/weather/taf.ts
@@ -1,0 +1,111 @@
+// Pure TAF parsing (no DOM).
+
+export interface TafGroup {
+  wind: string | null;
+  vis: string | null;
+  clouds: string | null;
+  wx: string | null;
+  type?: string;
+}
+
+export interface ParsedTaf {
+  validity: string | null;
+  base: TafGroup | null;
+  tempMax: string | null;
+  tempMin: string | null;
+  changes: TafGroup[];
+}
+
+/** Trim leading METAR noise: keep everything from the first "TAF " token. */
+export function extractTafPortion(rawTaf: string): string {
+  const tafMatch = rawTaf.match(/(^|\n)(TAF\s)/);
+  if (tafMatch && tafMatch.index !== undefined) {
+    return rawTaf.substring(tafMatch.index + (tafMatch[1] ? tafMatch[1].length : 0));
+  }
+  const idx = rawTaf.indexOf('TAF ');
+  if (idx !== -1) return rawTaf.substring(idx);
+  return rawTaf;
+}
+
+export function parseTaf(raw: string | null): ParsedTaf {
+  const result: ParsedTaf = {
+    validity: null,
+    base: null,
+    tempMax: null,
+    tempMin: null,
+    changes: [],
+  };
+  if (!raw) return result;
+
+  const text = raw.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim();
+
+  const valMatch = text.match(/\b(\d{4}\/\d{4})\b/);
+  if (valMatch && valMatch[1]) {
+    const v = valMatch[1];
+    result.validity =
+      v.slice(0, 2) + 'd ' + v.slice(2, 4) + 'Z → ' + v.slice(5, 7) + 'd ' + v.slice(7, 9) + 'Z';
+  }
+
+  const txMatch = text.match(/TX(\d{2})\/(\d{4}Z)/);
+  if (txMatch) result.tempMax = txMatch[1] + '°C @ ' + txMatch[2];
+
+  const tnMatch = text.match(/TN(\d{2})\/(\d{4}Z)/);
+  if (tnMatch) result.tempMin = tnMatch[1] + '°C @ ' + tnMatch[2];
+
+  const parts = text.split(/\s+(TEMPO|BECMG|FM\d{6}|PROB\d{2}\s+TEMPO|PROB\d{2})\s+/);
+
+  if (parts[0]) {
+    result.base = parseWeatherTokens(parts[0]);
+  }
+
+  for (let i = 1; i < parts.length; i += 2) {
+    const type = parts[i];
+    const content = parts[i + 1] || '';
+    const chg = parseWeatherTokens(content);
+    chg.type = type;
+    if (chg.wind || chg.vis || chg.clouds || chg.wx) {
+      result.changes.push(chg);
+    }
+  }
+
+  return result;
+}
+
+export function parseWeatherTokens(text: string): TafGroup {
+  const r: TafGroup = { wind: null, vis: null, clouds: null, wx: null };
+
+  const wm = text.match(/(VRB|\d{3})(\d{2,3})(G(\d{2,3}))?KT/);
+  if (wm) {
+    const dir = wm[1] === 'VRB' ? 'VRB' : wm[1] + '°';
+    const gust = wm[4] ? ' G' + wm[4] : '';
+    r.wind = dir + '/' + wm[2] + 'kt' + gust;
+  }
+
+  if (text.indexOf('CAVOK') !== -1) {
+    r.vis = 'CAVOK';
+  } else {
+    const vm = text.match(/\b(\d{4})\b/);
+    if (vm && vm[1] && parseInt(vm[1]) <= 9999) {
+      const m = parseInt(vm[1]);
+      r.vis = m >= 9999 ? '>10 km' : (m / 1000).toFixed(1) + ' km';
+    }
+  }
+
+  const cloudMatches = text.match(/(FEW|SCT|BKN|OVC)(\d{3})/g);
+  if (cloudMatches) {
+    r.clouds = cloudMatches
+      .map((c) => {
+        const cov = c.slice(0, 3);
+        const alt = parseInt(c.slice(3)) * 100;
+        return cov + ' ' + alt + 'ft';
+      })
+      .join(' ');
+  }
+
+  const wxPatterns = text.match(/[-+]?(RA|SN|DZ|FG|BR|HZ|TS|SH|GR|SQ|FC|SS|DS|FZ|MI|PR|BC|BL|DR|VC)+/g);
+  if (wxPatterns) {
+    r.wx = wxPatterns.join(' ');
+  }
+
+  return r;
+}

--- a/services/controller_hmi_service/frontend/src/wind/calc.test.ts
+++ b/services/controller_hmi_service/frontend/src/wind/calc.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkWindLimits, computeWindComponents } from './calc';
+
+describe('computeWindComponents', () => {
+  it('pure headwind when wind is aligned with the runway', () => {
+    const c = computeWindComponents(170, 20, 170);
+    expect(c.headwind).toBe(20);
+    expect(c.crosswind).toBe(0);
+    expect(c.tailwind).toBe(0);
+    expect(c.hwDisplay).toBe(20);
+  });
+
+  it('pure tailwind when wind is opposite the runway', () => {
+    const c = computeWindComponents(350, 12, 170);
+    expect(c.headwind).toBe(-12);
+    expect(c.tailwind).toBe(12);
+    expect(c.hwDisplay).toBe(0);
+    expect(c.crosswind).toBe(0);
+  });
+
+  it('pure crosswind at 90°', () => {
+    const c = computeWindComponents(260, 15, 170);
+    expect(c.crosswind).toBe(15);
+    expect(Math.abs(c.headwind)).toBeLessThanOrEqual(1); // rounding
+  });
+
+  it('45° split: components are speed·cos(45) rounded', () => {
+    const c = computeWindComponents(215, 20, 170);
+    expect(c.headwind).toBe(14);
+    expect(c.crosswind).toBe(14);
+  });
+
+  it('handles wrap-around directions (350° wind on runway 010)', () => {
+    const c = computeWindComponents(350, 10, 10);
+    expect(c.headwind).toBe(9); // 20° off-axis
+    expect(c.crosswind).toBe(3);
+  });
+});
+
+describe('checkWindLimits', () => {
+  it('flags crosswind first', () => {
+    expect(checkWindLimits(25, 10, 20, 5)).toEqual({
+      exceeded: true,
+      message: 'XW LIMIT EXCEEDED',
+    });
+  });
+
+  it('flags tailwind when crosswind is within limits', () => {
+    expect(checkWindLimits(10, 7, 20, 5)).toEqual({
+      exceeded: true,
+      message: 'TW LIMIT EXCEEDED',
+    });
+  });
+
+  it('passes at the exact limit', () => {
+    expect(checkWindLimits(20, 5, 20, 5)).toEqual({ exceeded: false, message: null });
+  });
+});

--- a/services/controller_hmi_service/frontend/src/wind/calc.ts
+++ b/services/controller_hmi_service/frontend/src/wind/calc.ts
@@ -1,0 +1,44 @@
+// Pure wind-component math for the runway wind widget.
+
+export interface WindComponents {
+  /** Signed headwind (negative = tailwind), as displayed component. */
+  headwind: number;
+  /** Absolute crosswind component. */
+  crosswind: number;
+  /** Tailwind (0 when headwind). */
+  tailwind: number;
+  /** Headwind clamped to 0 for display. */
+  hwDisplay: number;
+}
+
+/** Decompose wind (direction °, speed kt) onto a runway heading. */
+export function computeWindComponents(
+  windDirectionDeg: number,
+  windSpeedKt: number,
+  runwayHeadingDeg: number,
+): WindComponents {
+  const angleDiff = ((windDirectionDeg - runwayHeadingDeg) * Math.PI) / 180;
+  const headwind = Math.round(windSpeedKt * Math.cos(angleDiff));
+  const crosswind = Math.round(Math.abs(windSpeedKt * Math.sin(angleDiff)));
+  const tailwind = headwind < 0 ? Math.abs(headwind) : 0;
+  const hwDisplay = headwind >= 0 ? headwind : 0;
+  return { headwind, crosswind, tailwind, hwDisplay };
+}
+
+export interface LimitCheck {
+  exceeded: boolean;
+  message: string | null;
+}
+
+/** Alert message when crosswind/tailwind exceed their limits (XW first,
+ * mirroring the original widget behavior). */
+export function checkWindLimits(
+  crosswind: number,
+  tailwind: number,
+  xwLimit: number,
+  twLimit: number,
+): LimitCheck {
+  if (crosswind > xwLimit) return { exceeded: true, message: 'XW LIMIT EXCEEDED' };
+  if (tailwind > twLimit) return { exceeded: true, message: 'TW LIMIT EXCEEDED' };
+  return { exceeded: false, message: null };
+}

--- a/services/controller_hmi_service/frontend/vitest.config.ts
+++ b/services/controller_hmi_service/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node', // pure-logic tests; switch per-file to happy-dom when DOM is needed
+  },
+});


### PR DESCRIPTION
## Summary

First Phase-3 slice of epic #59. The HMI frontend gets its first tests ever: pure logic is extracted out of the DOM-bound modules into leaf modules and covered with 53 Vitest tests.

## Changes

- **`src/smr/projection.ts`** — geographic→SVG projection (`computeSmrBounds`, `geoToSVG` with explicit bounds, `projectGeoFromBearing`, `bearingDeg`, `leaderAttachPoint`). Tests: bounds/margins, centre mapping, north-up orientation, bearing round-trips, leader-line edge attachment.
- **`src/wind/calc.ts`** — head/cross/tailwind decomposition + limit checks. Tests incl. wrap-around headings and the 45° split.
- **`src/efs/format.ts` / `ordering.ts`** — strip formatters (FL/speed/time/squawk/route) and ordering (`sortFlightPlans`, `sortByUserOrder`, immutable `moveInOrder`). Tests incl. squawk determinism and 0-7 digit validity.
- **`src/weather/taf.ts`** — TAF parser + token parser + METAR-noise stripper, table-tested with a realistic LEST TAF. One pre-existing parser quirk (change-group time window shadows the visibility token) is **pinned by a test** with a comment so a future fix is deliberate.
- Consumers (`app`, `wind`, `efs`, `weather`) rewired to the pure modules; duplicated local code deleted.
- Vitest wired into the CI frontend job (`npm test`).

## Verification

53 Vitest tests green; typecheck / lint (0 warnings) / build green; DOM-contract pytest green.

Part of #59.