### PR TITLE
fix(hmi): commit the storage module the gitignore was swallowing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,10 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+# Anchored to the repo root: unanchored, these match any lib/ at any depth and
+# silently swallowed services/controller_hmi_service/frontend/src/lib/.
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/services/controller_hmi_service/frontend/src/lib/storage.ts
+++ b/services/controller_hmi_service/frontend/src/lib/storage.ts
@@ -1,0 +1,90 @@
+// Typed accessors for every localStorage key the HMI uses.
+// All reads are defensive: malformed JSON falls back to the default.
+
+export interface AsrSettings {
+  ptt_key?: string;
+  input_device?: string;
+  output_device?: string;
+  backend?: string;
+  ollama_url?: string;
+  ollama_model?: string;
+  api_key?: string;
+  api_base_url?: string;
+  api_model?: string;
+}
+
+export interface PanelSizes {
+  leftW: number;
+  dashH: number;
+  bottomH: number;
+  commsH: number;
+}
+
+export interface LabelOffset {
+  ox: number;
+  oy: number;
+}
+
+function readJson<T>(key: string): T | null {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // storage full / unavailable — settings are best-effort
+  }
+}
+
+// ---- airport_asr_settings ----
+
+export const getAsrSettings = (): AsrSettings => readJson<AsrSettings>('airport_asr_settings') ?? {};
+
+export const setAsrSettings = (settings: AsrSettings): void =>
+  writeJson('airport_asr_settings', settings);
+
+// ---- airport_username ----
+
+export const getUsername = (): string | null => localStorage.getItem('airport_username');
+
+export const setUsername = (username: string): void =>
+  localStorage.setItem('airport_username', username);
+
+// ---- hmi-panel-sizes ----
+
+export function getPanelSizes(): PanelSizes | null {
+  const p = readJson<PanelSizes>('hmi-panel-sizes');
+  if (
+    p &&
+    (['leftW', 'dashH', 'bottomH', 'commsH'] as const).every(
+      (k) => typeof p[k] === 'number' && isFinite(p[k]),
+    )
+  ) {
+    return p;
+  }
+  return null;
+}
+
+export const setPanelSizes = (sizes: PanelSizes): void => writeJson('hmi-panel-sizes', sizes);
+
+// ---- smr_lbl_offset_{registration} ----
+
+export const getSmrLabelOffset = (registration: string): LabelOffset =>
+  readJson<LabelOffset>(`smr_lbl_offset_${registration}`) ?? { ox: 0, oy: 0 };
+
+export const setSmrLabelOffset = (registration: string, offset: LabelOffset): void =>
+  writeJson(`smr_lbl_offset_${registration}`, offset);
+
+// ---- strip_lbl_{registration}_{key} ----
+
+export const getStripLabel = (registration: string, key: string): string | null =>
+  localStorage.getItem(`strip_lbl_${registration}_${key}`);
+
+export const setStripLabel = (registration: string, key: string, value: string): void =>
+  localStorage.setItem(`strip_lbl_${registration}_${key}`, value);


### PR DESCRIPTION
Unblocks the `frontend` job, red on `dev` and on every open PR.

## What happened

The Python packaging block in `.gitignore` carries `lib/` and `lib64/` **unanchored**, so they match a `lib/` directory at any depth — including `services/controller_hmi_service/frontend/src/lib/`.

`storage.ts` (the typed `localStorage` accessors) was written during the TypeScript migration, silently never staged, and never missed locally because the file sits happily on disk. On CI it simply doesn't exist:

```
src/legacy/asr.ts(4,66):    error TS2307: Cannot find module '../lib/storage'
src/legacy/resize.ts(3,63): error TS2307: Cannot find module '../lib/storage'
src/legacy/setup.ts(4,29):  error TS2307: Cannot find module '../lib/storage'
```

Same failure mode that lost the HMI's `.html` files earlier.

## The fix

Anchor both patterns to the repo root, where the Python build artefacts they target actually live, and add the missing module. `git status --ignored` confirms the frontend `src/lib/` was the only thing the unanchored form was catching.

Verified on a clean checkout of this branch — not the working tree that already had the file:

| Step | Result |
|---|---|
| `npm run typecheck` | pass |
| `npm run lint` | pass |
| `npm run build` | pass, 36 modules |

## Worth a look afterwards

`.gitignore` is a stock Python template applied to a repo that is now half TypeScript. Other unanchored directory patterns in it — `build/`, `dist/`, `share/`, `var/` — can bite the same way as the frontend grows.