### PR TITLE
test: characterization tests for build_timeline and forward_to_agent (partial #49)

### DIFF
--- a/tests/debrief/test_build_timeline_characterization.py
+++ b/tests/debrief/test_build_timeline_characterization.py
@@ -1,0 +1,377 @@
+"""Characterization tests for ``debrief_builder.build_timeline``.
+
+`build_timeline` has degree 40 and cognitive complexity 29: it folds four
+heterogeneous record streams (controller transcripts, pilot agent replies, sim
+events, Postgres clearance rows) into one chronological text block, and every
+stream has its own skip rules, fallbacks and formatting quirks.
+`tests/debrief/test_debrief_builder.py` covers the happy path; this module
+pins down the *edges* — the exact rules that decide whether a record produces a
+line at all, what the line looks like, and how ties are ordered.
+
+These are characterization tests: they assert what the code does **today**,
+correct or not, so a later refactor can be shown to change nothing. Where the
+current behavior looks debatable it is called out in the test docstring rather
+than "fixed".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# debrief_builder lives inside the orchestrator service source; add it to sys.path
+_ORCH = Path(__file__).resolve().parents[2] / "services" / "orchestrator_service"
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+import pytest
+
+from debrief_builder import build_timeline
+
+
+# 2026-04-22 13:33:20 UTC — fixed so the rendered HH:MM:SS is deterministic.
+# (Note: the T0 in test_debrief_builder.py is a different, rounder epoch whose
+# comment says 13:33:20 but actually resolves to 19:33:20 UTC. That file never
+# asserts the rendered clock, so it does not matter there; here it does.)
+T0 = 1_776_864_800.0
+T0_HHMMSS = "13:33:20"
+
+
+def _lines(**kwargs) -> list[str]:
+    """Call build_timeline with empty defaults for the streams not given."""
+    payload = {"transcripts": [], "agent_replies": [], "events": [], "clearances": []}
+    payload.update(kwargs)
+    text = build_timeline(**payload)
+    return text.splitlines() if text else []
+
+
+# ---------------------------------------------------------------------------
+# Timestamp coercion and rendering
+# ---------------------------------------------------------------------------
+
+
+def test_epoch_float_renders_as_utc_hhmmss():
+    assert _lines(transcripts=[{"ts": T0, "text": "hello"}]) == [
+        f'[{T0_HHMMSS}] CTRL: "hello"'
+    ]
+
+
+def test_iso_8601_timestamp_is_coerced_then_rendered_as_utc():
+    """ISO strings (with and without the Z suffix) are accepted and converted."""
+    lines = _lines(
+        transcripts=[
+            {"ts": "2026-04-22T13:33:20Z", "text": "with Z"},
+            {"ts": "2026-04-22T13:33:21+00:00", "text": "with offset"},
+        ]
+    )
+    assert lines == [
+        f'[{T0_HHMMSS}] CTRL: "with Z"',
+        '[13:33:21] CTRL: "with offset"',
+    ]
+
+
+def test_missing_and_unparseable_timestamps_collapse_to_epoch_zero():
+    """A missing or garbage ``ts`` becomes 0.0 — so the entry renders as
+    00:00:00 and sorts to the very top of the timeline, ahead of real ones."""
+    lines = _lines(
+        transcripts=[
+            {"ts": T0, "text": "real"},
+            {"text": "no ts at all"},
+            {"ts": "not-a-date", "text": "garbage ts"},
+        ]
+    )
+    assert lines[0] == '[00:00:00] CTRL: "no ts at all"'
+    assert lines[1] == '[00:00:00] CTRL: "garbage ts"'
+    assert lines[2] == f'[{T0_HHMMSS}] CTRL: "real"'
+
+
+def test_numeric_string_timestamp_is_accepted_as_epoch():
+    """``_coerce_ts`` falls through to ISO parsing for strings, and
+    ``fromisoformat`` rejects a bare number — so "1776800000.0" is NOT read as
+    an epoch; it degrades to 0.0."""
+    assert _lines(transcripts=[{"ts": str(T0), "text": "x"}]) == [
+        '[00:00:00] CTRL: "x"'
+    ]
+
+
+# ---------------------------------------------------------------------------
+# CTRL lines (transcripts)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", ["", "   ", "\n\t ", None])
+def test_transcripts_without_usable_text_produce_no_line(text):
+    assert _lines(transcripts=[{"ts": T0, "text": text}]) == []
+
+
+def test_transcript_text_is_stripped_but_inner_spacing_kept():
+    assert _lines(transcripts=[{"ts": T0, "text": "  taxi  via  tango  "}]) == [
+        f'[{T0_HHMMSS}] CTRL: "taxi  via  tango"'
+    ]
+
+
+def test_transcript_quotes_are_not_escaped():
+    """Embedded double quotes are passed through verbatim — the LLM prompt is
+    plain text, not JSON, so no escaping happens."""
+    assert _lines(transcripts=[{"ts": T0, "text": 'say "again"'}]) == [
+        f'[{T0_HHMMSS}] CTRL: "say "again""'
+    ]
+
+
+# ---------------------------------------------------------------------------
+# PILOT lines (agent replies)
+# ---------------------------------------------------------------------------
+
+
+def test_pilot_line_full_shape():
+    assert _lines(
+        agent_replies=[
+            {
+                "ts": T0,
+                "dep": "GND",
+                "registration": "EC-IYV",
+                "callsign": "IBE3421",
+                "reply": "Taxi via T, IBE3421",
+            }
+        ]
+    ) == [f'[{T0_HHMMSS}] PILOT (GND, EC-IYV/IBE3421): "Taxi via T, IBE3421"']
+
+
+def test_pilot_line_falls_back_to_registration_when_callsign_missing():
+    assert _lines(
+        agent_replies=[
+            {"ts": T0, "dep": "DEL", "registration": "EC-IYV", "reply": "roger"}
+        ]
+    ) == [f'[{T0_HHMMSS}] PILOT (DEL, EC-IYV/EC-IYV): "roger"']
+
+
+def test_pilot_line_uses_dashes_when_registration_and_dep_missing():
+    assert _lines(agent_replies=[{"ts": T0, "reply": "roger"}]) == [
+        f'[{T0_HHMMSS}] PILOT (-, -/-): "roger"'
+    ]
+
+
+@pytest.mark.parametrize("reply", ["", "   ", None])
+def test_agent_replies_without_usable_reply_produce_no_line(reply):
+    assert _lines(agent_replies=[{"ts": T0, "dep": "DEL", "reply": reply}]) == []
+
+
+def test_error_replies_are_kept_in_the_timeline():
+    """`forward_to_agent` stores "[ERROR] ..." strings as replies when a Cloud
+    Run agent is down. They are NOT filtered out — the instructor sees them."""
+    assert _lines(
+        agent_replies=[{"ts": T0, "dep": "GND", "reply": "[ERROR] could not reach GND agent"}]
+    ) == [f'[{T0_HHMMSS}] PILOT (GND, -/-): "[ERROR] could not reach GND agent"']
+
+
+# ---------------------------------------------------------------------------
+# EVENT lines
+# ---------------------------------------------------------------------------
+
+
+def test_event_with_no_fields_at_all_still_produces_a_line():
+    """Unlike transcripts/replies, events are never skipped: an empty dict
+    yields a fully defaulted line."""
+    assert _lines(events=[{}]) == ["[00:00:00] EVENT (-): event"]
+
+
+def test_event_extra_renders_scalars_in_insertion_order():
+    assert _lines(
+        events=[
+            {
+                "ts": T0,
+                "registration": "EC-VBT",
+                "event": "pushback_started",
+                "extra": {"plan_id": "abc123", "legs": 3, "ok": True, "dist": 1.5},
+            }
+        ]
+    ) == [f"[{T0_HHMMSS}] EVENT (EC-VBT): pushback_started plan_id=abc123 legs=3 ok=True dist=1.5"]
+
+
+def test_event_extra_drops_empty_and_non_scalar_values():
+    """None, "" and any container value are omitted; note that 0 and False are
+    kept, because the filter tests ``v is None or v == ""``... and ``0 == ""``
+    is False in Python, so falsy numbers survive."""
+    assert _lines(
+        events=[
+            {
+                "ts": T0,
+                "registration": "EC-VBT",
+                "event": "taxi_done",
+                "extra": {
+                    "gone_none": None,
+                    "gone_empty": "",
+                    "gone_list": [1, 2],
+                    "gone_dict": {"a": 1},
+                    "kept_zero": 0,
+                    "kept_false": False,
+                },
+            }
+        ]
+    ) == [f"[{T0_HHMMSS}] EVENT (EC-VBT): taxi_done kept_zero=0 kept_false=False"]
+
+
+def test_event_extra_that_is_not_a_dict_is_ignored_silently():
+    assert _lines(
+        events=[{"ts": T0, "registration": "EC-VBT", "event": "x", "extra": "some string"}]
+    ) == [f"[{T0_HHMMSS}] EVENT (EC-VBT): x"]
+
+
+def test_event_extra_with_only_dropped_values_leaves_no_trailing_space():
+    assert _lines(
+        events=[{"ts": T0, "registration": "EC-VBT", "event": "x", "extra": {"a": None}}]
+    ) == [f"[{T0_HHMMSS}] EVENT (EC-VBT): x"]
+
+
+# ---------------------------------------------------------------------------
+# CLEARANCE lines
+# ---------------------------------------------------------------------------
+
+
+def test_clearance_summary_lists_only_the_five_whitelisted_fields_in_order():
+    """`clearance_text`, `altimeter` and every other column are deliberately
+    NOT summarised — only these five, always in this fixed order."""
+    assert _lines(
+        clearances=[
+            {
+                "updated_at": T0,
+                "aircraft_registration": "EC-IYV",
+                "dependency": "DEL",
+                # deliberately shuffled relative to the output order
+                "destination_icao": "LEPA",
+                "runway_in_use": "06R",
+                "squawk": 2000,
+                "instrumental_departure": "VAR1A",
+                "initial_altitude": 6000,
+                "altimeter": 1013.0,
+                "clearance_text": "cleared to LEPA",
+            }
+        ]
+    ) == [
+        f"[{T0_HHMMSS}] CLEARANCE (EC-IYV, DEL): squawk=2000 initial_altitude=6000 "
+        "instrumental_departure=VAR1A runway_in_use=06R destination_icao=LEPA"
+    ]
+
+
+def test_clearance_drops_none_empty_and_zero_valued_fields():
+    """Zero is treated as "unset" here (unlike in event extras) — the runner
+    upserts squawk=0/initial_altitude=0 placeholder rows for arrivals."""
+    assert _lines(
+        clearances=[
+            {
+                "updated_at": T0,
+                "aircraft_registration": "EC-NEW",
+                "dependency": "GND",
+                "squawk": 0,
+                "initial_altitude": 0,
+                "instrumental_departure": "",
+                "runway_in_use": None,
+                "destination_icao": "",
+            }
+        ]
+    ) == [f"[{T0_HHMMSS}] CLEARANCE (EC-NEW, GND):"]
+
+
+def test_clearance_falls_back_to_cleared_at_when_updated_at_is_absent():
+    assert _lines(
+        clearances=[
+            {"cleared_at": T0, "aircraft_registration": "EC-IYV", "dependency": "DEL"}
+        ]
+    ) == [f"[{T0_HHMMSS}] CLEARANCE (EC-IYV, DEL):"]
+
+
+def test_clearance_falsy_updated_at_falls_through_to_cleared_at():
+    """The fallback uses ``or``, not a key check, so updated_at=0 also falls
+    through to cleared_at."""
+    assert _lines(
+        clearances=[
+            {
+                "updated_at": 0,
+                "cleared_at": T0,
+                "aircraft_registration": "EC-IYV",
+                "dependency": "DEL",
+            }
+        ]
+    ) == [f"[{T0_HHMMSS}] CLEARANCE (EC-IYV, DEL):"]
+
+
+def test_clearance_defaults_registration_and_dependency_to_dashes():
+    assert _lines(clearances=[{"updated_at": T0}]) == [
+        f"[{T0_HHMMSS}] CLEARANCE (-, -):"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Interleaving and ordering
+# ---------------------------------------------------------------------------
+
+
+def test_records_with_equal_timestamps_keep_stream_processing_order():
+    """Ties are broken by the order the streams are processed — transcripts,
+    then replies, then events, then clearances — because ``list.sort`` is
+    stable. Any refactor that reorders the four loops changes this output."""
+    lines = _lines(
+        transcripts=[{"ts": T0, "text": "ctrl"}],
+        agent_replies=[{"ts": T0, "dep": "DEL", "reply": "pilot"}],
+        events=[{"ts": T0, "registration": "EC-IYV", "event": "ev"}],
+        clearances=[{"updated_at": T0, "aircraft_registration": "EC-IYV", "dependency": "DEL"}],
+    )
+    assert [line.split("] ")[1].split(" ")[0].rstrip(":") for line in lines] == [
+        "CTRL",
+        "PILOT",
+        "EVENT",
+        "CLEARANCE",
+    ]
+
+
+def test_full_departure_session_renders_in_chronological_order():
+    """End-to-end shape of a realistic DEL -> GND slice of a session."""
+    text = build_timeline(
+        transcripts=[
+            {"ts": T0, "text": "Iberia 3421 request IFR clearance to Palma"},
+            {"ts": T0 + 30, "text": "Iberia 3421 contact ground on 121.9"},
+        ],
+        agent_replies=[
+            {"ts": T0 + 8, "dep": "DEL", "registration": "EC-IYV", "callsign": "IBE3421",
+             "reply": "Cleared to Palma, VAR1A departure, squawk 2000, IBE3421"},
+            {"ts": T0 + 33, "dep": "GND", "registration": "EC-IYV", "callsign": "IBE3421",
+             "reply": "121.9, IBE3421"},
+        ],
+        events=[{"ts": T0 + 60, "registration": "EC-IYV", "event": "pushback_started"}],
+        clearances=[
+            {"updated_at": T0 + 10, "aircraft_registration": "EC-IYV", "dependency": "GND",
+             "squawk": 2000, "runway_in_use": "06R"}
+        ],
+    )
+    assert text.splitlines() == [
+        f'[{T0_HHMMSS}] CTRL: "Iberia 3421 request IFR clearance to Palma"',
+        '[13:33:28] PILOT (DEL, EC-IYV/IBE3421): "Cleared to Palma, VAR1A departure, '
+        'squawk 2000, IBE3421"',
+        "[13:33:30] CLEARANCE (EC-IYV, GND): squawk=2000 runway_in_use=06R",
+        '[13:33:50] CTRL: "Iberia 3421 contact ground on 121.9"',
+        '[13:33:53] PILOT (GND, EC-IYV/IBE3421): "121.9, IBE3421"',
+        "[13:34:20] EVENT (EC-IYV): pushback_started",
+    ]
+
+
+def test_none_streams_are_treated_as_empty():
+    assert build_timeline(None, None, None, None) == ""
+    assert build_timeline(None, [{"ts": T0, "dep": "DEL", "reply": "r"}], None, None) == (
+        f'[{T0_HHMMSS}] PILOT (DEL, -/-): "r"'
+    )
+
+
+def test_generators_are_accepted_as_input_streams():
+    """The signature says ``Iterable``; each stream is consumed exactly once."""
+    text = build_timeline(
+        transcripts=(t for t in [{"ts": T0, "text": "gen"}]),
+        agent_replies=iter([]),
+        events=iter([]),
+        clearances=iter([]),
+    )
+    assert text == f'[{T0_HHMMSS}] CTRL: "gen"'
+
+
+def test_output_has_no_trailing_newline():
+    text = build_timeline([{"ts": T0, "text": "a"}], [], [], [])
+    assert not text.endswith("\n")

--- a/tests/unit/orchestrator/test_forward_tool_characterization.py
+++ b/tests/unit/orchestrator/test_forward_tool_characterization.py
@@ -1,0 +1,712 @@
+"""Characterization tests for ``agent/tools/forward.py::forward_to_agent``.
+
+`forward_to_agent` is the orchestrator's central routing tool (fan-in 21, 125
+lines): it resolves the target Cloud Run agent, builds a phase-dependent
+payload, performs the HTTP call, records the reply for the debrief, optionally
+kicks off a taxi dispatch, and writes four keys into session state that
+`runner.py` reads afterwards.
+
+`test_forward_tool.py` already covers the main paths. This module pins down the
+*decision boundaries* between them — which branch a given input lands in, which
+side effects fire and which are skipped, and what happens on the failure paths.
+Those boundaries are exactly what a "split this into helpers" refactor is most
+likely to move by accident.
+
+These are characterization tests: they assert what the code does **today**, so
+the refactor can be shown to change nothing. Debatable behavior is flagged in
+the docstrings rather than "fixed".
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import respx
+
+from agent.tools import forward as forward_mod
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (local to this module — tests/conftest.py is intentionally untouched)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def configured_urls(monkeypatch):
+    """Point forward.py at deterministic URLs for the test."""
+    monkeypatch.setitem(forward_mod._ROUTES, "DEL", ("http://del.test", "/agents/delivery/run"))
+    monkeypatch.setitem(forward_mod._ROUTES, "GND", ("http://gnd.test", "/agents/ground/run"))
+    monkeypatch.setitem(forward_mod._ROUTES, "TWR", ("http://twr.test", "/agents/tower/run"))
+    monkeypatch.setattr(forward_mod, "_FLIGHT_PLAN_URL", "http://fp.test")
+    monkeypatch.setattr(forward_mod, "_WEATHER_URL", "http://wx.test")
+
+
+@pytest.fixture
+def captured_log(monkeypatch):
+    """Capture session_log.append_agent_reply calls instead of hitting Redis."""
+    captured: list[dict] = []
+    monkeypatch.setattr(forward_mod, "append_agent_reply", lambda **kw: captured.append(kw))
+    return captured
+
+
+@pytest.fixture
+def captured_dispatch(monkeypatch):
+    """Capture dispatch_taxi_plan calls (imported lazily inside the tool)."""
+    captured: list[dict] = []
+
+    fake_router = types.ModuleType("shared.services.taxi_router")
+    fake_router.dispatch_taxi_plan = lambda merged, **kw: captured.append(
+        {"merged": merged, "kwargs": kw}
+    )
+    if "shared.services.taxi_router" in sys.modules:
+        original = sys.modules["shared.services.taxi_router"]
+        for attr in dir(original):
+            if not attr.startswith("_") and not hasattr(fake_router, attr):
+                setattr(fake_router, attr, getattr(original, attr))
+    monkeypatch.setitem(sys.modules, "shared.services.taxi_router", fake_router)
+    return captured
+
+
+def _ctx(session_id="sess-1", known_aircraft=None, **extra_state):
+    state = {"session_id": session_id, "known_aircraft": known_aircraft or []}
+    state.update(extra_state)
+    return SimpleNamespace(state=state)
+
+
+def _payload_of(route) -> dict:
+    return json.loads(route.calls[0].request.read())
+
+
+# ---------------------------------------------------------------------------
+# Target resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dependency, expected_url",
+    [
+        ("GND", "http://gnd.test/agents/ground/run"),
+        ("gnd", "http://gnd.test/agents/ground/run"),
+        ("GnD", "http://gnd.test/agents/ground/run"),
+        ("TWR", "http://twr.test/agents/tower/run"),
+        ("twr", "http://twr.test/agents/tower/run"),
+    ],
+)
+@respx.mock
+def test_dependency_is_upper_cased_before_routing(
+    configured_urls, captured_log, dependency, expected_url
+):
+    route = respx.post(expected_url).mock(return_value=httpx.Response(200, json={"reply": "ok"}))
+    known = [{"registration": "EC-MIG", "callsign": "IBE"}]
+
+    forward_mod.forward_to_agent(dependency, "EC-MIG", "msg", _ctx(known_aircraft=known))
+
+    assert route.called
+
+
+@pytest.mark.parametrize("dependency", ["", "APP", "who-knows", "DELIVERY"])
+@respx.mock
+def test_any_unrecognised_dependency_falls_back_to_del(
+    configured_urls, captured_log, dependency
+):
+    """Note the fallback normalises the *route* to DEL and also reports DEL in
+    ``state["dependency"]`` — the caller never learns the original value."""
+    respx.get("http://fp.test/plans/EC-MIG").mock(return_value=httpx.Response(404))
+    respx.post("http://del.test/agents/delivery/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+    ctx = _ctx()
+
+    forward_mod.forward_to_agent(dependency, "EC-MIG", "msg", ctx)
+
+    assert ctx.state["dependency"] == "DEL"
+
+
+def test_unconfigured_agent_url_returns_early_without_any_side_effect(
+    monkeypatch, captured_log, captured_dispatch
+):
+    """The "not configured" guard returns before the state writes — so
+    ``reply``/``dependency``/``registration`` are NOT set, and nothing is
+    logged. `runner.py` therefore falls back to the raw final LLM text."""
+    monkeypatch.setitem(forward_mod._ROUTES, "TWR", ("", "/agents/tower/run"))
+    ctx = _ctx(known_aircraft=[{"registration": "EC-MIG", "callsign": "IBE"}])
+
+    reply = forward_mod.forward_to_agent("TWR", "EC-MIG", "msg", ctx)
+
+    assert reply == "[ERROR] TWR agent is not configured"
+    assert "reply" not in ctx.state
+    assert "dependency" not in ctx.state
+    assert "registration" not in ctx.state
+    assert captured_log == []
+    assert captured_dispatch == []
+
+
+# ---------------------------------------------------------------------------
+# DEL branch: which inputs actually take it
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_del_without_registration_takes_the_clearance_branch_not_the_prefetch_branch(
+    configured_urls, captured_log
+):
+    """The pre-fetch guard is ``dep == "DEL" and registration``. An empty
+    registration therefore routes to DEL but builds a GND-style payload from
+    ``known_aircraft`` — no flight_plan/atis keys at all."""
+    route = respx.post("http://del.test/agents/delivery/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+    known = [{"registration": "", "callsign": "IBE", "squawk": 1234}]
+
+    forward_mod.forward_to_agent("DEL", "", "msg", _ctx(known_aircraft=known))
+
+    payload = _payload_of(route)
+    assert "flight_plan" not in payload
+    assert "atis" not in payload
+    assert payload["clearance_data"] == {"callsign": "IBE", "squawk": 1234}
+
+
+@respx.mock
+def test_del_accepts_the_lower_case_departure_icao_spelling(configured_urls, captured_log):
+    """The flight plan service has shipped both ``departure_ICAO`` and
+    ``departure_icao``; the upper-case one wins, the lower-case one is the
+    documented fallback."""
+    respx.get("http://fp.test/plans/EC-MIG").mock(
+        return_value=httpx.Response(200, json={"departure_icao": "LEBL"})
+    )
+    atis = respx.get("http://wx.test/atis/LEBL").mock(
+        return_value=httpx.Response(200, json={"info": "ATIS-B"})
+    )
+    route = respx.post("http://del.test/agents/delivery/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+
+    forward_mod.forward_to_agent("DEL", "EC-MIG", "msg", _ctx())
+
+    assert atis.called
+    assert _payload_of(route)["atis"] == {"info": "ATIS-B"}
+
+
+@respx.mock
+def test_del_upper_case_departure_icao_wins_over_lower_case(configured_urls, captured_log):
+    respx.get("http://fp.test/plans/EC-MIG").mock(
+        return_value=httpx.Response(
+            200, json={"departure_ICAO": "LEST", "departure_icao": "LEBL"}
+        )
+    )
+    atis = respx.get("http://wx.test/atis/LEST").mock(
+        return_value=httpx.Response(200, json={"info": "ATIS-A"})
+    )
+    respx.post("http://del.test/agents/delivery/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+
+    forward_mod.forward_to_agent("DEL", "EC-MIG", "msg", _ctx())
+
+    assert atis.called
+
+
+@respx.mock
+def test_del_skips_both_fetches_when_the_upstream_urls_are_unset(monkeypatch, captured_log):
+    """No FLIGHT_PLAN_SERVICE_URL / WEATHER_SERVICE_URL in the environment: the
+    keys are still present in the payload, both set to None, and no HTTP call
+    to those services is attempted."""
+    monkeypatch.setitem(forward_mod._ROUTES, "DEL", ("http://del.test", "/agents/delivery/run"))
+    monkeypatch.setattr(forward_mod, "_FLIGHT_PLAN_URL", "")
+    monkeypatch.setattr(forward_mod, "_WEATHER_URL", "")
+    route = respx.post("http://del.test/agents/delivery/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+
+    forward_mod.forward_to_agent("DEL", "EC-MIG", "msg", _ctx())
+
+    payload = _payload_of(route)
+    assert payload["flight_plan"] is None
+    assert payload["atis"] is None
+    assert len(respx.calls) == 1  # only the agent POST
+
+
+@respx.mock
+def test_del_context_fetch_network_error_degrades_to_none(configured_urls, captured_log):
+    """A dead flight plan / weather service must not break the DEL call."""
+    respx.get("http://fp.test/plans/EC-MIG").mock(side_effect=httpx.ConnectError("down"))
+    route = respx.post("http://del.test/agents/delivery/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+
+    reply = forward_mod.forward_to_agent("DEL", "EC-MIG", "msg", _ctx())
+
+    assert reply == "ok"
+    payload = _payload_of(route)
+    assert payload["flight_plan"] is None
+    assert payload["atis"] is None
+
+
+@respx.mock
+def test_del_atis_error_leaves_the_flight_plan_intact(configured_urls, captured_log):
+    respx.get("http://fp.test/plans/EC-MIG").mock(
+        return_value=httpx.Response(200, json={"departure_ICAO": "LEST"})
+    )
+    respx.get("http://wx.test/atis/LEST").mock(side_effect=httpx.ConnectError("down"))
+    route = respx.post("http://del.test/agents/delivery/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+
+    forward_mod.forward_to_agent("DEL", "EC-MIG", "msg", _ctx())
+
+    payload = _payload_of(route)
+    assert payload["flight_plan"] == {"departure_ICAO": "LEST"}
+    assert payload["atis"] is None
+
+
+@pytest.mark.parametrize("status", [400, 404, 500, 503])
+@respx.mock
+def test_del_non_200_context_responses_become_none(configured_urls, captured_log, status):
+    """Only HTTP 200 counts — anything else is discarded silently."""
+    respx.get("http://fp.test/plans/EC-MIG").mock(return_value=httpx.Response(status))
+    route = respx.post("http://del.test/agents/delivery/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+
+    forward_mod.forward_to_agent("DEL", "EC-MIG", "msg", _ctx())
+
+    assert _payload_of(route)["flight_plan"] is None
+
+
+# ---------------------------------------------------------------------------
+# GND/TWR branch: clearance_data assembly
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_clearance_data_key_is_omitted_entirely_when_nothing_is_known(
+    configured_urls, captured_log
+):
+    """Unknown registration and no taxi route: the payload carries only
+    ``session_id`` and ``message`` — the key is absent, not empty."""
+    route = respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+
+    forward_mod.forward_to_agent("GND", "EC-UNKNOWN", "msg", _ctx(known_aircraft=[]))
+
+    assert _payload_of(route) == {"session_id": "sess-1", "message": "msg"}
+
+
+@respx.mock
+def test_taxi_route_alone_is_enough_to_create_clearance_data(configured_urls, captured_log):
+    """Even for an aircraft with no stored clearance, a successful taxi route
+    materialises ``clearance_data`` with just that one key."""
+    route = respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+    taxi_route = {"success": True, "waypoints": [{"lat": 41.0, "lon": 2.0}]}
+
+    forward_mod.forward_to_agent(
+        "GND", "EC-UNKNOWN", "taxi", _ctx(known_aircraft=[]), taxi_route=taxi_route
+    )
+
+    assert _payload_of(route)["clearance_data"] == {"taxi_route": taxi_route}
+
+
+@respx.mock
+def test_taxi_route_without_success_key_is_not_merged(configured_urls, captured_log):
+    """The guard is ``taxi_route.get("success")`` — a route dict that simply
+    omits the flag is dropped exactly like an explicit failure."""
+    known = [{"registration": "EC-MIG", "callsign": "IBE"}]
+    route = respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+
+    forward_mod.forward_to_agent(
+        "GND",
+        "EC-MIG",
+        "taxi",
+        _ctx(known_aircraft=known),
+        taxi_route={"waypoints": [{"lat": 41.0, "lon": 2.0}]},
+    )
+
+    assert "taxi_route" not in _payload_of(route)["clearance_data"]
+
+
+@respx.mock
+def test_clearance_data_takes_the_first_match_and_strips_three_keys(
+    configured_urls, captured_log
+):
+    """Duplicate registrations in ``known_aircraft`` resolve to the first
+    entry; ``registration``/``dependency``/``source`` never reach the agent."""
+    known = [
+        {"registration": "EC-MIG", "dependency": "GND", "source": "db", "squawk": 1111},
+        {"registration": "EC-MIG", "dependency": "GND", "source": "redis", "squawk": 2222},
+    ]
+    route = respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+
+    forward_mod.forward_to_agent("GND", "EC-MIG", "msg", _ctx(known_aircraft=known))
+
+    assert _payload_of(route)["clearance_data"] == {"squawk": 1111}
+
+
+@respx.mock
+def test_missing_known_aircraft_state_key_is_tolerated(configured_urls, captured_log):
+    """``known_aircraft`` absent from state entirely (not just empty)."""
+    route = respx.post("http://twr.test/agents/tower/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+    ctx = SimpleNamespace(state={"session_id": "sess-1"})
+
+    reply = forward_mod.forward_to_agent("TWR", "EC-MIG", "msg", ctx)
+
+    assert reply == "ok"
+    assert "clearance_data" not in _payload_of(route)
+
+
+@respx.mock
+def test_session_id_missing_from_state_is_sent_as_empty_string(configured_urls, captured_log):
+    route = respx.post("http://twr.test/agents/tower/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+
+    forward_mod.forward_to_agent("TWR", "EC-MIG", "msg", SimpleNamespace(state={}))
+
+    assert _payload_of(route)["session_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Response handling and state writes
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_response_without_a_reply_key_yields_empty_reply_and_no_session_log(
+    configured_urls, captured_log
+):
+    """A malformed agent response degrades to an empty reply; the state key is
+    still written (as ""), but nothing is appended to the debrief log."""
+    respx.post("http://twr.test/agents/tower/run").mock(
+        return_value=httpx.Response(200, json={"clearance_data": {"squawk": 7000}})
+    )
+    ctx = _ctx()
+
+    reply = forward_mod.forward_to_agent("TWR", "EC-MIG", "msg", ctx)
+
+    assert reply == ""
+    assert ctx.state["reply"] == ""
+    assert ctx.state["clearance_data"] == {"squawk": 7000}
+    assert captured_log == []
+
+
+@respx.mock
+def test_empty_registration_is_normalised_to_none_in_state(configured_urls, captured_log):
+    """`runner.py` treats ``registration`` as optional — an empty string would
+    otherwise be persisted as a bogus aircraft key."""
+    respx.post("http://twr.test/agents/tower/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+    ctx = _ctx()
+
+    forward_mod.forward_to_agent("TWR", "", "msg", ctx)
+
+    assert ctx.state["registration"] is None
+
+
+@respx.mock
+def test_clearance_data_state_key_is_none_when_the_agent_omits_it(
+    configured_urls, captured_log
+):
+    """Always written, never left stale — `runner.py` reads it unconditionally."""
+    respx.post("http://twr.test/agents/tower/run").mock(
+        return_value=httpx.Response(200, json={"reply": "ok"})
+    )
+    ctx = _ctx()
+    ctx.state["clearance_data"] = {"stale": True}
+
+    forward_mod.forward_to_agent("TWR", "EC-MIG", "msg", ctx)
+
+    assert ctx.state["clearance_data"] is None
+
+
+@respx.mock
+def test_http_failure_still_writes_all_four_state_keys(configured_urls, captured_log):
+    """The error path is not an early return: state stays consistent so
+    `runner.py` can surface the error text to the controller."""
+    respx.post("http://gnd.test/agents/ground/run").mock(return_value=httpx.Response(503))
+    ctx = _ctx(known_aircraft=[{"registration": "EC-MIG", "callsign": "IBE"}])
+
+    reply = forward_mod.forward_to_agent("GND", "EC-MIG", "msg", ctx)
+
+    assert reply == "[ERROR] GND agent returned HTTP 503"
+    assert ctx.state["reply"] == reply
+    assert ctx.state["dependency"] == "GND"
+    assert ctx.state["registration"] == "EC-MIG"
+    assert ctx.state["clearance_data"] is None
+
+
+@respx.mock
+def test_error_replies_are_written_to_the_debrief_log(configured_urls, captured_log):
+    """The append guard is only ``reply and session_id`` — error strings count
+    as replies, so the instructor's timeline records the outage."""
+    respx.post("http://gnd.test/agents/ground/run").mock(
+        side_effect=httpx.ConnectError("refused")
+    )
+
+    forward_mod.forward_to_agent(
+        "GND", "EC-MIG", "msg", _ctx(known_aircraft=[{"registration": "EC-MIG"}])
+    )
+
+    assert len(captured_log) == 1
+    assert captured_log[0]["reply"].startswith("[ERROR] could not reach GND agent")
+    assert captured_log[0]["taxi_data"] is None
+
+
+@respx.mock
+def test_session_log_callsign_comes_from_taxi_data_not_known_aircraft(
+    configured_urls, captured_log, captured_dispatch
+):
+    """The ``callsign`` recorded for the debrief is whatever the pilot agent
+    echoed back in ``taxi_data.aircraft_registration`` — and it is None
+    whenever the agent sent no taxi_data at all."""
+    respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "reply": "Push approved",
+                "taxi_data": {"pushback_approved": True, "aircraft_registration": "IBE3421"},
+            },
+        )
+    )
+
+    forward_mod.forward_to_agent(
+        "GND", "EC-MIG", "pushback", _ctx(known_aircraft=[{"registration": "EC-MIG"}])
+    )
+
+    assert captured_log[0]["callsign"] == "IBE3421"
+    assert captured_log[0]["taxi_data"] == {
+        "pushback_approved": True,
+        "aircraft_registration": "IBE3421",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Taxi dispatch trigger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "taxi_data, should_dispatch",
+    [
+        ({"pushback_approved": True}, True),
+        ({"taxi_route": "T E1"}, True),
+        ({"pushback_approved": True, "taxi_route": "T E1"}, True),
+        ({"pushback_approved": False, "taxi_route": "T E1"}, True),
+        ({"pushback_approved": False}, False),
+        ({"pushback_approved": False, "taxi_route": ""}, False),
+        ({"pushback_approved": False, "taxi_route": "   "}, False),
+        ({"taxi_route": None}, False),
+        ({}, False),
+        (None, False),
+    ],
+)
+@respx.mock
+def test_gnd_dispatch_trigger_truth_table(
+    configured_urls, captured_log, captured_dispatch, taxi_data, should_dispatch
+):
+    """A whitespace-only taxi_route does not count; a falsy pushback flag alone
+    does not either. Both are stripped/booled before the OR."""
+    body = {"reply": "ok"}
+    if taxi_data is not None:
+        body["taxi_data"] = taxi_data
+    respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(200, json=body)
+    )
+
+    forward_mod.forward_to_agent(
+        "GND", "EC-MIG", "msg", _ctx(known_aircraft=[{"registration": "EC-MIG"}])
+    )
+
+    assert bool(captured_dispatch) is should_dispatch
+
+
+@respx.mock
+def test_dispatch_is_skipped_when_registration_is_empty(
+    configured_urls, captured_log, captured_dispatch
+):
+    respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(
+            200, json={"reply": "ok", "taxi_data": {"pushback_approved": True}}
+        )
+    )
+
+    forward_mod.forward_to_agent("GND", "", "msg", _ctx())
+
+    assert captured_dispatch == []
+
+
+@respx.mock
+def test_twr_never_dispatches_a_taxi_plan(configured_urls, captured_log, captured_dispatch):
+    respx.post("http://twr.test/agents/tower/run").mock(
+        return_value=httpx.Response(
+            200, json={"reply": "ok", "taxi_data": {"pushback_approved": True}}
+        )
+    )
+
+    forward_mod.forward_to_agent("TWR", "EC-MIG", "msg", _ctx())
+
+    assert captured_dispatch == []
+
+
+@respx.mock
+def test_dispatch_payload_shape_is_exactly_three_merged_keys(
+    configured_urls, captured_log, captured_dispatch
+):
+    """The taxi router receives the *A\\* route*, the *agent's structured taxi
+    data*, and the *pilot readback* — plus the controller's original
+    instruction as a separate kwarg. This is the taxi-router contract."""
+    taxi_route = {"success": True, "waypoints": [{"lat": 41.0, "lon": 2.0}]}
+    taxi_data = {"taxi_route": "T E1", "aircraft_registration": "IBE3421"}
+    respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(
+            200, json={"reply": "Taxi via T to E1, IBE3421", "taxi_data": taxi_data}
+        )
+    )
+
+    forward_mod.forward_to_agent(
+        "GND",
+        "EC-MIG",
+        "IBE3421 taxi to holding point E1 via T",
+        _ctx(session_id="sess-42", known_aircraft=[{"registration": "EC-MIG"}]),
+        taxi_route=taxi_route,
+    )
+
+    assert len(captured_dispatch) == 1
+    assert captured_dispatch[0]["merged"] == {
+        "taxi_route": taxi_route,
+        "taxi_data": taxi_data,
+        "instruction_text": "Taxi via T to E1, IBE3421",
+    }
+    assert captured_dispatch[0]["kwargs"] == {
+        "pilot_readback_text": "Taxi via T to E1, IBE3421",
+        "registration": "EC-MIG",
+        "controller_instruction": "IBE3421 taxi to holding point E1 via T",
+        "callsign": "IBE3421",
+        "session_id": "sess-42",
+    }
+
+
+@respx.mock
+def test_dispatch_callsign_falls_back_to_registration(
+    configured_urls, captured_log, captured_dispatch
+):
+    respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(
+            200, json={"reply": "ok", "taxi_data": {"pushback_approved": True}}
+        )
+    )
+
+    forward_mod.forward_to_agent(
+        "GND", "EC-MIG", "msg", _ctx(known_aircraft=[{"registration": "EC-MIG"}])
+    )
+
+    assert captured_dispatch[0]["kwargs"]["callsign"] == "EC-MIG"
+
+
+@respx.mock
+def test_dispatch_merges_a_failed_taxi_route_unchanged(
+    configured_urls, captured_log, captured_dispatch
+):
+    """``taxi_route`` is forwarded to the router verbatim even when it was not
+    merged into the agent payload — the success filter applies only upstream."""
+    failed_route = {"success": False, "error": "no route"}
+    respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(
+            200, json={"reply": "ok", "taxi_data": {"pushback_approved": True}}
+        )
+    )
+
+    forward_mod.forward_to_agent(
+        "GND",
+        "EC-MIG",
+        "msg",
+        _ctx(known_aircraft=[{"registration": "EC-MIG"}]),
+        taxi_route=failed_route,
+    )
+
+    assert captured_dispatch[0]["merged"]["taxi_route"] == failed_route
+
+
+@respx.mock
+def test_dispatch_runs_after_the_session_log_and_before_the_state_writes(
+    configured_urls, captured_log, monkeypatch
+):
+    """Ordering guard: if dispatch blows up, the debrief entry has already been
+    written but the state keys have NOT — and the tool still returns the reply.
+    A refactor that moves the state writes above the dispatch would change what
+    `runner.py` sees on a dispatch failure."""
+    fake_router = types.ModuleType("shared.services.taxi_router")
+
+    def _boom(*_, **__):
+        raise RuntimeError("router exploded")
+
+    fake_router.dispatch_taxi_plan = _boom
+    monkeypatch.setitem(sys.modules, "shared.services.taxi_router", fake_router)
+    respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(
+            200, json={"reply": "Push approved", "taxi_data": {"pushback_approved": True}}
+        )
+    )
+    ctx = _ctx(known_aircraft=[{"registration": "EC-MIG"}])
+
+    reply = forward_mod.forward_to_agent("GND", "EC-MIG", "msg", ctx)
+
+    assert reply == "Push approved"
+    assert len(captured_log) == 1
+    assert ctx.state["reply"] == "Push approved"
+
+
+@respx.mock
+def test_no_session_log_and_no_state_pollution_when_session_id_is_empty(
+    configured_urls, captured_log, captured_dispatch
+):
+    """An empty session_id suppresses the debrief entry but NOT the dispatch —
+    the aircraft still moves, the instructor just loses the line."""
+    respx.post("http://gnd.test/agents/ground/run").mock(
+        return_value=httpx.Response(
+            200, json={"reply": "ok", "taxi_data": {"pushback_approved": True}}
+        )
+    )
+
+    forward_mod.forward_to_agent(
+        "GND", "EC-MIG", "msg", _ctx(session_id="", known_aircraft=[{"registration": "EC-MIG"}])
+    )
+
+    assert captured_log == []
+    assert len(captured_dispatch) == 1
+    assert captured_dispatch[0]["kwargs"]["session_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Contract guard: the ADK tool signature the LLM sees
+# ---------------------------------------------------------------------------
+
+
+def test_public_signature_is_stable():
+    """The ADK builds the tool's JSON schema from this signature and docstring;
+    renaming or reordering a parameter silently changes the agent contract."""
+    import inspect
+
+    sig = inspect.signature(forward_mod.forward_to_agent)
+    assert list(sig.parameters) == [
+        "dependency",
+        "registration",
+        "message",
+        "tool_context",
+        "taxi_route",
+    ]
+    assert sig.parameters["taxi_route"].default is None
+    assert forward_mod.forward_to_agent.__doc__ is not None


### PR DESCRIPTION
> Stacked on #93 (`feat/54-dedup-utils`). Review that one first; this PR's diff is only the two new test files.

## What

Characterization tests — they capture what the code does **today**, so the upcoming refactors of these two functions (#57, #56) can be shown to change nothing. No production code is touched.

### `build_timeline` — `tests/debrief/test_build_timeline_characterization.py` (32 tests)

`tests/debrief/test_debrief_builder.py` already covers the happy path; this module pins the edges of a function with degree 40 / cognitive complexity 29:

- timestamp coercion: epoch floats, ISO with `Z` and with an offset, and the silent `0.0` → `00:00:00` fallback for missing/garbage values (which sorts those entries to the top of the timeline)
- the per-stream skip rules — transcripts and replies are dropped when the text is blank, events **never** are
- the exact line shapes and every `-` fallback for `CTRL` / `PILOT` / `EVENT` / `CLEARANCE`
- the event-`extra` filter: scalars only, `None`/`""` dropped but `0`/`False` kept, non-dict `extra` ignored
- the five whitelisted clearance fields, their fixed order, and the `0`-means-unset rule that hides the runner's placeholder arrival rows
- `updated_at or cleared_at` (a falsy `updated_at` falls through)
- the stable tie-break order between the four streams — transcripts, replies, events, clearances — which any reordering of the four loops would change

### `forward_to_agent` — `tests/unit/orchestrator/test_forward_tool_characterization.py` (50 tests)

`test_forward_tool.py` covers the main paths; this module pins the *branch boundaries* of the orchestrator's central routing tool (fan-in 21), i.e. the things a "split into helpers" refactor is most likely to move by accident:

- dependency normalisation (`gnd` → GND) and the catch-all DEL fallback, which also rewrites `state["dependency"]`
- the unconfigured-agent-URL early return: **no** state writes, **no** debrief entry
- which inputs take the DEL pre-fetch branch — notably, `DEL` with an empty registration falls into the clearance branch instead
- both `departure_ICAO` / `departure_icao` spellings, unset upstream URLs, connection errors and non-200s all degrading to `None`
- `clearance_data` assembly: key omitted entirely when nothing is known, materialised by a taxi route alone, first-match-wins, and the three stripped keys
- state writes on success **and** on HTTP failure (the error path is not an early return), empty registration → `None`, `clearance_data` always reset
- the debrief-log guard (`reply and session_id`) — error strings do get logged; the `callsign` comes from `taxi_data`, not `known_aircraft`
- the full taxi-dispatch trigger truth table (10 cases, including whitespace-only `taxi_route`), the exact merged payload and kwargs handed to `dispatch_taxi_plan`, and the ordering guarantee that a dispatch failure leaves the debrief entry written and the state keys unwritten
- a guard on the public signature, since the ADK derives the agent-facing JSON schema from it

Both modules define their own fixtures — `tests/conftest.py` is deliberately left untouched.

## Why this only partially addresses #49

The other two functions in the issue are out of scope here: `dispatch_taxi_plan` lives in `shared/services/taxi_router/router.py`, which currently has **heavy work in progress**, and `ATISGenerator._parse_metar` is being handled separately.

Partially addresses #49 (the issue stays open).

## Testing

`pytest tests/unit/orchestrator tests/integration tests/debrief` — 254 passed, 2 xfailed (the pre-existing, documented `advance_registration_twr` / `_gnd_arrival` runner bug). Full suite: 370 passed, 1 skipped, 4 xfailed.