### PR TITLE
feat(taxi): strict taxiway routing with straight centerline join (1/4)

### DIFF
--- a/plugins/GND/graph.py
+++ b/plugins/GND/graph.py
@@ -3,6 +3,44 @@ import re
 import networkx as nx
 import math
 
+EARTH_R_M = 6371000.0
+
+
+def project_point_to_segment(
+    lat: float, lon: float,
+    lat_a: float, lon_a: float,
+    lat_b: float, lon_b: float,
+) -> tuple[float, float, float, float]:
+    """Perpendicular foot of point P on the (infinite) line through A-B.
+
+    Uses a local equirectangular plane centred at A, accurate enough at
+    airport scale (segments of tens to hundreds of metres).
+
+    Returns (foot_lat, foot_lon, perp_dist_m, t) where t is the along-track
+    parameter: t=0 at A, t=1 at B. t is NOT clamped — t<0 / t>1 means the
+    foot falls beyond an endpoint; the caller decides whether to extend the
+    segment ("prolong the line") or clamp to it.
+    """
+    cos_lat = math.cos(math.radians((lat_a + lat) / 2.0))
+    px = math.radians(lon - lon_a) * cos_lat * EARTH_R_M
+    py = math.radians(lat - lat_a) * EARTH_R_M
+    bx = math.radians(lon_b - lon_a) * cos_lat * EARTH_R_M
+    by = math.radians(lat_b - lat_a) * EARTH_R_M
+
+    seg_len_sq = bx * bx + by * by
+    if seg_len_sq < 1e-9:
+        # Degenerate zero-length segment: the foot is A itself.
+        dx = math.hypot(px, py)
+        return lat_a, lon_a, dx, 0.0
+
+    t = (px * bx + py * by) / seg_len_sq
+    foot_x = t * bx
+    foot_y = t * by
+    perp_dist = math.hypot(px - foot_x, py - foot_y)
+    foot_lat = lat_a + math.degrees(foot_y / EARTH_R_M)
+    foot_lon = lon_a + math.degrees(foot_x / (cos_lat * EARTH_R_M))
+    return foot_lat, foot_lon, perp_dist, t
+
 
 class AirportGraph:
     """Create a directed graph to get shortest routes in an airport"""
@@ -29,6 +67,7 @@ class AirportGraph:
         # Lookup indices populated in _build_graph
         self._nodes_by_name: dict[str, list[str]] = {}
         self._nodes_by_taxiway: dict[str, list[str]] = {}
+        self._edges_by_taxiway: dict[str, set[tuple[str, str]]] = {}
         self._stands_by_id: dict[str, dict] = {}
         self._runways_by_id: dict[str, tuple[float, float]] = {}
 
@@ -105,6 +144,12 @@ class AirportGraph:
                         bucket.append(start_id)
                     if end_id not in bucket:
                         bucket.append(end_id)
+                    # Index directed edges by taxiway_id for strict routing
+                    # (both directions for twoway, matching the edges added above)
+                    edge_bucket = self._edges_by_taxiway.setdefault(key, set())
+                    edge_bucket.add((start_id, end_id))
+                    if direction == 'twoway':
+                        edge_bucket.add((end_id, start_id))
 
         # Index stands by a normalised stand_id string. The parser stores
         # stand_id as a Python list-literal string ("['Gate', '224']") so we
@@ -171,7 +216,7 @@ class AirportGraph:
                 min_distance = distance
                 nearest_node = node_id
 
-        return nearest_node, min_distance if nearest_node else (None, None)
+        return (nearest_node, min_distance) if nearest_node else (None, None)
     
     def find_shortest_path(
         self, 
@@ -234,6 +279,37 @@ class AirportGraph:
             self.graph, start_node_id, end_node_id,
             heuristic=heuristic, weight='weight',
         )
+
+    def taxiway_subgraph(self, taxiway_id: str) -> nx.DiGraph:
+        """Read-only view of the graph restricted to the edges of one taxiway.
+
+        Returns a networkx subgraph view containing only the directed edges
+        whose ``taxiway_id`` matches (case-insensitive). Used by strict
+        routing to keep A* on the authorized taxiway.
+        """
+        key = str(taxiway_id).upper()
+        edges = self._edges_by_taxiway.get(key, set())
+        return nx.subgraph_view(
+            self.graph,
+            filter_edge=lambda u, v: (u, v) in edges,
+        )
+
+    def taxiway_intersections(self, tw_a: str, tw_b: str) -> list:
+        """Node ids where taxiways ``tw_a`` and ``tw_b`` meet.
+
+        A node is an intersection when it is an endpoint of at least one
+        edge of each taxiway. Returns [] when the taxiways do not touch or
+        either is unknown.
+        """
+        def endpoints(tw: str) -> set:
+            edges = self._edges_by_taxiway.get(str(tw).upper(), set())
+            nodes: set = set()
+            for u, v in edges:
+                nodes.add(u)
+                nodes.add(v)
+            return nodes
+
+        return sorted(endpoints(tw_a) & endpoints(tw_b))
 
     def _find_nearest_via_start(
         self, start_lat: float, start_lon: float, via: list
@@ -461,6 +537,378 @@ class AirportGraph:
                 "token": end_token,
             },
         }
+
+    # Maximum length of the unconstrained hop from the last taxiway to a
+    # destination that is not on it (e.g. a runway threshold node). Longer
+    # hops mean the strict route would leave the authorized sequence for a
+    # significant distance, so we fail instead.
+    MAX_EXIT_HOP_M = 1000.0
+
+    # Maximum perpendicular distance from the aircraft position to the first
+    # authorized taxiway's centerline. Beyond this the strict route fails
+    # ("unable to reach taxiway X") instead of wandering across the graph.
+    MAX_ENTRY_JOIN_M = 500.0
+
+    # How far a taxiway segment may be prolonged beyond its endpoint when the
+    # perpendicular foot falls past the segment end, so the aircraft still
+    # joins the taxiway line straight instead of cutting diagonally to a node.
+    MAX_ENTRY_EXTENSION_M = 150.0
+
+    def _dijkstra_to_nearest(self, graph, source: str, targets: set):
+        """Shortest path from ``source`` to the closest reachable node of
+        ``targets`` within ``graph``. Returns (path, distance) or (None, None)
+        when no target is reachable."""
+        if source in targets:
+            return [source], 0.0
+        try:
+            lengths = nx.single_source_dijkstra_path_length(
+                graph, source, weight='weight',
+            )
+        except nx.NodeNotFound:
+            return None, None
+        reachable = [t for t in targets if t in lengths]
+        if not reachable:
+            return None, None
+        best = min(reachable, key=lambda t: lengths[t])
+        return nx.dijkstra_path(graph, source, best, weight='weight'), lengths[best]
+
+    def _join_taxiway_entry(self, lat: float, lon: float, taxiway: str,
+                            targets: set):
+        """Straight centerline join onto ``taxiway`` from a raw position.
+
+        Projects (lat, lon) perpendicularly onto each directed edge of the
+        taxiway; the foot may be prolonged up to MAX_ENTRY_EXTENSION_M beyond
+        a segment endpoint so the aircraft still joins the taxiway line
+        straight instead of cutting diagonally to a node. A candidate edge is
+        feasible when driving toward its end node can reach one of ``targets``
+        along the taxiway itself (this also rejects wrong-way one-way edges
+        and disconnected segments that share the taxiway name). Candidates
+        are ranked by perpendicular join distance first — the aircraft always
+        joins the geometrically nearest feasible stretch of the taxiway, never
+        a farther one that would shorten the total path — and the driving
+        direction along the taxiway is the tie-breaker (along-track + leg to
+        the nearest target).
+
+        Returns {"foot": (lat, lon), "entry_node": node_id,
+        "entry_dist_m": float, "along_m": float} or None when no feasible
+        edge lies within MAX_ENTRY_JOIN_M.
+        """
+        key = str(taxiway).upper()
+        edges = self._edges_by_taxiway.get(key, set())
+        if not edges or not targets:
+            return None
+        sub = self.taxiway_subgraph(key)
+        try:
+            dist_to_target = nx.multi_source_dijkstra_path_length(
+                sub.reverse(copy=False), set(targets), weight='weight',
+            )
+        except nx.NodeNotFound:
+            return None
+
+        best = None
+        for u, v in edges:
+            nu, nv = self.graph.nodes[u], self.graph.nodes[v]
+            seg_len = self.graph.edges[u, v].get('weight', 0.0)
+            if seg_len <= 0.0:
+                continue
+            _f_lat, _f_lon, _perp, t = project_point_to_segment(
+                lat, lon, nu['lat'], nu['lon'], nv['lat'], nv['lon'],
+            )
+            ext = self.MAX_ENTRY_EXTENSION_M / seg_len
+            t = max(-ext, min(1.0 + ext, t))
+            join_lat = nu['lat'] + t * (nv['lat'] - nu['lat'])
+            join_lon = nu['lon'] + t * (nv['lon'] - nu['lon'])
+            entry_dist = self._calculate_distance(lat, lon, join_lat, join_lon)
+            if entry_dist > self.MAX_ENTRY_JOIN_M:
+                continue
+            # Driving toward v, the first node crossed is u when the foot
+            # lies on the prolongation before u, otherwise v.
+            entry_node = u if t <= 0.0 else v
+            if entry_node not in dist_to_target:
+                continue
+            en = self.graph.nodes[entry_node]
+            along = self._calculate_distance(join_lat, join_lon, en['lat'], en['lon'])
+            # Rank: nearest feasible stretch first, then cheapest continuation,
+            # then the entry node closest to the foot (breaks the tie between
+            # collinear segments whose prolongations claim the same foot).
+            # Distances are quantized to 0.1 m so float noise between
+            # collinear candidates cannot mask the tie-breakers.
+            cost = (
+                round(entry_dist, 1),
+                round(along + dist_to_target[entry_node], 1),
+                along,
+            )
+            if best is None or cost < best[0]:
+                best = (cost, {
+                    "foot": (join_lat, join_lon),
+                    "entry_node": entry_node,
+                    "entry_dist_m": entry_dist,
+                    "along_m": along,
+                })
+        return best[1] if best else None
+
+    def find_route_strict(
+        self,
+        start_token: str,
+        sequence: list,
+        destination_token: str,
+    ) -> dict:
+        """Compute a taxi route that follows the controller-issued taxiway
+        ``sequence`` strictly, in order, using only edges of the authorized
+        taxiways (issue #67).
+
+        Unlike find_route_via (which treats vias as soft waypoints and
+        stitches legs with unconstrained A*), each leg here is restricted to
+        the subgraph of the taxiway being traversed. Joining the first
+        taxiway is a straight perpendicular hop onto its centerline
+        (_join_taxiway_entry), and only one bounded hop may leave the
+        sequence: from the last taxiway to an off-taxiway destination (e.g.
+        a runway threshold node). No via is ever skipped; unknown or
+        non-connected taxiways fail instead of degrading silently.
+        """
+        start = self.resolve_point(start_token)
+        if start is None:
+            return {"success": False, "error": f"Could not resolve start token: {start_token!r}"}
+        return self._route_strict_core(
+            sequence, destination_token,
+            start_lat=start[1], start_lon=start[2], start_node=start[0],
+            start_meta={
+                "node_id": start[0], "lat": start[1], "lon": start[2],
+                "token": start_token,
+            },
+        )
+
+    def _route_strict_core(
+        self,
+        sequence: list,
+        destination_token: str,
+        *,
+        start_lat: float,
+        start_lon: float,
+        start_node,
+        start_meta: dict,
+    ) -> dict:
+        """Shared core of find_route_strict / find_route_strict_from_position.
+
+        ``start_node`` is the node the aircraft is standing on, or None when
+        routing from a raw position; when it is None or not on the first
+        authorized taxiway, the entry is a straight perpendicular join onto
+        that taxiway's centerline instead of a graph search.
+        """
+        # Collapse consecutive duplicates ("A A B" -> "A B"); non-adjacent
+        # repeats are legitimate and preserved.
+        seq: list[str] = []
+        for tw in sequence or []:
+            key = str(tw).upper()
+            if not seq or seq[-1] != key:
+                seq.append(key)
+        if not seq:
+            return {"success": False, "error": "empty taxiway sequence"}
+
+        for tw in seq:
+            if tw not in self._edges_by_taxiway:
+                return {"success": False, "error": f"unknown taxiway '{tw}'"}
+
+        end = self.resolve_point(destination_token, start_lat, start_lon)
+        if end is None:
+            return {"success": False, "error": f"Could not resolve end token: {destination_token!r}"}
+
+        def tw_nodes(tw: str) -> set:
+            return {n for uv in self._edges_by_taxiway[tw] for n in uv}
+
+        # Entry: no hop at all when already standing on a node of the first
+        # taxiway; otherwise project the position perpendicularly onto the
+        # first taxiway's centerline and join it straight there. Never a
+        # graph search — beyond MAX_ENTRY_JOIN_M the route fails instead.
+        entry_wp = None
+        entry_dist = 0.0
+        entry_along = 0.0
+        if start_node is not None and start_node in tw_nodes(seq[0]):
+            cur = start_node
+        else:
+            if len(seq) > 1:
+                targets = set(self.taxiway_intersections(seq[0], seq[1]))
+                if not targets:
+                    return {
+                        "success": False,
+                        "error": f"taxiway sequence not connected: {seq[0]} -> {seq[1]}",
+                    }
+            elif end[0] in tw_nodes(seq[0]):
+                targets = {end[0]}
+            else:
+                targets = {min(
+                    tw_nodes(seq[0]),
+                    key=lambda n: self._calculate_distance(
+                        self.graph.nodes[n]['lat'], self.graph.nodes[n]['lon'],
+                        end[1], end[2],
+                    ),
+                )}
+            join = self._join_taxiway_entry(start_lat, start_lon, seq[0], targets)
+            if join is None:
+                return {
+                    "success": False,
+                    "error": f"no path from start to taxiway '{seq[0]}'",
+                }
+            entry_wp = {
+                "node_id": "entry",
+                "lat": join["foot"][0],
+                "lon": join["foot"][1],
+                "name": f"{seq[0]} entry",
+            }
+            entry_dist = join["entry_dist_m"]
+            entry_along = join["along_m"]
+            cur = join["entry_node"]
+
+        full_path: list = [cur]
+
+        # Middle legs: travel along T[i] (edges of T[i] only) to a real
+        # intersection with T[i+1].
+        for i in range(len(seq) - 1):
+            here, nxt = seq[i], seq[i + 1]
+            crossings = set(self.taxiway_intersections(here, nxt))
+            if not crossings:
+                return {
+                    "success": False,
+                    "error": f"taxiway sequence not connected: {here} -> {nxt}",
+                }
+            leg_path, _dist = self._dijkstra_to_nearest(
+                self.taxiway_subgraph(here), cur, crossings,
+            )
+            if leg_path is None:
+                return {
+                    "success": False,
+                    "error": f"taxiway sequence not connected: {here} -> {nxt}",
+                }
+            full_path.extend(leg_path[1:])
+            cur = full_path[-1]
+
+        # Final leg: along the last taxiway to its node closest to the
+        # destination, then (if needed) a short bounded exit hop.
+        last = seq[-1]
+        last_sub = self.taxiway_subgraph(last)
+        last_nodes = tw_nodes(last)
+        if end[0] in last_nodes:
+            leg_path, _dist = self._dijkstra_to_nearest(last_sub, cur, {end[0]})
+            if leg_path is None:
+                return {
+                    "success": False,
+                    "error": f"destination not reachable along taxiway '{last}'",
+                }
+            full_path.extend(leg_path[1:])
+        else:
+            try:
+                lengths = nx.single_source_dijkstra_path_length(
+                    last_sub, cur, weight='weight',
+                )
+            except nx.NodeNotFound:
+                lengths = {cur: 0.0}
+            reachable = set(lengths) & last_nodes | {cur}
+            exit_node = min(
+                reachable,
+                key=lambda n: self._calculate_distance(
+                    self.graph.nodes[n]['lat'], self.graph.nodes[n]['lon'],
+                    end[1], end[2],
+                ),
+            )
+            if exit_node != cur:
+                leg_path = nx.dijkstra_path(last_sub, cur, exit_node, weight='weight')
+                full_path.extend(leg_path[1:])
+            # Bounded unconstrained hop off the last taxiway to the destination
+            if exit_node != end[0]:
+                try:
+                    hop = self._astar(exit_node, end[0])
+                except (nx.NetworkXNoPath, nx.NodeNotFound):
+                    return {
+                        "success": False,
+                        "error": f"no path from taxiway '{last}' to destination",
+                    }
+                hop_dist = sum(
+                    self.graph.edges[hop[j], hop[j + 1]].get('weight', 0.0)
+                    for j in range(len(hop) - 1)
+                )
+                if hop_dist > self.MAX_EXIT_HOP_M:
+                    return {
+                        "success": False,
+                        "error": (
+                            f"destination too far from taxiway '{last}' "
+                            f"({hop_dist:.0f}m off the authorized sequence)"
+                        ),
+                    }
+                full_path.extend(hop[1:])
+
+        # Build waypoints, taxiway sequence and total distance (same shape
+        # as find_route_via so router/mover consume it unchanged). The
+        # synthetic entry waypoint (centerline join point) is prepended to
+        # the waypoints only — path_node_ids stays graph-nodes-only.
+        total_distance = entry_along + sum(
+            self.graph.edges[full_path[j], full_path[j + 1]].get('weight', 0.0)
+            for j in range(len(full_path) - 1)
+        )
+        waypoints = []
+        taxiway_sequence: list = []
+        for i, nid in enumerate(full_path):
+            n = self.graph.nodes[nid]
+            waypoints.append({
+                "node_id": nid,
+                "lat": n['lat'],
+                "lon": n['lon'],
+                "name": n.get('name', ''),
+            })
+            if i < len(full_path) - 1:
+                edge = self.graph.edges[nid, full_path[i + 1]]
+                tw = edge.get('taxiway_id')
+                if tw and (not taxiway_sequence or taxiway_sequence[-1] != tw):
+                    taxiway_sequence.append(tw)
+        if entry_wp is not None:
+            waypoints.insert(0, entry_wp)
+
+        return {
+            "success": True,
+            "strict": True,
+            "path_node_ids": full_path,
+            "waypoints": waypoints,
+            "taxiway_sequence": taxiway_sequence,
+            "total_distance_m": round(total_distance, 1),
+            "entry_distance_m": round(entry_dist, 1),
+            "start": start_meta,
+            "end": {
+                "node_id": end[0], "lat": end[1], "lon": end[2],
+                "token": destination_token,
+            },
+        }
+
+    def find_route_strict_from_position(
+        self,
+        start_lat: float,
+        start_lon: float,
+        sequence: list,
+        destination_token: str,
+    ) -> dict:
+        """Strict route from a raw GPS coordinate (issue #67).
+
+        The raw position is NOT snapped to a node for routing: the entry to
+        the first authorized taxiway is a perpendicular projection onto its
+        centerline (_join_taxiway_entry), so the aircraft joins the taxiway
+        straight instead of cutting diagonally to the nearest node. The
+        nearest main-CC node is still used as an off-movement-area guard and
+        reported as ``start`` metadata.
+        """
+        snapped, _snap = self.find_nearest_node(
+            start_lat, start_lon, max_distance=2000.0, restrict_to_main_cc=True,
+        )
+        if snapped is None:
+            return {
+                "success": False,
+                "error": f"No connected node within 2000m of ({start_lat:.6f}, {start_lon:.6f})",
+            }
+        return self._route_strict_core(
+            sequence, destination_token,
+            start_lat=start_lat, start_lon=start_lon, start_node=None,
+            start_meta={
+                "node_id": snapped, "lat": start_lat, "lon": start_lon,
+                "token": snapped,
+            },
+        )
 
     def find_route_from_position(
         self,

--- a/tests/taxi_router/graph_construction/test_airport_graph.py
+++ b/tests/taxi_router/graph_construction/test_airport_graph.py
@@ -2,8 +2,8 @@
 
 Most tests are parametrised over the airport(s) configured in conftest.py
 (currently LEBL) so that the structural invariants are verified on a real,
-large graph. Airport-specific tests (the xfail documenting the
-`find_nearest_node` defect) stay attached to the single `lebl_graph` fixture.
+large graph. Airport-specific tests stay attached to the single `lebl_graph`
+fixture.
 """
 import math
 
@@ -147,14 +147,8 @@ def test_find_nearest_node_restrict_to_main_cc(airport):
     assert found in main_cc
 
 
-# ---- Airport-specific: documented defect (single airport is enough) --------
+# ---- Airport-specific (single airport is enough) ----------------------------
 
-@pytest.mark.xfail(
-    reason="graph.py:174 has a precedence bug: "
-    "`return nearest_node, min_distance if nearest_node else (None, None)` "
-    "returns a nested tuple (None, (None, None)) when no match. "
-    "Bug documented for memoria 5.3.3."
-)
 def test_find_nearest_node_returns_clean_none_when_out_of_range(lebl_graph):
     found, dist = lebl_graph.find_nearest_node(0.0, 0.0, max_distance=1000.0)
     assert found is None

--- a/tests/taxi_router/graph_construction/test_projection.py
+++ b/tests/taxi_router/graph_construction/test_projection.py
@@ -1,0 +1,80 @@
+"""Unit tests for project_point_to_segment (straight centerline join).
+
+The helper returns the perpendicular foot of a point on the infinite line
+through a segment, with the along-track parameter t unclamped so callers can
+prolong the segment ("prolongar la linea") when the foot falls beyond an
+endpoint.
+"""
+import math
+
+import pytest
+
+from plugins.GND.graph import project_point_to_segment
+
+# Metres per degree of latitude on the sphere used by the module (R=6371 km).
+M_PER_DEG = math.pi * 6371000.0 / 180.0
+
+LAT_A, LON_A = 42.8930, -8.4190  # LEST apron area, arbitrary
+
+
+def _offset(lat, lon, north_m, east_m):
+    return (
+        lat + north_m / M_PER_DEG,
+        lon + east_m / (M_PER_DEG * math.cos(math.radians(lat))),
+    )
+
+
+def test_foot_inside_segment():
+    lat_b, lon_b = _offset(LAT_A, LON_A, 0.0, 200.0)  # 200 m due east
+    # Point above the midpoint, 30 m north of the segment.
+    p_lat, p_lon = _offset(LAT_A, LON_A, 30.0, 100.0)
+    f_lat, f_lon, perp, t = project_point_to_segment(
+        p_lat, p_lon, LAT_A, LON_A, lat_b, lon_b,
+    )
+    assert t == pytest.approx(0.5, abs=0.01)
+    assert perp == pytest.approx(30.0, abs=0.5)
+    mid_lat, mid_lon = _offset(LAT_A, LON_A, 0.0, 100.0)
+    assert f_lat == pytest.approx(mid_lat, abs=1e-6)
+    assert f_lon == pytest.approx(mid_lon, abs=1e-6)
+
+
+def test_foot_beyond_endpoint_b_is_not_clamped():
+    lat_b, lon_b = _offset(LAT_A, LON_A, 0.0, 100.0)
+    # 50 m past B along the track, 10 m off the line.
+    p_lat, p_lon = _offset(LAT_A, LON_A, 10.0, 150.0)
+    _f_lat, _f_lon, perp, t = project_point_to_segment(
+        p_lat, p_lon, LAT_A, LON_A, lat_b, lon_b,
+    )
+    assert t == pytest.approx(1.5, abs=0.01)
+    assert perp == pytest.approx(10.0, abs=0.5)
+
+
+def test_foot_before_endpoint_a_is_negative_t():
+    lat_b, lon_b = _offset(LAT_A, LON_A, 0.0, 100.0)
+    p_lat, p_lon = _offset(LAT_A, LON_A, -10.0, -50.0)
+    _f_lat, _f_lon, perp, t = project_point_to_segment(
+        p_lat, p_lon, LAT_A, LON_A, lat_b, lon_b,
+    )
+    assert t == pytest.approx(-0.5, abs=0.01)
+    assert perp == pytest.approx(10.0, abs=0.5)
+
+
+def test_degenerate_zero_length_segment_returns_a():
+    p_lat, p_lon = _offset(LAT_A, LON_A, 30.0, 40.0)
+    f_lat, f_lon, perp, t = project_point_to_segment(
+        p_lat, p_lon, LAT_A, LON_A, LAT_A, LON_A,
+    )
+    assert (f_lat, f_lon) == (LAT_A, LON_A)
+    assert perp == pytest.approx(50.0, abs=0.5)
+    assert t == 0.0
+
+
+def test_endpoint_order_symmetry():
+    lat_b, lon_b = _offset(LAT_A, LON_A, 50.0, 150.0)
+    p_lat, p_lon = _offset(LAT_A, LON_A, 40.0, 60.0)
+    f1 = project_point_to_segment(p_lat, p_lon, LAT_A, LON_A, lat_b, lon_b)
+    f2 = project_point_to_segment(p_lat, p_lon, lat_b, lon_b, LAT_A, LON_A)
+    assert f1[0] == pytest.approx(f2[0], abs=1e-6)
+    assert f1[1] == pytest.approx(f2[1], abs=1e-6)
+    assert f1[2] == pytest.approx(f2[2], abs=0.5)
+    assert f1[3] == pytest.approx(1.0 - f2[3], abs=0.01)

--- a/tests/taxi_router/graph_construction/test_taxiway_edge_index.py
+++ b/tests/taxi_router/graph_construction/test_taxiway_edge_index.py
@@ -1,0 +1,127 @@
+"""Tests for the per-taxiway edge index and intersection lookup (issue #66).
+
+These helpers back strict routing (issue #67): `taxiway_subgraph` constrains
+A* to authorized edges and `taxiway_intersections` picks real entry/exit
+nodes between consecutive taxiways in a controller clearance.
+"""
+import pytest
+
+
+# ---- _edges_by_taxiway index ------------------------------------------------
+
+def test_edges_by_taxiway_keys_match_nodes_by_taxiway(airport):
+    g = airport.graph
+    assert set(g._edges_by_taxiway.keys()) == set(g._nodes_by_taxiway.keys()), (
+        f"[{airport.icao}] edge and node taxiway indices diverge"
+    )
+
+
+def test_edges_by_taxiway_edges_exist_in_graph(airport):
+    g = airport.graph
+    for tw, edges in g._edges_by_taxiway.items():
+        for u, v in edges:
+            assert g.graph.has_edge(u, v), (
+                f"[{airport.icao}] indexed edge {u}->{v} for taxiway {tw} "
+                "not present in graph"
+            )
+
+
+def test_edges_by_taxiway_twoway_has_both_directions(airport):
+    # For every indexed (u, v) whose source edge is twoway, (v, u) must be
+    # indexed under the same taxiway as well.
+    g = airport.graph
+    for tw, edges in g._edges_by_taxiway.items():
+        for u, v in edges:
+            data = g.graph.edges[u, v]
+            if data.get("direction", "twoway").lower() == "twoway":
+                assert (v, u) in edges, (
+                    f"[{airport.icao}] twoway edge {u}->{v} of {tw} missing "
+                    "reverse direction in index"
+                )
+
+
+def test_edges_by_taxiway_endpoints_match_node_index(airport):
+    # The endpoints of the indexed edges must be exactly the nodes recorded
+    # in _nodes_by_taxiway for the same taxiway.
+    g = airport.graph
+    for tw, edges in g._edges_by_taxiway.items():
+        endpoint_nodes = {n for uv in edges for n in uv}
+        assert endpoint_nodes == set(g._nodes_by_taxiway[tw]), (
+            f"[{airport.icao}] endpoint mismatch for taxiway {tw}"
+        )
+
+
+# ---- taxiway_subgraph -------------------------------------------------------
+
+def test_taxiway_subgraph_contains_only_own_edges(airport):
+    g = airport.graph
+    for tw in airport.expected_taxiway_subset:
+        sub = g.taxiway_subgraph(tw)
+        assert sub.number_of_edges() > 0, (
+            f"[{airport.icao}] empty subgraph for known taxiway {tw}"
+        )
+        for u, v, data in sub.edges(data=True):
+            assert str(data.get("taxiway_id", "")).upper() == tw, (
+                f"[{airport.icao}] foreign edge {u}->{v} "
+                f"({data.get('taxiway_id')!r}) in subgraph of {tw}"
+            )
+
+
+def test_taxiway_subgraph_case_insensitive(airport):
+    g = airport.graph
+    tw = next(iter(airport.expected_taxiway_subset))
+    upper = g.taxiway_subgraph(tw.upper())
+    lower = g.taxiway_subgraph(tw.lower())
+    assert set(upper.edges()) == set(lower.edges())
+
+
+def test_taxiway_subgraph_unknown_taxiway_is_empty(airport):
+    sub = airport.graph.taxiway_subgraph("ZZ99")
+    assert sub.number_of_edges() == 0
+
+
+# ---- taxiway_intersections --------------------------------------------------
+
+def _adjacent_taxiway_pair(graph):
+    """Find a real pair of distinct taxiways sharing at least one node."""
+    membership: dict[str, set] = {}
+    for tw, edges in graph._edges_by_taxiway.items():
+        for u, v in edges:
+            membership.setdefault(u, set()).add(tw)
+            membership.setdefault(v, set()).add(tw)
+    for node, tws in membership.items():
+        if len(tws) >= 2:
+            a, b = sorted(tws)[:2]
+            return a, b
+    return None
+
+
+def test_taxiway_intersections_adjacent_pair_non_empty(airport):
+    pair = _adjacent_taxiway_pair(airport.graph)
+    assert pair is not None, f"[{airport.icao}] no adjacent taxiway pair found"
+    a, b = pair
+    nodes = airport.graph.taxiway_intersections(a, b)
+    assert nodes, f"[{airport.icao}] {a} and {b} share nodes but lookup is empty"
+    # Every reported node must be an endpoint of edges of both taxiways
+    for n in nodes:
+        assert n in airport.graph._nodes_by_taxiway[a]
+        assert n in airport.graph._nodes_by_taxiway[b]
+
+
+def test_taxiway_intersections_non_touching_pair_empty(airport):
+    g = airport.graph
+    # Find two taxiways with disjoint node sets
+    tws = list(airport.expected_taxiway_subset)
+    for i, a in enumerate(tws):
+        set_a = set(g._nodes_by_taxiway[a])
+        for b in tws[i + 1:]:
+            if set_a.isdisjoint(g._nodes_by_taxiway[b]):
+                assert g.taxiway_intersections(a, b) == []
+                return
+    pytest.skip(f"[{airport.icao}] every taxiway pair in subset touches")
+
+
+def test_taxiway_intersections_unknown_taxiway_empty(airport):
+    tw = next(iter(airport.expected_taxiway_subset))
+    assert airport.graph.taxiway_intersections(tw, "ZZ99") == []
+    assert airport.graph.taxiway_intersections("ZZ99", tw) == []

--- a/tests/taxi_router/taxi_routing/test_entry_join.py
+++ b/tests/taxi_router/taxi_routing/test_entry_join.py
@@ -1,0 +1,199 @@
+"""Tests for the straight centerline join onto the first authorized taxiway.
+
+The aircraft must enter the controller-named taxiway by projecting its
+position perpendicularly onto the taxiway centerline (prolonging the nearest
+segment when the foot falls beyond an endpoint) instead of cutting diagonally
+to the nearest graph node — and never via an unconstrained graph search.
+"""
+import math
+
+import pytest
+
+from plugins.GND.graph import AirportGraph, project_point_to_segment
+
+M_PER_DEG = math.pi * 6371000.0 / 180.0
+
+
+def _offset(lat, lon, north_m, east_m):
+    return (
+        lat + north_m / M_PER_DEG,
+        lon + east_m / (M_PER_DEG * math.cos(math.radians(lat))),
+    )
+
+
+def _haversine(lat1, lon1, lat2, lon2):
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dl = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dl / 2) ** 2
+    return 2 * 6371000.0 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _edge_taxiways(graph, path):
+    return [
+        str(graph.graph.edges[path[i], path[i + 1]].get("taxiway_id", "")).upper()
+        for i in range(len(path) - 1)
+    ]
+
+
+def _start_node_on(graph, tw):
+    nodes = sorted(
+        {n for uv in graph._edges_by_taxiway[tw.upper()] for n in uv}
+        & graph._main_cc
+    )
+    assert nodes, f"no main-CC node on taxiway {tw}"
+    return nodes[0]
+
+
+def _perpendicular_offset_from_edge(graph, tw, dist_m, min_len_m=60.0):
+    """Pick a long twoway main-CC edge of ``tw`` and return (P, midpoint):
+    P is ``dist_m`` perpendicular from the segment midpoint."""
+    edges = graph._edges_by_taxiway[tw.upper()]
+    for u, v in sorted(edges):
+        if (v, u) not in edges:
+            continue
+        if u not in graph._main_cc or v not in graph._main_cc:
+            continue
+        if graph.graph.edges[u, v]["weight"] < min_len_m:
+            continue
+        nu, nv = graph.graph.nodes[u], graph.graph.nodes[v]
+        mid_lat = (nu["lat"] + nv["lat"]) / 2.0
+        mid_lon = (nu["lon"] + nv["lon"]) / 2.0
+        # Unit vector perpendicular to the segment, in the local plane.
+        ex = (nv["lon"] - nu["lon"]) * math.cos(math.radians(mid_lat))
+        ey = nv["lat"] - nu["lat"]
+        norm = math.hypot(ex, ey)
+        p_lat, p_lon = _offset(mid_lat, mid_lon, dist_m * ex / norm, -dist_m * ey / norm)
+        return (p_lat, p_lon), (mid_lat, mid_lon)
+    pytest.skip(f"no suitable twoway edge on taxiway {tw}")
+
+
+# ---- LEBL: real-graph behavior ----------------------------------------------
+
+def test_entry_join_projects_perpendicularly(lebl_graph):
+    (p_lat, p_lon), (mid_lat, mid_lon) = _perpendicular_offset_from_edge(
+        lebl_graph, "E", 30.0,
+    )
+    dest = _start_node_on(lebl_graph, "M")
+    r = lebl_graph.find_route_strict_from_position(p_lat, p_lon, ["E", "M"], dest)
+    assert r["success"] is True, r.get("error")
+    wp0 = r["waypoints"][0]
+    assert wp0["node_id"] == "entry"
+    assert wp0["name"] == "E entry"
+    # The join point is the perpendicular foot: right at the segment midpoint,
+    # 30 m from the aircraft.
+    assert _haversine(wp0["lat"], wp0["lon"], mid_lat, mid_lon) < 2.0
+    assert r["entry_distance_m"] == pytest.approx(30.0, abs=1.0)
+    # Everything after the join stays on the authorized sequence.
+    used = set(_edge_taxiways(lebl_graph, r["path_node_ids"]))
+    assert used <= {"E", "M"}, f"unauthorized taxiways used: {used}"
+    # path_node_ids stays graph-nodes-only; the synthetic point is only a waypoint.
+    assert r["waypoints"][1]["node_id"] == r["path_node_ids"][0]
+
+
+def test_entry_join_too_far_fails(lebl_graph):
+    (p_lat, p_lon), _mid = _perpendicular_offset_from_edge(lebl_graph, "E", 700.0)
+    # Precondition: farther than MAX_ENTRY_JOIN_M from every E edge.
+    for u, v in lebl_graph._edges_by_taxiway["E"]:
+        nu, nv = lebl_graph.graph.nodes[u], lebl_graph.graph.nodes[v]
+        _f1, _f2, perp, _t = project_point_to_segment(
+            p_lat, p_lon, nu["lat"], nu["lon"], nv["lat"], nv["lon"],
+        )
+        assert perp > AirportGraph.MAX_ENTRY_JOIN_M
+    dest = _start_node_on(lebl_graph, "M")
+    r = lebl_graph.find_route_strict_from_position(p_lat, p_lon, ["E", "M"], dest)
+    assert r["success"] is False
+    assert "no path from start to taxiway 'E'" in r["error"]
+
+
+def test_entry_join_on_taxiway_position_is_degenerate(lebl_graph):
+    # Aircraft already sitting on an E node: the join point coincides with
+    # the position and the entry distance is ~0.
+    start = _start_node_on(lebl_graph, "E")
+    n = lebl_graph.graph.nodes[start]
+    dest = _start_node_on(lebl_graph, "M")
+    r = lebl_graph.find_route_strict_from_position(n["lat"], n["lon"], ["E", "M"], dest)
+    assert r["success"] is True, r.get("error")
+    assert r["entry_distance_m"] == pytest.approx(0.0, abs=0.5)
+    wp0 = r["waypoints"][0]
+    assert _haversine(wp0["lat"], wp0["lon"], n["lat"], n["lon"]) < 1.0
+
+
+# ---- Synthetic graph: full control over geometry -----------------------------
+#
+#   1 --100m-- 2 --100m-- 3 ----K---- 4        (T: 1-2-3, K: 3-4)
+#
+#   5 --100m-- 6      (disconnected segment also named T, 1 km north)
+
+LAT0, LON0 = 40.0, -3.0
+
+
+def _synthetic_data(t_direction="twoway"):
+    def node(nid, north_m, east_m):
+        lat, lon = _offset(LAT0, LON0, north_m, east_m)
+        return {"node_id": nid, "lat": lat, "lon": lon, "usage": "both", "name": f"n{nid}"}
+
+    nodes = [
+        node(1, 0, 0), node(2, 0, 100), node(3, 0, 200), node(4, 100, 200),
+        node(5, 1000, 0), node(6, 1000, 100),
+    ]
+    edges = [
+        {"start_node_id": 1, "end_node_id": 2, "direction": t_direction, "taxiway_id": "T"},
+        {"start_node_id": 2, "end_node_id": 3, "direction": t_direction, "taxiway_id": "T"},
+        {"start_node_id": 3, "end_node_id": 4, "direction": "twoway", "taxiway_id": "K"},
+        {"start_node_id": 5, "end_node_id": 6, "direction": "twoway", "taxiway_id": "T"},
+    ]
+    return {"nodes": nodes, "edges": edges, "stands": [], "runways": []}
+
+
+def test_synthetic_perpendicular_join_and_direction():
+    g = AirportGraph(data=_synthetic_data())
+    # 30 m south of the midpoint of segment 1-2.
+    p_lat, p_lon = _offset(LAT0, LON0, -30.0, 50.0)
+    r = g.find_route_strict_from_position(p_lat, p_lon, ["T", "K"], "4")
+    assert r["success"] is True, r.get("error")
+    assert r["waypoints"][0]["node_id"] == "entry"
+    foot_lat, foot_lon = _offset(LAT0, LON0, 0.0, 50.0)
+    assert _haversine(r["waypoints"][0]["lat"], r["waypoints"][0]["lon"], foot_lat, foot_lon) < 2.0
+    assert r["entry_distance_m"] == pytest.approx(30.0, abs=1.0)
+    # Correct driving direction: toward the T-K intersection (node 3).
+    assert r["path_node_ids"] == ["2", "3", "4"]
+    # Driven distance: 50 m along T to node 2, 100 m to 3, 100 m up K.
+    assert r["total_distance_m"] == pytest.approx(250.0, abs=2.0)
+
+
+def test_synthetic_join_extends_beyond_segment_end():
+    g = AirportGraph(data=_synthetic_data())
+    # 40 m west of node 1 (beyond the physical end of T), 10 m south: the
+    # foot lies on the prolongation of segment 1-2, not at node 1.
+    p_lat, p_lon = _offset(LAT0, LON0, -10.0, -40.0)
+    r = g.find_route_strict_from_position(p_lat, p_lon, ["T", "K"], "4")
+    assert r["success"] is True, r.get("error")
+    wp0 = r["waypoints"][0]
+    assert wp0["node_id"] == "entry"
+    foot_lat, foot_lon = _offset(LAT0, LON0, 0.0, -40.0)
+    assert _haversine(wp0["lat"], wp0["lon"], foot_lat, foot_lon) < 2.0
+    assert r["entry_distance_m"] == pytest.approx(10.0, abs=1.0)
+    # Entering on the prolongation, the first node crossed is 1.
+    assert r["path_node_ids"] == ["1", "2", "3", "4"]
+
+
+def test_synthetic_join_respects_oneway():
+    g = AirportGraph(data=_synthetic_data(t_direction="oneway"))
+    # Beside the midpoint of 2-3, but T is one-way 1->2->3: entry must drive
+    # toward node 3, never backwards toward 2.
+    p_lat, p_lon = _offset(LAT0, LON0, -30.0, 150.0)
+    r = g.find_route_strict_from_position(p_lat, p_lon, ["T", "K"], "4")
+    assert r["success"] is True, r.get("error")
+    assert r["path_node_ids"] == ["3", "4"]
+
+
+def test_synthetic_disconnected_same_name_segment_is_infeasible():
+    g = AirportGraph(data=_synthetic_data())
+    # Right beside the disconnected T segment (5-6): it can never reach the
+    # T-K intersection, and the real T is ~1 km away — strict join must fail,
+    # not wander across the graph.
+    p_lat, p_lon = _offset(LAT0, LON0, 970.0, 50.0)
+    r = g.find_route_strict_from_position(p_lat, p_lon, ["T", "K"], "4")
+    assert r["success"] is False
+    assert "no path from start to taxiway 'T'" in r["error"]

--- a/tests/taxi_router/taxi_routing/test_routing_e2e.py
+++ b/tests/taxi_router/taxi_routing/test_routing_e2e.py
@@ -206,15 +206,19 @@ def test_route_with_via_passes_through_taxiway_node(lebl_graph):
     )
 
 
-# ---- Documented behaviour (xfail) ------------------------------------------
+# ---- Unknown-via behaviour: lenient vs strict (issue #71) -------------------
+# find_route_via keeps its historical best-effort behaviour for legacy
+# callers (plot scripts, destination-only fallback): an unknown taxiway in
+# `via` is silently ignored. Controller clearances are now routed by the
+# strict API instead (issue #67), which must fail naming the token — the
+# former xfail documenting the silent drop is replaced by these two tests.
 
-@pytest.mark.xfail(
-    reason="Best-effort via behaviour: an unknown taxiway in `via` is silently "
-    "ignored by _find_nearest_via_start (graph.py). The route succeeds but "
-    "does not force the missing waypoint. Documented for memoria 5.3.3 as a "
-    "deliberate design decision to be discussed."
-)
-def test_via_with_unknown_taxiway_raises_or_warns(lebl_graph):
+def test_lenient_via_with_unknown_taxiway_still_routes(lebl_graph):
     r = lebl_graph.find_route_via("Q", "06R", via=["ZZ99"])
+    assert r["success"] is True
+
+
+def test_strict_via_with_unknown_taxiway_fails(lebl_graph):
+    r = lebl_graph.find_route_strict("Q", ["ZZ99"], "06R")
     assert r["success"] is False
-    assert "ZZ99" in r.get("error", "")
+    assert "ZZ99" in r["error"]

--- a/tests/taxi_router/taxi_routing/test_routing_strict.py
+++ b/tests/taxi_router/taxi_routing/test_routing_strict.py
@@ -1,0 +1,180 @@
+"""Unit tests for strict controller-sequence routing (issue #67).
+
+find_route_strict must follow the issued taxiway sequence exactly: each leg
+runs only on edges of the taxiway being traversed, vias are never skipped,
+and unknown or non-connected sequences fail instead of degrading silently.
+
+LEBL adjacency used below (from `taxiway_intersections` on the fixture):
+D-K, D-M, D-N, E-J, E-K, E-L, E-M, E-N, J-Q, M-S. Taxiway B touches none
+of the sampled set.
+"""
+import networkx as nx
+import pytest
+
+
+def _tw_nodes(graph, tw):
+    return {n for uv in graph._edges_by_taxiway[tw.upper()] for n in uv}
+
+
+def _start_node_on(graph, tw):
+    """A deterministic node lying on the given taxiway (in the main CC)."""
+    nodes = sorted(_tw_nodes(graph, tw) & graph._main_cc)
+    assert nodes, f"no main-CC node on taxiway {tw}"
+    return nodes[0]
+
+
+def _edge_taxiways(graph, path):
+    return [
+        str(graph.graph.edges[path[i], path[i + 1]].get("taxiway_id", "")).upper()
+        for i in range(len(path) - 1)
+    ]
+
+
+# ---- Happy path -------------------------------------------------------------
+
+def test_strict_route_uses_only_authorized_edges(lebl_graph):
+    start = _start_node_on(lebl_graph, "D")
+    dest = _start_node_on(lebl_graph, "E")
+    r = lebl_graph.find_route_strict(start, ["D", "M", "E"], dest)
+    assert r["success"] is True, r.get("error")
+    assert r["strict"] is True
+    # Start is on D and destination is on E -> no entry/exit hop, so every
+    # edge must belong to the authorized sequence.
+    assert r["entry_distance_m"] == 0.0
+    used = set(_edge_taxiways(lebl_graph, r["path_node_ids"]))
+    assert used <= {"D", "M", "E"}, f"unauthorized taxiways used: {used}"
+
+
+def test_strict_route_honors_sequence_order(lebl_graph):
+    start = _start_node_on(lebl_graph, "D")
+    dest = _start_node_on(lebl_graph, "E")
+    r = lebl_graph.find_route_strict(start, ["D", "M", "E"], dest)
+    assert r["success"] is True, r.get("error")
+    # The order of first appearance of each authorized taxiway in the flown
+    # edge sequence must match the issued order (a taxiway may be absent only
+    # if its leg collapsed to a single intersection node).
+    edge_tws = _edge_taxiways(lebl_graph, r["path_node_ids"])
+    first_seen = {tw: edge_tws.index(tw) for tw in ("D", "M", "E") if tw in edge_tws}
+    positions = [first_seen[tw] for tw in ("D", "M", "E") if tw in first_seen]
+    assert positions == sorted(positions), (
+        f"issued order not honored: {edge_tws}"
+    )
+
+
+def test_strict_route_repeated_taxiway_traversed_again(lebl_graph):
+    # "taxi via E, M, E" — non-adjacent repeat must be preserved and flown.
+    start = _start_node_on(lebl_graph, "E")
+    dest = _start_node_on(lebl_graph, "E")
+    r = lebl_graph.find_route_strict(start, ["E", "M", "E"], dest)
+    assert r["success"] is True, r.get("error")
+    used = set(_edge_taxiways(lebl_graph, r["path_node_ids"]))
+    assert used <= {"E", "M"}, f"unauthorized taxiways used: {used}"
+
+
+def test_strict_route_consecutive_duplicates_collapse(lebl_graph):
+    # Phonetic repetition ("delta delta") must not create a zero-length leg.
+    start = _start_node_on(lebl_graph, "D")
+    dest = _start_node_on(lebl_graph, "M")
+    r1 = lebl_graph.find_route_strict(start, ["D", "D", "M"], dest)
+    r2 = lebl_graph.find_route_strict(start, ["D", "M"], dest)
+    assert r1["success"] and r2["success"]
+    assert r1["path_node_ids"] == r2["path_node_ids"]
+
+
+def test_strict_route_destination_on_last_taxiway(lebl_graph):
+    start = _start_node_on(lebl_graph, "Q")
+    dest = _start_node_on(lebl_graph, "J")
+    r = lebl_graph.find_route_strict(start, ["Q", "J"], dest)
+    assert r["success"] is True, r.get("error")
+    assert r["path_node_ids"][-1] == dest
+    used = set(_edge_taxiways(lebl_graph, r["path_node_ids"]))
+    assert used <= {"Q", "J"}
+
+
+# ---- Strict failure modes ---------------------------------------------------
+
+def test_strict_route_unknown_taxiway_fails_naming_token(lebl_graph):
+    start = _start_node_on(lebl_graph, "D")
+    r = lebl_graph.find_route_strict(start, ["D", "ZZ99"], "06R")
+    assert r["success"] is False
+    assert "ZZ99" in r["error"]
+
+
+def test_strict_route_non_connected_pair_fails_naming_pair(lebl_graph):
+    # B touches neither D nor any of the sampled taxiways at LEBL.
+    assert lebl_graph.taxiway_intersections("B", "D") == []
+    start = _start_node_on(lebl_graph, "B")
+    dest = _start_node_on(lebl_graph, "D")
+    r = lebl_graph.find_route_strict(start, ["B", "D"], dest)
+    assert r["success"] is False
+    assert "B" in r["error"] and "D" in r["error"]
+    assert "not connected" in r["error"]
+
+
+def test_strict_route_empty_sequence_fails(lebl_graph):
+    r = lebl_graph.find_route_strict("0", [], "06R")
+    assert r["success"] is False
+    assert "empty" in r["error"]
+
+
+def test_strict_route_destination_too_far_off_sequence_fails(lebl_graph):
+    # Runway 24L threshold is ~1.5km away from taxiway E's nearest node:
+    # the exit hop exceeds MAX_EXIT_HOP_M and must fail, not silently route.
+    start = _start_node_on(lebl_graph, "M")
+    r = lebl_graph.find_route_strict(start, ["M", "E"], "24L")
+    assert r["success"] is False
+    assert "too far" in r["error"]
+
+
+def test_strict_route_invalid_start_token(lebl_graph):
+    r = lebl_graph.find_route_strict("XYZ_NOT_A_TOKEN", ["D"], "06R")
+    assert r["success"] is False
+    assert "start token" in r["error"]
+
+
+# ---- Shape compatibility with find_route_via --------------------------------
+
+def test_strict_result_shape_matches_find_route_via(lebl_graph):
+    start = _start_node_on(lebl_graph, "D")
+    dest = _start_node_on(lebl_graph, "E")
+    r = lebl_graph.find_route_strict(start, ["D", "M", "E"], dest)
+    assert r["success"], r.get("error")
+    for key in (
+        "success", "path_node_ids", "waypoints",
+        "taxiway_sequence", "total_distance_m", "start", "end",
+    ):
+        assert key in r, f"missing key: {key}"
+    for sub in ("node_id", "lat", "lon", "token"):
+        assert sub in r["start"]
+        assert sub in r["end"]
+    for wp in r["waypoints"]:
+        assert set(wp) == {"node_id", "lat", "lon", "name"}
+
+
+def test_strict_path_nodes_are_connected(lebl_graph):
+    start = _start_node_on(lebl_graph, "D")
+    dest = _start_node_on(lebl_graph, "E")
+    r = lebl_graph.find_route_strict(start, ["D", "M", "E"], dest)
+    assert r["success"], r.get("error")
+    path = r["path_node_ids"]
+    for i in range(len(path) - 1):
+        assert lebl_graph.graph.has_edge(path[i], path[i + 1])
+
+
+# ---- find_route_strict_from_position ---------------------------------------
+
+def test_strict_from_position_snaps_and_delegates(lebl_graph):
+    start = _start_node_on(lebl_graph, "Q")
+    n = lebl_graph.graph.nodes[start]
+    dest = _start_node_on(lebl_graph, "J")
+    r = lebl_graph.find_route_strict_from_position(
+        n["lat"], n["lon"], ["Q", "J"], dest,
+    )
+    assert r["success"] is True, r.get("error")
+    assert r["start"]["node_id"] == start
+
+
+def test_strict_from_position_no_connected_node(lebl_graph):
+    r = lebl_graph.find_route_strict_from_position(0.0, 0.0, ["D"], "06R")
+    assert r["success"] is False
+    assert "No connected node" in r["error"]


### PR DESCRIPTION
## Summary

Stack 1/4 of the strict controller taxi route campaign (epic #73).

- Index directed edges per taxiway (`_edges_by_taxiway`) and add `taxiway_subgraph` / `taxiway_intersections` lookups to `AirportGraph`. Closes #66
- Add `find_route_strict` / `find_route_strict_from_position`: every leg runs only on edges of the taxiway being traversed, vias are never skipped, and unknown/non-connected sequences fail loudly instead of degrading to a free shortest path. Closes #67
- **Straight centerline join**: the aircraft position is projected perpendicularly onto the first authorized taxiway's centerline (`project_point_to_segment`), prolonging the nearest segment up to 150 m when the foot falls beyond an endpoint. The join point is emitted as a synthetic first waypoint (`node_id: "entry"`) so the mover drives straight onto the taxiway instead of cutting diagonally to the nearest graph node. Positions farther than 500 m fail ("unable") instead of wandering across the graph.
- Fix the operator-precedence bug in `find_nearest_node`'s failure return (xfail removed).

## Tests

- `test_taxiway_edge_index.py`: index/subgraph/intersection invariants on the LEBL fixture.
- `test_routing_strict.py`: only-authorized-edges, issued order honored, non-adjacent repeats preserved, exact failure messages, result-shape compatibility.
- `test_projection.py`: pure geometry of the perpendicular projection (inside segment, beyond endpoints, degenerate, symmetry).
- `test_entry_join.py`: perpendicular join on LEBL, prolongation beyond a segment end, >500 m fails, one-way direction respected, disconnected same-name segments rejected (synthetic 6-node graph).

`pytest tests/taxi_router`: 118 passed on this branch.