### PR TITLE
Docs (#59): openwiki refresh for the TypeScript HMI frontend

### DIFF
--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,6 +1,6 @@
 {
-  "last_commit": "a0b057cf49bf271b3f8baad5f6700f3de5b0be1d",
-  "updated_at": "2026-07-13T09:33:55Z",
-  "mode": "full-generation",
+  "last_commit": "27bdf10bb26120e1654ae59cfd9fa9f9f2eb07c8",
+  "updated_at": "2026-08-04T12:50:21Z",
+  "mode": "incremental-update",
   "generator": "openwiki-writer"
 }

--- a/openwiki/services/asr_service.md
+++ b/openwiki/services/asr_service.md
@@ -84,7 +84,7 @@ untouched, with a strict JSON schema, an 8-second timeout, and a fail-open contr
 keeps the deterministic result.
 
 One live-wiring nuance: the browser client
-([`ptt.js`](../../services/controller_hmi_service/static/js/ptt.js)) posts only `audio` and
+([`legacy/ptt.ts`](../../services/controller_hmi_service/frontend/src/legacy/ptt.ts)) posts only `audio` and
 `session_id` — never `session_callsigns`, `session_sids` or `context_mode` — and the HMI's proxy
 forwards that multipart body byte-for-byte. So every PTT transmission today runs stages 1-4 under
 the `generic` prompt; the session-aware fuzzy snap and the LLM step are fully wired and gated as

--- a/openwiki/services/controller_hmi_service.md
+++ b/openwiki/services/controller_hmi_service.md
@@ -165,7 +165,85 @@ above.
 | [`api/chat.py`](../../services/controller_hmi_service/api/chat.py) | `hmi:chat` WebSocket fan-out |
 | [`api/plugin_routes.py`](../../services/controller_hmi_service/api/plugin_routes.py) | Auth, session handshake, per-user ASR key — browser-called, despite the name |
 | [`api/auth.py`](../../services/controller_hmi_service/api/auth.py) | Postgres connection + password hashing |
-| `static/` | The served UI: strips, radar, ATIS, PTT, setup |
+| `static/` | Vite build output the browser actually receives — gitignored, generated, never edited by hand (see below) |
+
+## Frontend: Vite + TypeScript (epic #59)
+
+The UI used to be hand-written JS living straight under `static/js/`. As of epic #59 (PRs
+#76-#89, merged into `dev`) it is a proper build: source lives in
+[`frontend/`](../../services/controller_hmi_service/frontend/) and compiles into `static/`, which
+`main.py` still serves via `StaticFiles(directory="static", html=True)` — the runtime contract at
+the bottom of [architecture](../architecture.md) hasn't changed, only how that directory gets
+built.
+
+**History, briefly:** the original `static/*.html` files were never actually committed — an
+unanchored `*.html` rule in `.gitignore` silently swallowed them from day one, and no copy
+survived on disk. Phase 0 of the migration (`7706a5a`) reverse-engineered `index.html` and
+`setup.html` from the 11 legacy JS files' DOM lookups and pinned the result with a regression
+test (`test_dom_contract.py`, below) before any TypeScript conversion began.
+
+### Source layout
+
+`frontend/` is a Vite 6 + TypeScript 5 (`strict`, `noUncheckedIndexedAccess`) multi-page root —
+two HTML entry points, one `src/` tree:
+
+| Path | Role |
+|---|---|
+| [`index.html`](../../services/controller_hmi_service/frontend/index.html) | TWR workstation page; loads `src/main.ts` |
+| [`setup.html`](../../services/controller_hmi_service/frontend/setup.html) | Login / register / session / ASR-settings page; loads `src/setup-main.ts` |
+| [`src/main.ts`](../../services/controller_hmi_service/frontend/src/main.ts) | Composition root for `index.html`: imports CSS + legacy modules for their side-effect listener wiring, then calls `startUTCClock`, `initWindInstruments`, `initLightingControls`, `initSMRMap`, `startPolling` on `DOMContentLoaded` |
+| [`src/setup-main.ts`](../../services/controller_hmi_service/frontend/src/setup-main.ts) | Composition root for `setup.html`: `legacy/radar`, `legacy/asr`, `legacy/setup` |
+| [`src/legacy/`](../../services/controller_hmi_service/frontend/src/legacy/) | The 12 DOM-bound feature modules migrated from vanilla JS: `efs`, `weather`, `wind`, `atis`, `debrief`, `setup`, `asr`, `radar`, `resize`, `ptt`, `chat`, `header-widgets` — all strict TS, no IIFEs, no `window` bridges; each module wires its own `addEventListener` calls in an `init*()` function called from a composition root |
+| [`src/smr/`](../../services/controller_hmi_service/frontend/src/smr/) | Ground-radar internals: `projection.ts` (pure geo→SVG math, Vitest-tested), `state.ts` (shared `smrState`: graph, bounds, viewBox, active ILS runway), `render.ts` (builds/updates the SVG), `interaction.ts` (pan/zoom/label-drag) |
+| [`src/polling.ts`](../../services/controller_hmi_service/frontend/src/polling.ts) | The five refresh loops (strips 15 s, weather/TAF 60 s, airport 30 s, live positions 1 s) plus the app-level data they own (`flightPlans`, live positions, `currentICAO`) — the closest thing the app has to a store, see ADR-001 below |
+| [`src/chat/ui.ts`](../../services/controller_hmi_service/frontend/src/chat/ui.ts), [`src/efs/format.ts`](../../services/controller_hmi_service/frontend/src/efs/format.ts) + [`ordering.ts`](../../services/controller_hmi_service/frontend/src/efs/ordering.ts), [`src/weather/taf.ts`](../../services/controller_hmi_service/frontend/src/weather/taf.ts), [`src/wind/calc.ts`](../../services/controller_hmi_service/frontend/src/wind/calc.ts) | Pure logic extracted out of the DOM-bound modules specifically so it can be unit-tested |
+| [`src/api/client.ts`](../../services/controller_hmi_service/frontend/src/api/client.ts) | One typed fetch wrapper per backend endpoint (`getStrips`, `getAircraftPositions`, `dispatchOrchestrator`, `login`, `startSession`, ...) |
+| [`src/types/api.ts`](../../services/controller_hmi_service/frontend/src/types/api.ts) | Typed mirror of the backend contract — kept in sync by hand against `api/routes.py`, `api/plugin_routes.py`, `api/chat.py` |
+| [`src/lib/storage.ts`](../../services/controller_hmi_service/frontend/src/lib/storage.ts) | Typed accessors for every `localStorage` key (`airport_asr_settings`, `hmi-panel-sizes`, per-registration SMR label offsets and strip labels) |
+| `src/lighting.ts`, `src/rimcas.ts`, `src/runway-sequence.ts` | Smaller standalone panels (lighting controls, runway-incursion alerting, the runway-sequence bar) pulled out of the old `app.js` god-file |
+
+### Build output and `config.js`
+
+`static/` is entirely generated — `npm run build` (or `npm run watch`) — and is gitignored;
+nothing under it is hand-edited or committed. `main.py` still regenerates `static/config.js` at
+every service start from `ASR_URL` / `ORCHESTRATOR_URL`, and that file stays **outside** the Vite
+bundle graph by design: both HTML entries load it with a plain `<script src="/config.js">` before
+the module script, so runtime env vars don't need a rebuild. `public/config.js` is a checked-in
+dev fallback Vite copies verbatim for `npm run dev`.
+
+### Dev workflows
+
+`docker-compose.yml` bind-mounts `./static:/app/static`, which **shadows** whatever the Docker
+image built — so the host `static/` must be produced separately before `docker compose up`:
+
+| Workflow | Command | When |
+|---|---|---|
+| Build once | `cd frontend && npm ci && npm run build`, then `docker compose up -d` | Simplest, no live iteration |
+| Watch + rebuild | `npm run watch` | Editing while the stack runs; reload the browser after each save |
+| Vite dev server | `npm run dev` (port 5173, proxies `/api` to `:8005` with `ws: true` for the chat WebSocket) | Fastest loop, HMR for CSS |
+
+Without the compose bind mount (e.g. Cloud Run), the multi-stage
+[`Dockerfile`](../../services/controller_hmi_service/Dockerfile) is self-contained: a
+`node:22-alpine` stage runs `npm ci && npm run build`, and the `python:3.11-slim` stage copies
+`main.py`, `api/`, and the built `static/` from it.
+
+### Testing
+
+| Layer | What | Where |
+|---|---|---|
+| Vitest | 53 unit tests over the pure modules (`efs/format`, `efs/ordering`, `weather/taf`, `wind/calc`, `smr/projection`) | `npm test` (or `npm run test:watch`); config in [`vitest.config.ts`](../../services/controller_hmi_service/frontend/vitest.config.ts) |
+| DOM contract | Pins the JS↔HTML contract so the Phase-0 loss can't repeat: every `getElementById`/`querySelector` id or class the TS looks up must resolve in `index.html`/`setup.html` (minus an explicit allowlist of runtime-created ids/classes), and inline `on*=` handlers are forbidden outright | [`tests/unit/controller_hmi/test_dom_contract.py`](../../tests/unit/controller_hmi/test_dom_contract.py) |
+| CI | A dedicated `frontend` job (`.github/workflows/ci.yml`) runs `npm ci`, `typecheck`, `lint`, `test`, `build` on Node 22 for every push/PR touching `dev`/`main` | [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) |
+
+### State: no Redux Toolkit, for now
+
+The repo-wide rule mandates Redux Toolkit for global state, but there is no React here, and after
+the Phase-3 module split `polling.ts` (server data) and `smr/state.ts` (SMR view state) already
+centralize ownership behind typed functions at near-zero cost — hand-rolled RTK without React
+would out-boilerplate the state surface it manages. The decision, and the concrete triggers that
+would flip it (a React rewrite, shared *derived* state across more than two consumers, undo/redo
+or cross-tab sync), are recorded in
+[`frontend/docs/adr-001-no-global-state-library.md`](../../services/controller_hmi_service/frontend/docs/adr-001-no-global-state-library.md).
 
 ## Related
 [architecture](../architecture.md) · [xplane](../xplane.md) · [asr](asr_service.md) · [orchestrator](orchestrator_service.md) · [index](../index.md)


### PR DESCRIPTION
Openwiki refresh closing out epic #59: `services/controller_hmi_service.md` now documents the frontend architecture (Vite+TS layout, `static/` as gitignored build output, `config.js` runtime contract, dev workflows, multi-stage Dockerfile, Vitest + DOM-contract testing, ADR-001) with a historical note on the Phase 0 HTML recovery; stale `static/js` link fixed in `asr_service.md`; `.last-update.json` bumped. Generated with the openwiki-writer agent, every claim verified against the code.

Part of #59.