### PR TITLE
refactor: deduplicate _fmt_ts and _generate_registration (partial #54)

### DIFF
--- a/services/flight_plan_service/core/api_generator.py
+++ b/services/flight_plan_service/core/api_generator.py
@@ -1,6 +1,5 @@
 import os
 import random
-import string
 import logging
 from datetime import datetime, timedelta
 from typing import Optional
@@ -9,6 +8,7 @@ import httpx
 
 from models.schemas import FlightPlanResponse
 from core.data import AIRCRAFT_DATA, PILOT_NAMES, AIRLINE_DATA, AIRLINE_REGISTRATION_PREFIX
+from core.registration import generate_registration
 
 logger = logging.getLogger(__name__)
 
@@ -90,11 +90,11 @@ class APIFlightPlanGenerator:
             airline = AIRLINE_DATA[airline_icao]
             callsign = self._generate_callsign(airline_icao)
             prefix = AIRLINE_REGISTRATION_PREFIX.get(airline["country"], "EC")
-            aircraft_reg = self._generate_registration(prefix)
+            aircraft_reg = generate_registration(prefix)
             flight_type = "S"
         else:
             callsign = ""
-            aircraft_reg = self._generate_registration("EC")
+            aircraft_reg = generate_registration("EC")
             flight_type = "G"
 
         # Calculate times
@@ -214,13 +214,6 @@ class APIFlightPlanGenerator:
             parts.append(last_exit_wp)
 
         return " ".join(parts) if parts else "DCT"
-
-    @staticmethod
-    def _generate_registration(prefix: str = "EC") -> str:
-        letters = "".join(random.choices(string.ascii_uppercase, k=3))
-        if prefix.endswith("-"):
-            return f"{prefix}{letters}"
-        return f"{prefix}-{letters}"
 
     @staticmethod
     def _select_airline(aircraft_type: str) -> str:

--- a/services/flight_plan_service/core/generator.py
+++ b/services/flight_plan_service/core/generator.py
@@ -1,5 +1,4 @@
 import random
-import string
 from datetime import datetime, timedelta
 
 from models.schemas import FlightPlanResponse
@@ -7,6 +6,7 @@ from core.data import (
     AIRCRAFT_DATA, AIRPORT_DATA, DISTANCES, PILOT_NAMES,
     AIRLINE_DATA, AIRLINE_REGISTRATION_PREFIX,
 )
+from core.registration import generate_registration
 
 
 class FlightPlanGenerator:
@@ -33,11 +33,11 @@ class FlightPlanGenerator:
             airline = AIRLINE_DATA[airline_icao]
             callsign = self._generate_callsign(airline_icao)
             prefix = AIRLINE_REGISTRATION_PREFIX.get(airline["country"], "EC")
-            aircraft_reg = self._generate_registration(prefix)
+            aircraft_reg = generate_registration(prefix)
             flight_type = "S"  # Scheduled
         else:
             callsign = ""
-            aircraft_reg = self._generate_registration("EC")
+            aircraft_reg = generate_registration("EC")
             flight_type = "G"  # General aviation
 
         # Get aircraft data
@@ -99,13 +99,6 @@ class FlightPlanGenerator:
     def _generate_aircraft_type(self) -> str:
         """Generate random aircraft type"""
         return random.choice(self.aircraft_types)
-
-    def _generate_registration(self, prefix: str = "EC") -> str:
-        """Generate random aircraft registration with country prefix"""
-        letters = ''.join(random.choices(string.ascii_uppercase, k=3))
-        if prefix.endswith("-"):
-            return f"{prefix}{letters}"
-        return f"{prefix}-{letters}"
 
     def _select_airline(self, aircraft_type: str) -> str:
         """Select a random airline that operates the given aircraft type"""

--- a/services/flight_plan_service/core/registration.py
+++ b/services/flight_plan_service/core/registration.py
@@ -1,0 +1,21 @@
+"""Aircraft registration generation, shared by both flight plan generators.
+
+Both the fully local generator and the API-backed one need the same rule:
+a country/airline prefix plus three random uppercase letters.
+"""
+
+import random
+import string
+
+
+def generate_registration(prefix: str = "EC") -> str:
+    """Generate a random aircraft registration with the given prefix.
+
+    The prefix may already carry its separator (e.g. ``"N-"``); when it does
+    not, a hyphen is inserted, so both ``"EC"`` and ``"EC-"`` yield
+    ``"EC-XYZ"``.
+    """
+    letters = "".join(random.choices(string.ascii_uppercase, k=3))
+    if prefix.endswith("-"):
+        return f"{prefix}{letters}"
+    return f"{prefix}-{letters}"

--- a/services/orchestrator_service/debrief_builder.py
+++ b/services/orchestrator_service/debrief_builder.py
@@ -4,21 +4,10 @@ Pure functions, no I/O; unit-testable standalone. Inputs are the raw
 lists the `session_log` returns plus the clearance rows from Postgres.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Iterable, Optional
 
-
-def _fmt_ts(ts: float | str | None) -> str:
-    if ts is None:
-        return "--:--:--"
-    try:
-        if isinstance(ts, str):
-            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-        else:
-            dt = datetime.fromtimestamp(float(ts), tz=timezone.utc)
-        return dt.strftime("%H:%M:%S")
-    except (ValueError, TypeError):
-        return "--:--:--"
+from utils import fmt_ts as _fmt_ts
 
 
 def _coerce_ts(ts) -> float:

--- a/services/orchestrator_service/frequency_audit.py
+++ b/services/orchestrator_service/frequency_audit.py
@@ -16,8 +16,9 @@ Design:
 from __future__ import annotations
 
 import re
-from datetime import datetime, timezone
 from typing import Iterable, Optional
+
+from utils import fmt_ts as _fmt_ts
 
 # Fallback when the airport has no parsed COM frequencies in Redis. Same
 # values as shared.models.communications.Frequencies — duplicated here to
@@ -141,19 +142,6 @@ def _expected_for(service: Optional[str], com_frequencies: list[dict]) -> Option
             except (TypeError, ValueError, KeyError):
                 continue
     return _DEFAULT_FREQS_MHZ.get(service)
-
-
-def _fmt_ts(ts: float | str | None) -> str:
-    if ts is None:
-        return "--:--:--"
-    try:
-        if isinstance(ts, str):
-            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-        else:
-            dt = datetime.fromtimestamp(float(ts), tz=timezone.utc)
-        return dt.strftime("%H:%M:%S")
-    except (ValueError, TypeError):
-        return "--:--:--"
 
 
 def audit_frequencies(

--- a/services/orchestrator_service/utils.py
+++ b/services/orchestrator_service/utils.py
@@ -1,0 +1,27 @@
+"""Small helpers shared across orchestrator modules.
+
+Kept dependency-free (stdlib only) so any module in the service can import it
+without pulling in FastAPI, SQLAlchemy or Redis.
+"""
+
+from datetime import datetime, timezone
+
+
+def fmt_ts(ts: float | str | None) -> str:
+    """Render a timestamp as ``HH:MM:SS`` (UTC).
+
+    Accepts either a POSIX epoch value (int/float, or a string parseable as
+    one by ``float()``) or an ISO-8601 string, with or without a trailing
+    ``Z``. Anything unusable renders as ``"--:--:--"`` rather than raising,
+    because these strings are only ever shown in the debrief report.
+    """
+    if ts is None:
+        return "--:--:--"
+    try:
+        if isinstance(ts, str):
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        else:
+            dt = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+        return dt.strftime("%H:%M:%S")
+    except (ValueError, TypeError):
+        return "--:--:--"


### PR DESCRIPTION
## What

Two of the utility pairs listed in #54 were copy-pasted duplicates. Each now lives in exactly one place, imported by both former call sites.

| Utility | Was duplicated in | Now lives in |
|---|---|---|
| `_fmt_ts` | `services/orchestrator_service/debrief_builder.py`, `services/orchestrator_service/frequency_audit.py` | `services/orchestrator_service/utils.py` as `fmt_ts` |
| `_generate_registration` | `services/flight_plan_service/core/generator.py` (method), `services/flight_plan_service/core/api_generator.py` (staticmethod) | `services/flight_plan_service/core/registration.py` as `generate_registration` |

- `fmt_ts` is imported as `from utils import fmt_ts as _fmt_ts`, so the debrief/audit call sites are byte-for-byte unchanged.
- `generate_registration` is a free function; the two class methods are gone and their four call sites now call it directly. `import string` became unused in both generators and was dropped.
- Both new modules are picked up by the existing Dockerfiles (whole-directory `COPY`), so no build changes are needed.

Pure refactor: no behaviour change, no API change, no new dependencies.

## Why this only partially addresses #54

The third pair in the issue table, `_haversine_m`, lives in `shared/services/taxi_router/pushback.py` and `shared/services/taxi_router/router.py`. **`router.py` currently has heavy work in progress**, so touching it here would conflict. That dedup — plus the `get_clearance` endpoint and the JS `_stopPttCapture` items — is left for a follow-up.

Partially addresses #54 (the issue stays open).

## Testing

`pytest tests` — 288 passed, 1 skipped, 4 xfailed (identical to the pre-change baseline). The flight plan generators are not covered by the suite, so both were additionally smoke-run by hand to confirm they still produce registrations.