### PR TITLE
feat(taxi): dispatch strictly on the controller's spoken sequence, reply unable when infeasible (3/4)

### DIFF
--- a/services/orchestrator_service/agent/tools/taxi_route.py
+++ b/services/orchestrator_service/agent/tools/taxi_route.py
@@ -36,10 +36,13 @@ def get_taxi_route(
         known_tokens = None
 
     destination = extract_destination(instruction_text)
+    # dedup=False: a clearance may legitimately revisit a taxiway
+    # ("via A, B, A") and strict routing (issue #69) must keep the order.
     via = extract_taxiway_tokens(
         taxi_route_text=None,
         fallback_text=instruction_text,
         known_tokens=known_tokens,
+        dedup=False,
     )
 
     # If the destination token also appeared as a via token, remove it from via

--- a/shared/services/taxi_router/constraints.py
+++ b/shared/services/taxi_router/constraints.py
@@ -1,5 +1,10 @@
 """Merge controller-issued via-points with the pilot's colación (readback).
 
+NOTE (issue #69): this merge no longer feeds routing. dispatch_taxi_plan
+routes strictly on the controller's spoken sequence and only compares the
+readback against it for mismatch logging. The function is kept for readback
+evaluation tooling.
+
 The pilot's sequence is authoritative for order (ICAO rule: the pilot must
 repeat the clearance). Any taxiway in the controller list that the pilot
 did NOT read back is spliced in at the position that keeps progression

--- a/shared/services/taxi_router/router.py
+++ b/shared/services/taxi_router/router.py
@@ -9,10 +9,11 @@ Two public entry points:
   expects.
 
 - `dispatch_taxi_plan(clearance_data, pilot_readback_text, *, registration,
-  callsign)`: merges controller + pilot waypoints, builds the two-leg
-  plan (pushback -> waypoints), writes it to Redis for the plugin to
-  consume, and emits a `hmi:chat` rejection when the readback cannot be
-  routed.
+  callsign)`: routes strictly on the controller's spoken taxiway sequence
+  (issue #69), builds the two-leg plan (pushback -> waypoints), writes it
+  to Redis for the plugin to consume, and emits a `hmi:chat` rejection
+  when the issued sequence cannot be flown. The pilot readback never
+  alters the route; a mismatch is only logged.
 """
 
 import json
@@ -23,7 +24,6 @@ import uuid
 from typing import Optional
 
 from . import config
-from .constraints import merge_constraints
 from .destination_parser import extract_destination
 from .errors import RouteNotFoundError, UnknownTaxiwayError
 from .hmi_chat import format_readback_rejected, publish_pilot_message
@@ -116,7 +116,13 @@ def compute_taxi_route(
     via: list[str],
     callsign: str,
 ) -> dict:
-    """A* over the taxiway graph from the aircraft's live position.
+    """Route over the taxiway graph from the aircraft's live position.
+
+    When the controller named via taxiways, the route follows them strictly
+    (issue #69): each leg runs only on edges of the authorized taxiway and an
+    infeasible sequence fails instead of being silently re-routed. With no
+    vias (destination-only clearance) the lenient A* is used and the result
+    is tagged `"strict": False`.
 
     Mirrors the contract expected by
     `services/orchestrator_service/agent/tools/taxi_route.py`:
@@ -139,10 +145,18 @@ def compute_taxi_route(
         return {"success": False, "error": str(exc)}
 
     lat, lon, _hdg = pos
+    via = list(via or [])
+    if via:
+        return graph.find_route_strict_from_position(
+            start_lat=lat, start_lon=lon,
+            sequence=via, destination_token=destination,
+        )
     result = graph.find_route_from_position(
         start_lat=lat, start_lon=lon,
-        end_token=destination, via=list(via or []),
+        end_token=destination, via=[],
     )
+    if result.get("success"):
+        result["strict"] = False
     return result
 
 
@@ -198,17 +212,34 @@ def dispatch_taxi_plan(
         known_tokens=known_tokens,
     )
 
-    # Controller via-points came from the precomputed taxi_route attached
-    # to the GND clearance. Fall back to its taxiway_sequence.
-    taxi_route = clearance_data.get("taxi_route") or {}
-    controller_via = list(taxi_route.get("taxiway_sequence") or [])
+    # The controller's SPOKEN sequence is the single routing source of truth
+    # (issue #69). The precomputed taxi_route attached to the clearance is
+    # the output of an earlier A* run and is never used for routing again.
+    controller_seq = extract_taxiway_tokens(
+        None, fallback_text=controller_instruction or "",
+        known_tokens=known_tokens, dedup=False,
+    )
+
+    # Destination comes ONLY from what the controller said. The DB's
+    # runway_in_use is not consulted. When the controller doesn't state
+    # an endpoint, the route ends at the last spoken taxiway.
+    destination = (
+        extract_destination(controller_instruction or "")
+        or extract_destination(pilot_readback_text or "")
+    )
+    if destination:
+        dest_upper = destination.upper()
+        controller_seq = [t for t in controller_seq if t.upper() != dest_upper]
+    elif controller_seq:
+        destination = controller_seq[-1]
+        controller_seq = controller_seq[:-1]
 
     # A clearance can carry pushback, taxi, or both. Three legitimate cases:
     #   - pushback only             -> one pushback leg
     #   - pushback + taxi via X     -> pushback + waypoints
     #   - taxi only (follow-up)     -> waypoints leg, no pushback
     pushback_approved = bool(taxi_data.get("pushback_approved")) if isinstance(taxi_data, dict) else False
-    has_taxi_clearance = bool(controller_via) or bool(readback_via)
+    has_taxi_clearance = bool(controller_seq) or bool(destination)
     pushback_dir = parse_pushback_direction(instruction_text)
     delay = random.uniform(*delay_range)
 
@@ -240,34 +271,35 @@ def dispatch_taxi_plan(
     if not has_taxi_clearance:
         return {"success": False, "error": "no taxi clearance and no pushback"}
 
-    # Full taxi clearance: merge constraints and run A*
-    merged = merge_constraints(controller_via, readback_via)
+    # The pilot readback never alters the flown route: it is only compared
+    # against the controller sequence and a mismatch is logged for debrief.
+    if readback_via and readback_via != list(dict.fromkeys(controller_seq)):
+        logger.warning(
+            "[taxi_router] readback mismatch for %s: controller=%s readback=%s",
+            registration, controller_seq, readback_via,
+        )
 
-    # Destination comes ONLY from what the controller said. The DB's
-    # runway_in_use is not consulted. When the controller doesn't state
-    # an endpoint, the route ends at the last via-point.
-    destination = (
-        extract_destination(controller_instruction or "")
-        or extract_destination(pilot_readback_text or "")
-    )
-    if not destination:
-        if merged:
-            destination = merged[-1]
-            merged = merged[:-1]
-        else:
-            return {"success": False, "error": "no taxi clearance"}
-
-    route_result = graph.find_route_from_position(
-        start_lat=stand_lat, start_lon=stand_lon,
-        end_token=destination, via=merged,
-    )
+    strict = bool(controller_seq)
+    if strict:
+        route_result = graph.find_route_strict_from_position(
+            start_lat=stand_lat, start_lon=stand_lon,
+            sequence=controller_seq, destination_token=destination,
+        )
+    else:
+        # Destination-only clearance ("taxi to runway 24L"): there is no
+        # sequence to follow strictly, so fall back to the lenient A* and
+        # tag the plan explicitly.
+        route_result = graph.find_route_from_position(
+            start_lat=stand_lat, start_lon=stand_lon,
+            end_token=destination, via=[],
+        )
     if not route_result.get("success"):
         reason_detail = route_result.get("error", "route unavailable")
-        logger.info(
-            "[taxi_router] route rejected for %s via=%s dest=%s: %s",
-            registration, merged, destination, reason_detail,
+        logger.warning(
+            "[taxi_router] route rejected for %s seq=%s dest=%s strict=%s: %s",
+            registration, controller_seq, destination, strict, reason_detail,
         )
-        short_reason = _shorten_reason(reason_detail, merged, readback_via)
+        short_reason = _shorten_reason(reason_detail, controller_seq, readback_via)
         _reject(
             r, callsign=callsign, registration=registration,
             reason=short_reason, session_id=session_id,
@@ -311,15 +343,16 @@ def dispatch_taxi_plan(
         "plan_id": str(uuid.uuid4()),
         "started_at": time.time(),
         "delay_before_start_s": round(delay, 2),
+        "strict": strict,
         "legs": legs,
     }
 
     key = config.MOVE_CMD_KEY.format(registration=registration)
     r.set(key, json.dumps(plan), ex=ttl)
     logger.info(
-        "[taxi_router] dispatched plan %s for %s: delay=%.1fs pushback=%.1fm taxi=%dwp dest=%s legs=%d",
+        "[taxi_router] dispatched plan %s for %s: delay=%.1fs pushback=%.1fm taxi=%dwp dest=%s legs=%d strict=%s",
         plan["plan_id"], registration, delay, pushback_dist,
-        len(waypoints), destination, len(legs),
+        len(waypoints), destination, len(legs), strict,
     )
     return {"success": True, "plan_id": plan["plan_id"], "ttl_s": ttl, "legs": len(legs)}
 
@@ -328,14 +361,32 @@ def dispatch_taxi_plan(
 
 def _shorten_reason(
     detail: str,
-    merged_via: list[str],
+    controller_via: list[str],
     pilot_via: list[str],
 ) -> str:
     """Map a graph-layer error string to a pilot-facing phrase."""
+    import re
+
     low = detail.lower()
+    # Strict-routing failures (issue #70): the pilot names the exact problem
+    # so the trainee controller can re-issue a valid clearance.
+    m = re.search(r"unknown taxiway '([^']+)'", detail)
+    if m:
+        return f"taxiway {m.group(1)} not available"
+    m = re.search(r"sequence not connected: (\S+) -> (\S+)", detail)
+    if m:
+        return f"taxiways {m.group(1)} and {m.group(2)} are not connected"
+    m = re.search(r"no path from start to taxiway '([^']+)'", detail)
+    if m:
+        return f"unable to reach taxiway {m.group(1)}"
+    if "destination too far from taxiway" in low or (
+        "destination not reachable along taxiway" in low
+    ):
+        return "the issued route does not reach the destination"
+    # Lenient-routing failures (legacy phrasing)
     if "via point" in low:
         # Try to extract the offending token
-        for tok in pilot_via + merged_via:
+        for tok in pilot_via + controller_via:
             if f"'{tok}'" in detail or f"{tok!r}" in detail:
                 return f"taxiway {tok} not found"
         return "requested taxiway not found"

--- a/tests/taxi_router/test_dispatch_taxi_plan.py
+++ b/tests/taxi_router/test_dispatch_taxi_plan.py
@@ -1,0 +1,255 @@
+"""First test coverage for dispatch_taxi_plan (issue #71).
+
+Uses a dict-backed fake Redis injected through the existing `redis_client=`
+parameter and the real LEBL fixture graph (router._load_graph monkeypatched),
+so no live Redis/network is needed.
+
+LEBL facts used (verified against the fixture): taxiways E-M and M-D
+intersect, runway 02 is reachable from taxiway D within the bounded exit
+hop; taxiways B and D do not touch.
+"""
+import json
+
+import pytest
+
+from shared.services.taxi_router import router as router_mod
+from shared.services.taxi_router.router import dispatch_taxi_plan
+
+
+# ---- Fakes ------------------------------------------------------------------
+
+class FakeRedis:
+    """Minimal dict-backed stand-in for redis.Redis (decode_responses=True)."""
+
+    def __init__(self):
+        self.hashes: dict[str, dict] = {}
+        self.kv: dict[str, str] = {}
+        self.ttls: dict[str, int] = {}
+        self.published: list[tuple[str, str]] = []
+        self.lists: dict[str, list] = {}
+
+    def hgetall(self, key):
+        return dict(self.hashes.get(key, {}))
+
+    def set(self, key, value, ex=None):
+        self.kv[key] = value
+        if ex is not None:
+            self.ttls[key] = ex
+
+    def setex(self, key, ttl, value):
+        self.kv[key] = value
+        self.ttls[key] = ttl
+
+    def publish(self, channel, message):
+        self.published.append((channel, message))
+
+    def rpush(self, key, value):
+        self.lists.setdefault(key, []).append(value)
+
+
+REG = "EC-TST"
+MOVE_CMD_KEY = f"aircraft:{REG}:move_cmd"
+
+
+def _tw_nodes(graph, tw):
+    return {n for uv in graph._edges_by_taxiway[tw.upper()] for n in uv}
+
+
+@pytest.fixture()
+def fake_redis(lebl_graph):
+    """FakeRedis with the aircraft parked on a taxiway-E node."""
+    r = FakeRedis()
+    node = sorted(_tw_nodes(lebl_graph, "E") & lebl_graph._main_cc)[0]
+    n = lebl_graph.graph.nodes[node]
+    r.hashes[f"aircraft:state:{REG}"] = {
+        "latitude": str(n["lat"]),
+        "longitude": str(n["lon"]),
+        "heading": "90.0",
+    }
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _patch_graph(monkeypatch, lebl_graph):
+    monkeypatch.setattr(router_mod, "_load_graph", lambda: lebl_graph)
+
+
+def _dispatch(fake_redis, *, controller, readback="", clearance=None):
+    return dispatch_taxi_plan(
+        clearance or {},
+        readback,
+        registration=REG,
+        controller_instruction=controller,
+        callsign="TST123",
+        delay_range_s=(0.0, 0.0),
+        redis_client=fake_redis,
+    )
+
+
+# ---- Strict happy path ------------------------------------------------------
+
+def test_strict_dispatch_writes_plan_with_controller_sequence(fake_redis, lebl_graph):
+    result = _dispatch(
+        fake_redis,
+        controller="TST123 taxi to runway 02 via echo mike delta",
+        readback="taxi runway 02 via echo mike delta, TST123",
+    )
+    assert result["success"] is True, result.get("error")
+    plan = json.loads(fake_redis.kv[MOVE_CMD_KEY])
+    assert plan["strict"] is True
+    taxi_leg = plan["legs"][-1]
+    assert taxi_leg["mode"] == "waypoints"
+    # First appearance of the authorized taxiways in the flown sequence
+    # must honor the spoken order E -> M -> D (entry/exit hops aside).
+    seq = [str(t).upper() for t in taxi_leg["taxiway_sequence"]]
+    positions = [seq.index(tw) for tw in ("E", "M", "D") if tw in seq]
+    assert positions == sorted(positions), seq
+
+
+def test_strict_dispatch_never_uses_precomputed_taxi_route(fake_redis):
+    # A poisoned precomputed sequence (unknown taxiway) must be ignored:
+    # routing runs on the spoken instruction only.
+    result = _dispatch(
+        fake_redis,
+        controller="TST123 taxi to runway 02 via echo mike delta",
+        clearance={"taxi_route": {"taxiway_sequence": ["ZZ99"]}},
+    )
+    assert result["success"] is True, result.get("error")
+    assert MOVE_CMD_KEY in fake_redis.kv
+
+
+def test_readback_cannot_change_route_geometry(fake_redis):
+    r1 = _dispatch(
+        fake_redis,
+        controller="TST123 taxi to runway 02 via echo mike delta",
+        readback="taxi runway 02 via echo mike delta, TST123",
+    )
+    plan1 = json.loads(fake_redis.kv[MOVE_CMD_KEY])
+    # Same clearance, wildly different readback -> identical waypoints
+    r2 = _dispatch(
+        fake_redis,
+        controller="TST123 taxi to runway 02 via echo mike delta",
+        readback="taxi runway 02 via november kilo lima, TST123",
+    )
+    plan2 = json.loads(fake_redis.kv[MOVE_CMD_KEY])
+    assert r1["success"] and r2["success"]
+    assert plan1["legs"][-1]["waypoints"] == plan2["legs"][-1]["waypoints"]
+
+
+def test_readback_mismatch_is_logged(fake_redis, caplog):
+    with caplog.at_level("WARNING"):
+        _dispatch(
+            fake_redis,
+            controller="TST123 taxi to runway 02 via echo mike delta",
+            readback="taxi runway 02 via november kilo, TST123",
+        )
+    assert any("readback mismatch" in rec.message for rec in caplog.records)
+
+
+# ---- Strict rejection: no move_cmd, pilot says unable -----------------------
+
+def test_non_connected_sequence_rejected_no_move_cmd(fake_redis):
+    result = _dispatch(
+        fake_redis,
+        controller="TST123 taxi to runway 02 via bravo delta",
+    )
+    assert result["success"] is False
+    assert result.get("reason_to_pilot_chat") is True
+    assert MOVE_CMD_KEY not in fake_redis.kv
+    # The simulated pilot names the offending pair on hmi:chat
+    assert fake_redis.published, "no pilot chat message published"
+    payload = json.loads(fake_redis.published[0][1])
+    assert "unable" in payload["text"].lower()
+    assert "not connected" in payload["text"]
+
+
+def test_corrected_clearance_dispatches_after_rejection(fake_redis):
+    bad = _dispatch(
+        fake_redis, controller="TST123 taxi to runway 02 via bravo delta",
+    )
+    assert bad["success"] is False
+    good = _dispatch(
+        fake_redis, controller="TST123 taxi to runway 02 via echo mike delta",
+    )
+    assert good["success"] is True, good.get("error")
+    assert MOVE_CMD_KEY in fake_redis.kv
+
+
+# ---- Pushback-only and destination-only paths -------------------------------
+
+def test_pushback_only_dispatches_single_leg(fake_redis):
+    result = _dispatch(
+        fake_redis,
+        controller="TST123 pushback approved face north",
+        clearance={"taxi_data": {"pushback_approved": True}},
+    )
+    assert result["success"] is True, result.get("error")
+    assert result["legs"] == 1
+    plan = json.loads(fake_redis.kv[MOVE_CMD_KEY])
+    assert plan["legs"][0]["mode"] == "pushback"
+
+
+def test_pushback_plus_taxi_starts_at_entry_waypoint(fake_redis, lebl_graph):
+    # Aircraft parked 30 m off taxiway E: the taxi leg must begin at the
+    # synthetic centerline-join waypoint ("entry"), which is also what the
+    # pushback leg aims the aircraft towards.
+    import math
+    edges = lebl_graph._edges_by_taxiway["E"]
+    u, v = next(
+        (u, v) for u, v in sorted(edges)
+        if (v, u) in edges
+        and u in lebl_graph._main_cc and v in lebl_graph._main_cc
+        and lebl_graph.graph.edges[u, v]["weight"] >= 60.0
+    )
+    nu, nv = lebl_graph.graph.nodes[u], lebl_graph.graph.nodes[v]
+    mid_lat = (nu["lat"] + nv["lat"]) / 2.0
+    mid_lon = (nu["lon"] + nv["lon"]) / 2.0
+    ex = (nv["lon"] - nu["lon"]) * math.cos(math.radians(mid_lat))
+    ey = nv["lat"] - nu["lat"]
+    norm = math.hypot(ex, ey)
+    m_per_deg = math.pi * 6371000.0 / 180.0
+    off_lat = mid_lat + 30.0 * ex / norm / m_per_deg
+    off_lon = mid_lon - 30.0 * ey / norm / (m_per_deg * math.cos(math.radians(mid_lat)))
+    fake_redis.hashes[f"aircraft:state:{REG}"] = {
+        "latitude": str(off_lat), "longitude": str(off_lon), "heading": "90.0",
+    }
+    result = _dispatch(
+        fake_redis,
+        controller="TST123 pushback approved, taxi to runway 02 via echo mike delta",
+        clearance={"taxi_data": {"pushback_approved": True}},
+    )
+    assert result["success"] is True, result.get("error")
+    plan = json.loads(fake_redis.kv[MOVE_CMD_KEY])
+    assert plan["legs"][0]["mode"] == "pushback"
+    taxi_leg = plan["legs"][-1]
+    assert taxi_leg["mode"] == "waypoints"
+    first_wp = taxi_leg["waypoints"][0]
+    assert first_wp["node_id"] == "entry"
+    assert first_wp["name"] == "E entry"
+
+
+def test_destination_only_falls_back_lenient_flagged(fake_redis):
+    result = _dispatch(
+        fake_redis,
+        controller="TST123 taxi to runway 02",
+    )
+    assert result["success"] is True, result.get("error")
+    plan = json.loads(fake_redis.kv[MOVE_CMD_KEY])
+    assert plan["strict"] is False
+
+
+def test_no_clearance_at_all_fails(fake_redis):
+    result = _dispatch(fake_redis, controller="TST123 hold position")
+    assert result["success"] is False
+    assert MOVE_CMD_KEY not in fake_redis.kv
+
+
+def test_no_live_position_fails(lebl_graph):
+    r = FakeRedis()  # no aircraft:state hash
+    result = dispatch_taxi_plan(
+        {}, "", registration=REG,
+        controller_instruction="taxi to runway 02 via echo",
+        redis_client=r,
+    )
+    assert result["success"] is False
+    assert "position" in result["error"]

--- a/tests/taxi_router/test_shorten_reason.py
+++ b/tests/taxi_router/test_shorten_reason.py
@@ -1,0 +1,61 @@
+"""Unit tests for the pilot-facing rejection phrases (issue #70).
+
+_shorten_reason maps graph-layer error strings — including the strict
+routing errors introduced by issue #67 — to the short phrase the simulated
+pilot speaks on `hmi:chat` ("<callsign>, unable, <reason>. Request
+alternative.").
+"""
+from shared.services.taxi_router.router import _shorten_reason
+
+
+# ---- Strict-routing failures (issue #70) ------------------------------------
+
+def test_unknown_taxiway_names_the_token():
+    got = _shorten_reason("unknown taxiway 'ZZ99'", [], [])
+    assert got == "taxiway ZZ99 not available"
+
+
+def test_sequence_not_connected_names_the_pair():
+    got = _shorten_reason("taxiway sequence not connected: B -> D", [], [])
+    assert got == "taxiways B and D are not connected"
+
+
+def test_no_path_to_first_taxiway():
+    got = _shorten_reason("no path from start to taxiway 'Q'", [], [])
+    assert got == "unable to reach taxiway Q"
+
+
+def test_destination_too_far_off_sequence():
+    got = _shorten_reason(
+        "destination too far from taxiway 'E' (1526m off the authorized sequence)",
+        [], [],
+    )
+    assert got == "the issued route does not reach the destination"
+
+
+def test_destination_not_reachable_along_taxiway():
+    got = _shorten_reason("destination not reachable along taxiway 'J'", [], [])
+    assert got == "the issued route does not reach the destination"
+
+
+# ---- Legacy lenient-routing failures ---------------------------------------
+
+def test_via_point_with_token():
+    got = _shorten_reason("Could not resolve via point: 'Z'", ["Z"], [])
+    assert got == "taxiway Z not found"
+
+
+def test_generic_no_path():
+    got = _shorten_reason("No path from node '1' to node '2'", [], [])
+    assert got == "no route available"
+
+
+def test_off_movement_area():
+    got = _shorten_reason(
+        "No connected node within 2000m of (0.000000, 0.000000)", [], [],
+    )
+    assert got == "position off the movement area"
+
+
+def test_unknown_error_falls_back():
+    assert _shorten_reason("weird internal error", [], []) == "unable to comply"

--- a/tests/unit/orchestrator/test_get_taxi_route_tool.py
+++ b/tests/unit/orchestrator/test_get_taxi_route_tool.py
@@ -33,12 +33,15 @@ def _stub_router(monkeypatch, *, destination, via, graph_tokens=None, raise_grap
     def _fake_extract_destination(text):
         return destination
 
-    def _fake_extract_taxiway_tokens(*, taxi_route_text, fallback_text, known_tokens):
+    def _fake_extract_taxiway_tokens(
+        *, taxi_route_text, fallback_text, known_tokens, dedup=True,
+    ):
         # Echo the via list -- known_tokens is asserted via call recording
         _fake_extract_taxiway_tokens.last_call = {
             "taxi_route_text": taxi_route_text,
             "fallback_text": fallback_text,
             "known_tokens": known_tokens,
+            "dedup": dedup,
         }
         return list(via)
 


### PR DESCRIPTION
## Summary

Stack 3/4, on top of #84.

- `dispatch_taxi_plan` extracts the taxiway sequence from the **controller's spoken instruction** (`dedup=False`) and routes with `find_route_strict_from_position`; the pre-computed clearance `taxi_route` is never reused, and the pilot readback can no longer alter route geometry (mismatches are logged only). Closes #69
- Infeasible sequences (unknown taxiway, not connected, unreachable, off-movement-area position) write **no move_cmd** and the simulated pilot replies on `hmi:chat` with a short reason built by `_shorten_reason` (e.g. "unable ..., taxiways B and D are not connected"). Closes #70
- `get_taxi_route` mirrors the same token extraction so the ADK tool and the dispatcher agree; `merge_constraints` is degraded to readback-evaluation tooling only.

## Tests

- First `dispatch_taxi_plan` battery (dict-backed FakeRedis + real LEBL fixture graph): strict plan honors spoken order, poisoned precomputed route ignored, readback cannot change geometry, rejection publishes "unable" and writes no key, pushback+taxi starts at the synthetic centerline-join waypoint.
- Exact pilot-phrase tests for `_shorten_reason`.
- Updated `test_get_taxi_route_tool.py`. Closes #71

`pytest tests/taxi_router tests/unit/orchestrator/test_get_taxi_route_tool.py`: 150 passed on this branch.