### PR TITLE
chore: add ruff (lint + format) to pyproject and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           pip install \
             "pytest>=8" "pytest-asyncio>=0.23" "pytest-mock>=3.12" \
             "pytest-cov>=5" "respx>=0.20" "fastapi>=0.110" \
-            "sqlalchemy>=2.0" httpx redis pydantic networkx psycopg2-binary
+            "sqlalchemy>=2.0" httpx requests redis pydantic networkx psycopg2-binary
 
       # No --cov-fail-under override here: `fail_under` in pyproject.toml is
       # the single source of truth for the gate. It sits two points below the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,30 @@ jobs:
           path: coverage.xml
           if-no-files-found: warn
 
+  lint:
+    runs-on: ubuntu-latest
+    # Advisory until the repo-wide `ruff check --fix` + `ruff format` pass
+    # lands — see issue #48. Flip this off in that same commit so the job
+    # starts blocking.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install ruff
+        run: pip install "ruff>=0.14,<0.15"
+
+      - name: Lint
+        run: ruff check --output-format=github .
+
+      - name: Format check
+        run: ruff format --check .
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    # Advisory until the repo-wide `ruff check --fix` + `ruff format` pass
-    # lands — see issue #48. Flip this off in that same commit so the job
-    # starts blocking.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -68,10 +64,16 @@ jobs:
       - name: Install ruff
         run: pip install "ruff>=0.14,<0.15"
 
+      # Advisory until the repo-wide `ruff check --fix` + `ruff format` pass
+      # lands — see issue #48. Violations still show up as annotations on the
+      # diff; they just don't fail the build yet. Drop both
+      # continue-on-error lines in that same commit to start blocking.
       - name: Lint
+        continue-on-error: true
         run: ruff check --output-format=github .
 
       - name: Format check
+        continue-on-error: true
         run: ruff format --check .
 
   frontend:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,12 @@ jobs:
             "pytest-cov>=5" "respx>=0.20" "fastapi>=0.110" \
             "sqlalchemy>=2.0" httpx redis pydantic networkx psycopg2-binary
 
-      # Coverage is informational for now: --cov-fail-under=0 overrides the
-      # fail_under=70 gate in pyproject.toml so the build never fails on the
-      # coverage number while we establish a baseline.
-      - name: Run test suite (coverage informational)
-        run: pytest --cov --cov-report=xml --cov-report=term --cov-fail-under=0
+      # No --cov-fail-under override here: `fail_under` in pyproject.toml is
+      # the single source of truth for the gate. It sits two points below the
+      # measured baseline and is raised in follow-up PRs towards 70% of the
+      # full scope — see issue #47.
+      - name: Run test suite
+        run: pytest --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage report
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,21 +78,19 @@ filterwarnings = [
 # (aircraft_mover FSM, debrief endpoint, shared/services/aircraft_*) are
 # tracked but excluded from the fail_under threshold since they are out of
 # scope for the current phase — see memoria 5.3.3 for the deferred items.
+#
+# `source` must list packages or DIRECTORIES only. Single .py file paths are
+# not valid entries: coverage treats them as module names, warns
+# "Module ... was never imported", and silently drops them from the report —
+# which is what used to happen to debrief_builder, runner, session_log,
+# frequency_audit, config, event_bridge, arrival_planner, runway_config,
+# phases and geo. Scope is therefore expressed as directories here and
+# narrowed in `omit` below.
 source = [
-    "services/orchestrator_service/agent",
-    "services/orchestrator_service/api",
-    "services/orchestrator_service/db",
-    "services/orchestrator_service/frequency_audit.py",
-    "services/orchestrator_service/runner.py",
-    "services/orchestrator_service/session_log.py",
-    "services/orchestrator_service/debrief_builder.py",
-    "services/orchestrator_service/config.py",
-    "services/arrival_simulator_service/core/event_bridge.py",
-    "services/arrival_simulator_service/core/arrival_planner.py",
-    "services/arrival_simulator_service/core/runway_config.py",
-    "services/arrival_simulator_service/core/phases.py",
-    "services/arrival_simulator_service/core/geo.py",
-    "shared/services/taxi_router",
+    "services/orchestrator_service",
+    "services/arrival_simulator_service/core",
+    "shared/services",
+    "shared/models",
 ]
 omit = [
     "*/__pycache__/*",
@@ -101,13 +99,26 @@ omit = [
     "*/agent/prompts.py",
     "*/agent/debrief_agent.py",
     "*/agent/debrief_prompt.py",
-    "*/agent/tools/confirm.py",
     "*/api/aircraft.py",
     "*/api/clearances.py",
     "*/api/debrief.py",
     "*/api/flight_plans.py",
     "*/api/weather.py",
     "*/shared/callbacks.py",
+    # Pulled in by the directory-level `source` entries above but out of scope
+    # for this phase: no test battery covers them yet. Several are also
+    # deletion candidates under issue #46.
+    "*/arrival_simulator_service/core/plan_catalog.py",
+    "*/arrival_simulator_service/core/scheduler.py",
+    "*/shared/services/aircraft_state_store.py",
+    "*/shared/services/aircraft_tracker.py",
+    "*/shared/services/airport_data_store.py",
+    "*/shared/services/stand_assigner.py",
+    "*/shared/models/aircraft.py",
+    "*/shared/models/aircraft_state.py",
+    "*/shared/models/airport.py",
+    "*/shared/models/command_parser.py",
+    "*/shared/models/communications.py",
     "tests/*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,50 @@ test = [
     "fastapi>=0.110",
     "sqlalchemy>=2.0",
 ]
+dev = [
+    "ruff>=0.14,<0.15",
+]
 
 [tool.setuptools.packages.find]
 include = ["xplane_plugin*"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+extend-exclude = ["*.ipynb", "data", "output", "logs", "wiki"]
+
+[tool.ruff.lint]
+# Ruff's default E subset. E501 (line length) is deliberately left out: ~40
+# files exceed 100 characters and `ruff format` cannot break long strings or
+# comments, so selecting it would mean hand-reflowing with no autofix behind
+# it. Add it once the formatting pass has landed.
+select = ["E4", "E7", "E9", "F", "I", "UP", "B"]
+
+[tool.ruff.lint.per-file-ignores]
+"**/__init__.py" = ["F401"]     # re-exports are the point of these files
+"tests/**" = ["E402"]           # sys.path setup has to precede project imports
+"plugins/**" = ["E402"]         # XPPython3 plugins import after the path hack
+"xplane_plugin/**" = ["E402"]
+# _load_env_file() must populate os.environ before FastAPI and the service
+# modules are imported, and routes.py extends sys.path the same way.
+"services/controller_hmi_service/main.py" = ["E402"]
+"services/controller_hmi_service/api/routes.py" = ["E402"]
+
+[tool.ruff.lint.flake8-bugbear]
+# FastAPI's dependency-injection defaults are function calls by design, so
+# B008 would fire on every endpoint signature in the repo.
+extend-immutable-calls = [
+    "fastapi.Body",
+    "fastapi.Depends",
+    "fastapi.File",
+    "fastapi.Form",
+    "fastapi.Header",
+    "fastapi.Path",
+    "fastapi.Query",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["services", "shared", "tests", "xplane_plugin"]
 
 [tool.pytest.ini_options]
 pythonpath = [".", "services/orchestrator_service", "services/arrival_simulator_service"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,4 +129,8 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "if __name__ == .__main__.:",
 ]
-fail_under = 70
+# Baseline measured on CI at 79% over 1364 statements (PR #80), with the
+# `source` scope corrected above. The gate sits two points below it to absorb
+# line-count noise; raise it as coverage improves. The old 70% target was set
+# against the broken scope and is already cleared.
+fail_under = 77

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ filterwarnings = [
 source = [
     "services/orchestrator_service",
     "services/arrival_simulator_service/core",
+    "services/weather_service/core",
     "shared/services",
     "shared/models",
 ]
@@ -110,6 +111,8 @@ omit = [
     # deletion candidates under issue #46.
     "*/arrival_simulator_service/core/plan_catalog.py",
     "*/arrival_simulator_service/core/scheduler.py",
+    "*/weather_service/core/database/*",
+    "*/weather_service/core/metar_taf_fetcher.py",
     "*/shared/services/aircraft_state_store.py",
     "*/shared/services/aircraft_tracker.py",
     "*/shared/services/airport_data_store.py",
@@ -129,8 +132,9 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "if __name__ == .__main__.:",
 ]
-# Baseline measured on CI at 79% over 1364 statements (PR #80), with the
-# `source` scope corrected above. The gate sits two points below it to absorb
-# line-count noise; raise it as coverage improves. The old 70% target was set
-# against the broken scope and is already cleared.
-fail_under = 77
+# The gate sits two points below the measured baseline to absorb line-count
+# noise, and is raised whenever a PR lifts coverage. History:
+#   77 — 78.89% over 1364 statements, `source` scope corrected (#47, PR #80)
+#   79 — 81.81% over 1523 statements, weather_service covered (#49)
+# The old 70% target was set against the broken scope and is already cleared.
+fail_under = 79

--- a/tests/debrief/test_debrief_builder.py
+++ b/tests/debrief/test_debrief_builder.py
@@ -6,11 +6,17 @@ _ORCH = Path(__file__).resolve().parents[2] / "services" / "orchestrator_service
 if str(_ORCH) not in sys.path:
     sys.path.insert(0, str(_ORCH))
 
-from debrief_builder import build_timeline, summarise_stats, truncate_timeline
+from debrief_builder import (
+    _coerce_ts,
+    _fmt_ts,
+    build_timeline,
+    summarise_stats,
+    truncate_timeline,
+)
 
 
 # Fixed epoch timestamps so formatting is deterministic (UTC)
-T0 = 1_776_800_000.0  # 2026-04-22 13:33:20 UTC
+T0 = 1_776_800_000.0  # 2026-04-21 19:33:20 UTC
 
 
 def test_timeline_ordering_mixes_sources():
@@ -95,3 +101,135 @@ def test_missing_text_fields_skipped():
         clearances=[],
     )
     assert text == ""
+
+
+# ---- Timestamp handling (issue #49) -----------------------------------------
+#
+# `_fmt_ts` and `_coerce_ts` accept epoch floats, ISO strings and None, because
+# transcripts arrive from Redis while clearances come from Postgres. The cases
+# below pin every branch before the #58 refactor touches them.
+
+
+def test_iso_timestamps_are_accepted_alongside_epochs():
+    text = build_timeline(
+        transcripts=[{"ts": "2026-04-22T13:33:20Z", "text": "first"}],
+        agent_replies=[],
+        events=[],
+        clearances=[{"updated_at": "2026-04-22T13:33:25+00:00",
+                     "aircraft_registration": "EC-IYV", "dependency": "DEL"}],
+    )
+    lines = text.splitlines()
+
+    assert lines[0].startswith("[13:33:20] CTRL")
+    assert lines[1].startswith("[13:33:25] CLEARANCE")
+
+
+def test_iso_and_epoch_entries_sort_into_one_sequence():
+    text = build_timeline(
+        transcripts=[{"ts": "2026-04-22T13:33:30Z", "text": "later"}],
+        agent_replies=[{"ts": T0, "reply": "earlier"}],
+        events=[],
+        clearances=[],
+    )
+
+    assert '"earlier"' in text.splitlines()[0]
+    assert '"later"' in text.splitlines()[1]
+
+
+def test_missing_timestamps_fall_back_to_the_epoch_and_sort_first():
+    text = build_timeline(
+        transcripts=[{"ts": T0, "text": "timed"}, {"text": "undated"}],
+        agent_replies=[],
+        events=[],
+        clearances=[],
+    )
+    lines = text.splitlines()
+
+    # `_coerce_ts(None)` is 0.0, so an undated entry is stamped 00:00:00 and
+    # leads the timeline rather than being marked unknown.
+    assert lines[0].startswith("[00:00:00]")
+    assert '"undated"' in lines[0]
+    assert lines[1].startswith("[19:33:20]")
+
+
+def test_unparseable_timestamps_degrade_instead_of_raising():
+    text = build_timeline(
+        transcripts=[{"ts": "not a timestamp", "text": "garbled"}],
+        agent_replies=[],
+        events=[],
+        clearances=[],
+    )
+
+    assert text.startswith("[00:00:00] CTRL")
+
+
+def test_coerce_ts_branches():
+    assert _coerce_ts(None) == 0.0
+    assert _coerce_ts(12) == 12.0
+    assert _coerce_ts(T0) == T0
+    assert _coerce_ts("2026-04-21T19:33:20+00:00") == T0
+    assert _coerce_ts("not a timestamp") == 0.0
+    assert _coerce_ts(object()) == 0.0
+
+
+def test_fmt_ts_string_and_placeholder_branches_are_unreachable_from_build_timeline():
+    # `build_timeline` always pipes timestamps through `_coerce_ts` first, so
+    # `_fmt_ts` only ever sees floats there. Its string and failure branches
+    # survive for direct callers; pinning them keeps the refactor honest about
+    # what it is allowed to delete.
+    assert _fmt_ts(None) == "--:--:--"
+    assert _fmt_ts("2026-04-22T13:33:20Z") == "13:33:20"
+    assert _fmt_ts("not a timestamp") == "--:--:--"
+    assert _fmt_ts(T0) == "19:33:20"
+
+
+def test_event_extra_drops_empty_and_structured_values():
+    text = build_timeline(
+        transcripts=[],
+        agent_replies=[],
+        events=[{"ts": T0, "registration": "EC-VBT", "event": "taxi_cleared",
+                 "extra": {"plan_id": "abc123", "note": "", "reason": None,
+                           "route": ["A", "B"], "holds": {"n": 1}, "ok": True}}],
+        clearances=[],
+    )
+
+    assert "plan_id=abc123" in text
+    assert "ok=True" in text
+    # Empty, null and nested values are all skipped rather than serialised.
+    for skipped in ("note=", "reason=", "route=", "holds="):
+        assert skipped not in text
+
+
+def test_clearance_summary_skips_unset_fields():
+    text = build_timeline(
+        transcripts=[],
+        agent_replies=[],
+        events=[],
+        clearances=[{"cleared_at": T0, "aircraft_registration": "EC-IYV",
+                     "dependency": "DEL", "squawk": 2000, "initial_altitude": 0,
+                     "runway_in_use": "", "destination_icao": None}],
+    )
+
+    assert "squawk=2000" in text
+    # 0, "" and None are all treated as "not set".
+    for skipped in ("initial_altitude=", "runway_in_use=", "destination_icao="):
+        assert skipped not in text
+
+
+def test_truncate_returns_text_unchanged_when_it_fits():
+    short = "\n".join(f"line {i}" for i in range(5))
+
+    assert truncate_timeline(short, max_chars=24000) == short
+
+
+def test_truncation_always_drops_at_least_one_line():
+    # The budget accounting adds a newline per kept line, so keeping every line
+    # costs len(text) + 1 — one over a budget that already triggered
+    # truncation. `dropped` can therefore never reach 0, which makes the
+    # marker-less return at the end of truncate_timeline dead code.
+    block = "\n".join(f"line {i}" for i in range(3))
+
+    out = truncate_timeline(block, max_chars=len(block) - 1)
+
+    assert out.startswith("[... 1 earlier entries omitted ...]")
+    assert out.endswith("line 1\nline 2")

--- a/tests/weather/_weather_service_import.py
+++ b/tests/weather/_weather_service_import.py
@@ -1,0 +1,71 @@
+"""Isolated import of weather_service modules for the tests in this package.
+
+Import `atis_generator` from here rather than reaching for `sys.path`::
+
+    from tests.weather._weather_service_import import atis_generator
+
+
+`weather_service` and `arrival_simulator_service` both ship top-level packages
+named `core`, and each service assumes its own directory sits on `sys.path`
+(that is how they run inside their containers). The `sys.path` shim that
+`tests/arrivals/conftest.py` uses therefore cannot be repeated here: whichever
+service lands on the path first wins, and `from core.arrival_planner import ...`
+and `from core.metar_taf_fetcher import ...` cannot both resolve in one session.
+
+So weather_service's modules are loaded from their file paths instead, with
+`core` and `models` aliased only for the duration of the load and restored
+afterwards. Nothing leaks into `sys.modules`, and the arrivals tests keep the
+`core` they expect. Coverage still attributes the lines correctly, because it
+keys on file paths rather than module names.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_SVC = Path(__file__).resolve().parents[2] / "services" / "weather_service"
+
+# Top-level names weather_service occupies while it is being imported. Anything
+# already bound to them is put back once the load finishes.
+_BORROWED = ("core", "core.atis_generator", "core.metar_taf_fetcher", "models", "models.schemas")
+
+
+def _exec_from_path(module_name: str, path: Path) -> types.ModuleType:
+    """Import `path` under `module_name`, registering it before execution.
+
+    Registering first is what lets `atis_generator` resolve its own
+    `from core.metar_taf_fetcher import get_metar` against the module already
+    placed in `sys.modules` rather than searching `sys.path` again.
+    """
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError(f"cannot load {module_name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_atis_generator() -> types.ModuleType:
+    saved = {name: sys.modules.get(name) for name in _BORROWED}
+    try:
+        for pkg_name, pkg_dir in (("core", _SVC / "core"), ("models", _SVC / "models")):
+            package = types.ModuleType(pkg_name)
+            package.__path__ = [str(pkg_dir)]
+            sys.modules[pkg_name] = package
+
+        _exec_from_path("models.schemas", _SVC / "models" / "schemas.py")
+        _exec_from_path("core.metar_taf_fetcher", _SVC / "core" / "metar_taf_fetcher.py")
+        return _exec_from_path("core.atis_generator", _SVC / "core" / "atis_generator.py")
+    finally:
+        for name, previous in saved.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+atis_generator = _load_atis_generator()

--- a/tests/weather/test_atis_broadcast.py
+++ b/tests/weather/test_atis_broadcast.py
@@ -1,0 +1,323 @@
+"""Characterization tests for the rest of `ATISGenerator` (issue #49).
+
+`_parse_metar` is covered in `test_atis_generator.py`; this file pins the
+methods around it — runway and approach selection, the ATIS letter sequence,
+transition levels, and the broadcast text that `generate()` assembles from all
+of them. Together they are the safety net for breaking the class up later.
+
+No network: `get_metar` is replaced at the module level, so `_fetch_metar` runs
+its real code against a canned payload.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.weather._weather_service_import import atis_generator
+
+ATISGenerator = atis_generator.ATISGenerator
+
+LEBL_METAR = {
+    "icaoId": "LEBL",
+    "reportTime": "2026-08-04 09:00:00",
+    "rawOb": "LEBL 040900Z 18008KT 9999 FEW025 27/20 Q1015 NOSIG",
+    "wdir": 180,
+    "wspd": 8,
+    "wgst": None,
+    "visib": "6+",
+    "wxString": None,
+    "clouds": [{"cover": "FEW", "base": 2500}],
+    "temp": 27,
+    "dewp": 20,
+    "altim": 1015,
+}
+
+
+@pytest.fixture
+def generator(monkeypatch):
+    """An ATISGenerator whose METAR feed returns LEBL_METAR."""
+    monkeypatch.setattr(atis_generator, "get_metar", lambda icao, output_format="json": [LEBL_METAR])
+    return ATISGenerator()
+
+
+# ---- Fetching ---------------------------------------------------------------
+
+
+def test_fetch_returns_the_first_observation(generator):
+    assert generator._fetch_metar("LEBL") == LEBL_METAR
+
+
+def test_empty_feed_is_reported_as_a_fetch_failure(monkeypatch):
+    monkeypatch.setattr(atis_generator, "get_metar", lambda icao, output_format="json": [])
+
+    with pytest.raises(ValueError, match="Failed to fetch METAR for LEBL"):
+        ATISGenerator()._fetch_metar("LEBL")
+
+
+def test_feed_errors_are_wrapped(monkeypatch):
+    def boom(icao, output_format="json"):
+        raise ConnectionError("upstream down")
+
+    monkeypatch.setattr(atis_generator, "get_metar", boom)
+
+    with pytest.raises(ValueError, match="upstream down"):
+        ATISGenerator()._fetch_metar("LEBL")
+
+
+# ---- Runway selection -------------------------------------------------------
+
+
+@pytest.mark.parametrize("wind, expected", [
+    (200, "20"),    # exact alignment with 20
+    (180, "20"),    # nearest of 02/20/07/25
+    (70, "07L"),    # ties break on the first runway listed
+    (250, "25L"),
+    (20, "02"),
+])
+def test_runway_is_the_closest_heading_to_the_wind(wind, expected):
+    runways = ["02", "20", "07L", "07R", "25L", "25R"]
+
+    assert ATISGenerator()._select_runway_from_wind(wind, runways) == expected
+
+
+def test_side_suffixes_are_stripped_before_comparing(generator):
+    assert generator._select_runway_from_wind(140, ["14L", "32R"]) == "14L"
+
+
+def test_non_numeric_runways_are_skipped(generator):
+    assert generator._select_runway_from_wind(180, ["ABC", "18"]) == "18"
+
+
+def test_no_usable_runway_yields_none(generator):
+    assert generator._select_runway_from_wind(180, ["ABC"]) is None
+    assert generator._select_runway_from_wind(180, []) is None
+
+
+# ---- Approach selection -----------------------------------------------------
+
+
+@pytest.mark.parametrize("available, expected", [
+    (["ILS", "VOR", "RNAV"], "ILS"),
+    (["VOR", "RNAV"], "VOR"),
+    (["RNAV"], "RNAV"),
+])
+def test_approach_preference_is_ils_then_vor_then_rnav(generator, available, expected):
+    airport = {"approaches": {"25R": available}}
+
+    assert generator._select_approach_for_runway("25R", airport) == expected
+
+
+def test_unranked_approach_falls_back_to_the_first_listed(generator):
+    airport = {"approaches": {"25R": ["LOC", "NDB"]}}
+
+    assert generator._select_approach_for_runway("25R", airport) == "LOC"
+
+
+@pytest.mark.parametrize("airport", [{"approaches": {"25R": []}}, {"approaches": {}}, {}])
+def test_runway_without_approaches_yields_none(generator, airport):
+    assert generator._select_approach_for_runway("25R", airport) is None
+
+
+# ---- ATIS letter sequence ---------------------------------------------------
+
+
+def test_letters_advance_per_airport(generator):
+    assert generator._get_next_atis_letter("LEBL") == "A"
+    assert generator._get_next_atis_letter("LEBL") == "B"
+    assert generator._get_next_atis_letter("LEMD") == "A"
+    assert generator._get_next_atis_letter("LEBL") == "C"
+
+
+def test_preview_does_not_consume_a_letter(generator):
+    assert generator._get_next_atis_letter("LEBL") == "A"
+    assert generator._get_next_atis_letter("LEBL", preview=True) == "B"
+    assert generator._get_next_atis_letter("LEBL", preview=True) == "B"
+    assert generator._get_next_atis_letter("LEBL") == "B"
+
+
+def test_the_sequence_wraps_after_z(generator):
+    generator._atis_counters["LEBL"] = 25
+
+    assert generator._get_next_atis_letter("LEBL") == "A"
+
+
+# ---- Transition level -------------------------------------------------------
+
+
+@pytest.mark.parametrize("qnh, expected", [
+    (1040, "FL65"), (1032, "FL65"),
+    (1031, "FL70"), (1014, "FL70"),
+    (1013, "FL75"), (996, "FL75"),
+    (995, "FL80"), (978, "FL80"),
+    (977, "FL90"), (950, "FL90"),
+])
+def test_transition_level_boundaries(generator, qnh, expected):
+    assert generator._calculate_transition_level(qnh) == expected
+
+
+# ---- Unknown airports -------------------------------------------------------
+
+
+def test_unknown_airport_gets_a_generic_09_27_layout(generator):
+    default = generator._get_default_airport("LEXX")
+
+    assert default["name"] == "LEXX"
+    assert default["runways"] == ["09", "27"]
+    assert default["approaches"] == {"09": ["RNAV"], "27": ["RNAV"]}
+
+
+def test_generate_falls_back_to_the_default_layout(generator):
+    response = generator.generate("LEXX")
+
+    assert response.arrival_runway in {"09", "27"}
+    assert response.approach_type == "RNAV"
+    assert response.transition_altitude == 6000
+
+
+# ---- generate() -------------------------------------------------------------
+
+
+def test_generate_auto_selects_runways_from_the_wind(generator):
+    response = generator.generate("LEBL")
+
+    assert response.icao_code == "LEBL"
+    assert response.atis_letter == "A"
+    assert response.departure_runway == "20"
+    assert response.arrival_runway == "20"
+    assert response.qnh_hpa == 1015
+    assert response.transition_level == "FL70"
+    assert response.raw_metar == LEBL_METAR["rawOb"]
+
+
+def test_atc_values_override_auto_selection(generator):
+    response = generator.generate(
+        "LEBL", departure_runway="25L", arrival_runway="25R", approach="ILS"
+    )
+
+    assert (response.departure_runway, response.arrival_runway) == ("25L", "25R")
+    assert response.approach_type == "ILS"
+
+
+def test_icao_code_is_upcased(generator):
+    assert generator.generate("lebl").icao_code == "LEBL"
+
+
+def test_variable_wind_leaves_runway_selection_to_atc(monkeypatch):
+    calm = dict(LEBL_METAR, wdir="VRB", wspd=3)
+    monkeypatch.setattr(atis_generator, "get_metar", lambda icao, output_format="json": [calm])
+
+    response = ATISGenerator().generate("LEBL")
+
+    assert response.wind_variable is True
+    assert response.departure_runway is None
+    assert response.arrival_runway is None
+    assert "Wind variable at 3 knots." in response.atis_text
+
+
+# ---- Broadcast text ---------------------------------------------------------
+
+
+def test_broadcast_reads_out_the_full_picture(generator):
+    text = generator.generate("LEBL").atis_text
+
+    assert text.startswith("Barcelona El Prat information ALFA.")
+    assert "Departure runway 20." in text
+    assert "Arrival runway 20." in text
+    assert "Wind 180 degrees, 8 knots." in text
+    assert "Visibility 10.0 kilometers." in text
+    assert "Clouds few at 2500 feet." in text
+    assert "Temperature 27, dewpoint 20." in text
+    assert "QNH 1015 hectopascals." in text
+    assert "Transition level FL70." in text
+    assert "Transition altitude 6000 feet." in text
+    assert "Information ALFA recorded at 0900 Zulu." in text
+    assert text.endswith("Advise on initial contact you have information ALFA.")
+
+
+def test_gusts_and_weather_reach_the_broadcast(monkeypatch):
+    stormy = dict(
+        LEBL_METAR,
+        wdir=220, wspd=15, wgst=28, wxString="TSRA",
+        clouds=[{"cover": "BKN", "base": 1200}, {"cover": "OVC", "base": 3000}],
+    )
+    monkeypatch.setattr(atis_generator, "get_metar", lambda icao, output_format="json": [stormy])
+
+    text = ATISGenerator().generate("LEBL").atis_text
+
+    assert "Wind 220 degrees, 15 knots, gusting 28." in text
+    assert "Weather: thunderstorm with rain." in text
+    assert "Clouds broken at 1200 feet, overcast at 3000 feet." in text
+
+
+def test_optional_sections_are_suppressed_on_request(generator):
+    text = generator.generate("LEBL", include_tl=False, include_ta=False).atis_text
+
+    assert "Transition level" not in text
+    assert "Transition altitude" not in text
+
+
+def test_qfe_and_remarks_are_appended(generator):
+    text = generator.generate("LEBL", qfe=1013, remarks="  bird activity  ").atis_text
+
+    assert "QFE 1013 hectopascals." in text
+    assert text.endswith("RMK bird activity")
+
+
+def test_blank_remarks_are_dropped(generator):
+    assert "RMK" not in generator.generate("LEBL", remarks="   ").atis_text
+
+
+def test_preview_broadcasts_do_not_burn_a_letter(generator):
+    assert generator.generate("LEBL", preview=True).atis_letter == "A"
+    assert generator.generate("LEBL").atis_letter == "A"
+    assert generator.generate("LEBL").atis_letter == "B"
+
+
+class TestBroadcastQuirks:
+    """Pinned oddities in the spoken text — see `TestQuirks` in the sibling file."""
+
+    def test_a_northerly_wind_is_announced_as_variable(self, monkeypatch):
+        # `parsed["wind_direction"] == 0` is treated as "variable", but 0 is
+        # also what a wind from 360 degrees parses to, so a real northerly
+        # loses its direction in the broadcast.
+        northerly = dict(LEBL_METAR, wdir=0, wspd=12)
+        monkeypatch.setattr(
+            atis_generator, "get_metar", lambda icao, output_format="json": [northerly]
+        )
+
+        response = ATISGenerator().generate("LEBL")
+
+        assert response.wind_variable is False
+        assert "Wind variable at 12 knots." in response.atis_text
+
+    def test_cavok_is_unreachable_through_generate(self, generator):
+        # `_generate_atis_text` has a CAVOK branch, but `_parse_metar` never
+        # sets the `cavok` key, so a CAVOK observation is still read out as a
+        # visibility figure. The branch is only reachable by calling the text
+        # builder directly.
+        parsed = generator._parse_metar({
+            "rawOb": "LEBL 040900Z 18008KT CAVOK 27/20 Q1015",
+            "reportTime": "2026-08-04 09:00:00",
+            "wdir": 180, "wspd": 8, "temp": 27, "dewp": 20, "altim": 1015,
+        })
+        assert "cavok" not in parsed
+
+        spoken = generator._generate_atis_text(
+            icao_code="LEBL",
+            atis_letter="A",
+            parsed={**parsed, "cavok": True},
+            departure_runway=None,
+            arrival_runway=None,
+            approach=None,
+            transition_level="FL70",
+            transition_altitude=6000,
+            airport_name="Barcelona El Prat",
+        )
+
+        assert "CAVOK." in spoken
+        assert "Visibility" not in spoken
+
+    def test_visibility_is_announced_to_one_decimal_kilometre(self, generator):
+        # 9999 m is the METAR code for "10 km or more"; rounding prints it as
+        # a flat 10.0 km, which is the intent, but 9500 m reads as 9.5 km.
+        assert "Visibility 10.0 kilometers." in generator.generate("LEBL").atis_text

--- a/tests/weather/test_atis_generator.py
+++ b/tests/weather/test_atis_generator.py
@@ -1,0 +1,368 @@
+"""Characterization tests for `ATISGenerator._parse_metar` (issue #49).
+
+These pin down what the parser does *today*, quirks included, so the giant
+functions around it can be broken up later without silently changing METAR
+interpretation. Where current behaviour looks wrong (see the `Quirks` class)
+the test asserts the wrong answer on purpose and says so — fixing it is a
+separate change against a passing suite.
+
+Payloads follow the shape aviationweather.gov returns for
+`/api/data/metar?format=json`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.weather._weather_service_import import atis_generator
+
+ATISGenerator = atis_generator.ATISGenerator
+
+
+def metar(**overrides) -> dict:
+    """A well-formed LEBL payload, overridable field by field.
+
+    `None` is a meaningful value for several fields, so removing a key is
+    spelled by passing the sentinel `DROP`.
+    """
+    payload = {
+        "icaoId": "LEBL",
+        "reportTime": "2026-08-04 09:00:00",
+        "rawOb": "LEBL 040900Z 18008KT 9999 FEW025 27/20 Q1015 NOSIG",
+        "wdir": 180,
+        "wspd": 8,
+        "wgst": None,
+        "visib": "6+",
+        "wxString": None,
+        "clouds": [{"cover": "FEW", "base": 2500}],
+        "temp": 27,
+        "dewp": 20,
+        "altim": 1015,
+    }
+    payload.update(overrides)
+    return {k: v for k, v in payload.items() if v is not DROP}
+
+
+class _Drop:
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "DROP"
+
+
+DROP = _Drop()
+
+
+@pytest.fixture
+def parse():
+    generator = ATISGenerator()
+    return generator._parse_metar
+
+
+# ---- Wind -------------------------------------------------------------------
+
+
+def test_numeric_wind_direction_is_not_variable(parse):
+    parsed = parse(metar(wdir=180, wspd=8))
+
+    assert parsed["wind_direction"] == 180
+    assert parsed["wind_speed"] == 8
+    assert parsed["wind_variable"] is False
+
+
+def test_string_wind_direction_is_coerced_to_int(parse):
+    # aviationweather.gov returns wdir as a number, but the raw feed has been
+    # seen serialising it as a string.
+    assert parse(metar(wdir="240"))["wind_direction"] == 240
+
+
+@pytest.mark.parametrize("wdir", ["VRB", None, DROP])
+def test_variable_wind_reports_zero_degrees(parse, wdir):
+    parsed = parse(metar(wdir=wdir))
+
+    assert parsed["wind_direction"] == 0
+    assert parsed["wind_variable"] is True
+
+
+def test_gust_is_parsed_when_present(parse):
+    assert parse(metar(wgst=25))["wind_gust"] == 25
+
+
+@pytest.mark.parametrize("wgst", [None, DROP])
+def test_absent_gust_is_none(parse, wgst):
+    assert parse(metar(wgst=wgst))["wind_gust"] is None
+
+
+def test_missing_wind_speed_defaults_to_calm(parse):
+    assert parse(metar(wspd=DROP))["wind_speed"] == 0
+
+
+# ---- Visibility -------------------------------------------------------------
+
+
+def test_9999_in_raw_metar_wins_over_visib(parse):
+    # The rawOb marker is checked first, so the statute-mile field is ignored.
+    parsed = parse(metar(
+        rawOb="LEBL 040900Z 18008KT 9999 FEW025 27/20 Q1015",
+        visib="2",
+    ))
+
+    assert parsed["visibility_m"] == 9999
+
+
+def test_statute_miles_are_converted_to_metres(parse):
+    parsed = parse(metar(rawOb="LEBL 040900Z 18008KT 3SM BR 27/20 Q1015", visib="1.5"))
+
+    assert parsed["visibility_m"] == int(1.5 * 1609.34)
+
+
+def test_plus_suffix_is_stripped_before_conversion(parse):
+    # "6+" means "6 statute miles or more"; 6 SM clamps below the 9999 ceiling.
+    parsed = parse(metar(rawOb="LEBL 040900Z 18008KT 6SM FEW025 27/20 Q1015", visib="6+"))
+
+    assert parsed["visibility_m"] == 9656
+
+
+def test_long_visibility_is_clamped_to_9999(parse):
+    parsed = parse(metar(rawOb="LEBL 040900Z 18008KT 10SM FEW025 27/20 Q1015", visib="10+"))
+
+    assert parsed["visibility_m"] == 9999
+
+
+def test_missing_visibility_falls_back_to_9999(parse):
+    parsed = parse(metar(rawOb="LEBL 040900Z 18008KT FEW025 27/20 Q1015", visib=DROP))
+
+    assert parsed["visibility_m"] == 9999
+
+
+# ---- Weather phenomena ------------------------------------------------------
+
+
+def test_known_phenomenon_is_described(parse):
+    parsed = parse(metar(wxString="TSRA"))
+
+    assert parsed["weather"] == "TSRA"
+    assert parsed["weather_description"] == "thunderstorm with rain"
+
+
+def test_unknown_phenomenon_passes_through_undescribed(parse):
+    parsed = parse(metar(wxString="SG"))
+
+    assert parsed["weather"] == "SG"
+    assert parsed["weather_description"] == "SG"
+
+
+@pytest.mark.parametrize("wx", [None, DROP])
+def test_no_phenomenon_leaves_the_keys_unset(parse, wx):
+    # Callers use parsed.get("weather"), so the keys are simply absent.
+    parsed = parse(metar(wxString=wx))
+
+    assert "weather" not in parsed
+    assert "weather_description" not in parsed
+
+
+# ---- Clouds and ceiling -----------------------------------------------------
+
+
+def test_layers_are_preserved_in_order(parse):
+    parsed = parse(metar(clouds=[
+        {"cover": "FEW", "base": 1200},
+        {"cover": "SCT", "base": 3000},
+    ]))
+
+    assert [(layer.coverage, layer.base_ft) for layer in parsed["clouds"]] == [
+        ("FEW", 1200),
+        ("SCT", 3000),
+    ]
+
+
+def test_ceiling_is_the_lowest_broken_or_overcast_layer(parse):
+    parsed = parse(metar(clouds=[
+        {"cover": "FEW", "base": 800},
+        {"cover": "OVC", "base": 2500},
+        {"cover": "BKN", "base": 1500},
+    ]))
+
+    assert parsed["ceiling_ft"] == 1500
+
+
+def test_few_and_scattered_never_form_a_ceiling(parse):
+    parsed = parse(metar(clouds=[
+        {"cover": "FEW", "base": 700},
+        {"cover": "SCT", "base": 1100},
+    ]))
+
+    assert parsed["ceiling_ft"] is None
+
+
+@pytest.mark.parametrize("layer", [
+    {"cover": "BKN", "base": None},
+    {"cover": None, "base": 1500},
+    {},
+])
+def test_incomplete_layers_are_skipped(parse, layer):
+    parsed = parse(metar(clouds=[layer]))
+
+    assert parsed["clouds"] == []
+    assert parsed["ceiling_ft"] is None
+
+
+def test_clear_sky_yields_no_layers(parse):
+    parsed = parse(metar(clouds=[], rawOb="LEBL 040900Z 18008KT CAVOK 27/20 Q1015"))
+
+    assert parsed["clouds"] == []
+    assert parsed["ceiling_ft"] is None
+
+
+# ---- Temperature and pressure -----------------------------------------------
+
+
+def test_temperature_and_dewpoint_are_read(parse):
+    parsed = parse(metar(temp=27, dewp=20))
+
+    assert (parsed["temperature_c"], parsed["dewpoint_c"]) == (27, 20)
+
+
+def test_subzero_temperatures_survive_truncation(parse):
+    parsed = parse(metar(temp=-3.4, dewp=-5.6))
+
+    # int() truncates toward zero rather than rounding.
+    assert (parsed["temperature_c"], parsed["dewpoint_c"]) == (-3, -5)
+
+
+def test_missing_temperature_falls_back_to_isa_ish_defaults(parse):
+    parsed = parse(metar(temp=DROP, dewp=DROP))
+
+    assert (parsed["temperature_c"], parsed["dewpoint_c"]) == (15, 10)
+
+
+def test_qnh_is_read_in_hectopascals(parse):
+    assert parse(metar(altim=1015))["qnh_hpa"] == 1015
+
+
+def test_fractional_qnh_is_truncated(parse):
+    assert parse(metar(altim=1015.9))["qnh_hpa"] == 1015
+
+
+@pytest.mark.parametrize("altim", [None, DROP])
+def test_missing_qnh_falls_back_to_standard_pressure(parse, altim):
+    assert parse(metar(altim=altim))["qnh_hpa"] == 1013
+
+
+# ---- Observation time and raw text ------------------------------------------
+
+
+def test_report_time_is_parsed(parse):
+    parsed = parse(metar(reportTime="2026-08-04 09:00:00"))
+
+    assert parsed["observation_time"] == datetime(2026, 8, 4, 9, 0, 0)
+
+
+def test_trailing_z_becomes_a_utc_offset(parse):
+    parsed = parse(metar(reportTime="2026-08-04T09:00:00Z"))
+
+    assert parsed["observation_time"] == datetime(2026, 8, 4, 9, 0, tzinfo=timezone.utc)
+
+
+def test_missing_report_time_falls_back_to_now(parse):
+    before = datetime.utcnow()
+    parsed = parse(metar(reportTime=DROP))
+
+    assert before <= parsed["observation_time"] <= datetime.utcnow()
+    # Naive, i.e. not comparable with the tz-aware value the "Z" form produces.
+    assert parsed["observation_time"].tzinfo is None
+
+
+def test_raw_metar_is_carried_through(parse):
+    raw = "LEBL 040900Z 18008KT 9999 FEW025 27/20 Q1015 NOSIG"
+
+    assert parse(metar(rawOb=raw))["raw_metar"] == raw
+
+
+def test_missing_raw_metar_becomes_empty_string(parse):
+    assert parse(metar(rawOb=DROP))["raw_metar"] == ""
+
+
+# ---- Real payloads ----------------------------------------------------------
+
+
+def test_lemd_thunderstorm_payload(parse):
+    parsed = parse({
+        "icaoId": "LEMD",
+        "reportTime": "2026-08-04 16:30:00",
+        "rawOb": "LEMD 041630Z 22015G28KT 4000 TSRA BKN012CB OVC030 24/19 Q1008",
+        "wdir": 220,
+        "wspd": 15,
+        "wgst": 28,
+        "visib": "2.5",
+        "wxString": "TSRA",
+        "clouds": [{"cover": "BKN", "base": 1200}, {"cover": "OVC", "base": 3000}],
+        "temp": 24,
+        "dewp": 19,
+        "altim": 1008,
+    })
+
+    assert parsed["wind_direction"] == 220
+    assert parsed["wind_gust"] == 28
+    assert parsed["visibility_m"] == 4023
+    assert parsed["weather_description"] == "thunderstorm with rain"
+    assert parsed["ceiling_ft"] == 1200
+    assert parsed["qnh_hpa"] == 1008
+
+
+def test_lest_low_visibility_payload(parse):
+    parsed = parse({
+        "icaoId": "LEST",
+        "reportTime": "2026-08-04 06:00:00",
+        "rawOb": "LEST 040600Z VRB02KT 0500 FG VV002 11/11 Q1021",
+        "wdir": "VRB",
+        "wspd": 2,
+        "wgst": None,
+        "visib": "0.3",
+        "wxString": "FG",
+        "clouds": [],
+        "temp": 11,
+        "dewp": 11,
+        "altim": 1021,
+    })
+
+    assert parsed["wind_variable"] is True
+    assert parsed["wind_direction"] == 0
+    assert parsed["visibility_m"] == 482
+    assert parsed["weather_description"] == "fog"
+    assert parsed["ceiling_ft"] is None
+
+
+# ---- Quirks -----------------------------------------------------------------
+
+
+class TestQuirks:
+    """Behaviour that is almost certainly wrong, pinned so a fix is deliberate.
+
+    Each of these is a candidate bug report against `_parse_metar`; none is
+    fixed here, because #49 is the safety net for the refactor, not the
+    refactor.
+    """
+
+    def test_zero_visibility_reports_unlimited(self, parse):
+        # `elif visib:` treats a numeric 0 as "field absent", so a METAR
+        # reporting no visibility at all comes back as 9999 m — the exact
+        # opposite of the truth.
+        parsed = parse(metar(rawOb="LEST 040600Z VRB02KT 0000 FG 11/11 Q1021", visib=0))
+
+        assert parsed["visibility_m"] == 9999
+
+    def test_zero_gust_is_dropped(self, parse):
+        # Harmless in practice (a 0 kt gust is not reported), but the same
+        # falsy-vs-absent conflation as above.
+        assert parse(metar(wgst=0))["wind_gust"] is None
+
+    def test_9999_anywhere_in_the_raw_text_is_taken_as_visibility(self, parse):
+        # The marker is matched against the whole rawOb, not the visibility
+        # group, so an unrelated token wins.
+        parsed = parse(metar(
+            rawOb="LEBL 040900Z 18008KT 0500 FG RMK 9999 TEST 27/20 Q1015",
+            visib="0.3",
+        ))
+
+        assert parsed["visibility_m"] == 9999


### PR DESCRIPTION
Closes #48. Stacked behind #80 and #86 — the diff cleans up as those merge.

## Config only, no reformat

The issue proposes an initial autofix commit. Holding it back: `ruff check --fix` + `ruff format` touches **158 files**, which would collide head-on with the strict-taxi work in flight (#66–#72) and the open refactors (#55–#57, #63, #64). It lands as its own isolated commit once those merge, flipping `continue-on-error` off in the same change. Until then the `lint` job reports violations without blocking.

## Rules

`E4`, `E7`, `E9`, `F`, `I`, `UP`, `B` — ruff's default `E` subset. **`E501` is deliberately out**: ~40 files exceed 100 characters and `ruff format` cannot break long strings or comments, so selecting it would mean hand-reflowing with no autofix behind it. It goes in after the formatting pass.

Three sets of false positives are pre-empted, or the report would be mostly noise:

| Rule | Why it's ignored |
|---|---|
| `B008` | FastAPI's `Depends()` / `Query()` defaults are function calls by design — it would fire on every endpoint signature in the repo |
| `E402` | Import order is load-bearing in the conftest `sys.path` shims, the XPPython3 plugins, and `controller_hmi_service/main.py`, which must populate `os.environ` before the service modules import |
| `F401` | Re-exports are the point of `__init__.py` |

## Sizing the follow-up

Measured by running the pass locally and reverting it:

| | Count |
|---|---|
| Violations today | 421 |
| Autofixable | 316 |
| Files the formatter would rewrite | 121 |
| Files touched by the full pass | 158 |
| **Left needing a human afterwards** | **42** |

The residue: 24 `B904` (raise-without-from — overlaps the exception-handler audit in #63), 9 `B905` (zip-without-strict), 5 `E741`, 3 `B007`, 1 `F841`.

## Acceptance criteria

- [x] `[tool.ruff]` configured in `pyproject.toml`
- [x] Lint job in `ci.yml` — advisory now, blocking in the follow-up commit
- [ ] Codebase formatted (isolated autofix commit, deferred — see above)