### PR TITLE
refactor(agents): single generic runner and FastAPI app for DEL/GND/TWR

### DIFF
--- a/agents/common/__init__.py
+++ b/agents/common/__init__.py
@@ -1,0 +1,7 @@
+"""Single source of truth for the code shared by the DEL / GND / TWR pilot agents.
+
+The modules here are vendored into ``agents/<phase>/shared/`` by
+``scripts/sync_agent_common.py`` because each agent is built from its own directory
+(``gcloud run deploy --source agents/<phase>``), so a container cannot import
+anything living above it. Edit the files here, never the vendored copies.
+"""

--- a/agents/common/agent_app.py
+++ b/agents/common/agent_app.py
@@ -1,0 +1,158 @@
+"""Generic FastAPI wrapper shared by the DEL / GND / TWR pilot agents.
+
+The three ``main.py`` files were the same ~90-line app: a ``POST /agents/<role>/run``
+handler that hands ``run_agent`` to a four-worker ``ThreadPoolExecutor`` (the runner
+opens its own event loop with ``asyncio.run()``, so it cannot run inside FastAPI's),
+plus ``GET /agents/<role>/info`` and ``GET /health``. Only the position label, the
+route, the request/response field names and the OpenAPI metadata differed.
+
+``create_app()`` is that common body; each agent's ``main.py`` supplies the
+configuration and keeps only its ``uvicorn`` entry point.
+
+Note this module deliberately does **not** use ``from __future__ import annotations``:
+the request and response models are created per-app inside ``create_app()``, so the
+handler annotations must be real objects when FastAPI inspects them, not strings it
+would try to resolve against module globals.
+
+Packaging note
+--------------
+Same as ``agent_runner.py``: this file is the single source of truth and is vendored
+into ``agents/<phase>/shared/agent_app.py`` because each agent's Docker build context
+is its own directory. Run ``python scripts/sync_agent_common.py`` after editing.
+"""
+
+import asyncio
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from fastapi import FastAPI
+from pydantic import create_model
+
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s — %(message)s"
+
+# Requests are served by run_agent() on a worker thread because run_agent opens
+# its own event loop; four workers matches the original per-agent setting.
+_MAX_WORKERS = 4
+
+
+@dataclass(frozen=True)
+class AgentAppConfig:
+    """Everything that differs between the DEL, GND and TWR FastAPI apps."""
+
+    label: str
+    """Short position name used in every log line, e.g. ``"DEL"``."""
+
+    role: str
+    """URL segment and OpenAPI tag, e.g. ``"delivery"`` -> ``/agents/delivery/run``."""
+
+    title: str
+    """OpenAPI title, e.g. ``"AIrport DEL Agent"``."""
+
+    version: str
+    """OpenAPI version string."""
+
+    description: str
+    """Human-readable blurb returned by ``GET /agents/<role>/info``."""
+
+    data_key: str
+    """Structured-payload key of the JSON response, e.g. ``"clearance_data"``.
+
+    This is part of the contract the orchestrator consumes -- do not rename it.
+    """
+
+    context_fields: tuple[str, ...] = ()
+    """Optional context fields accepted in the request body, in payload order."""
+
+
+def configure_logging() -> None:
+    """Apply the agents' shared logging configuration from ``LOG_LEVEL``."""
+    level = os.environ.get("LOG_LEVEL", "info").upper()
+    logging.basicConfig(level=level, format=_LOG_FORMAT)
+
+
+def create_app(
+    config: AgentAppConfig,
+    run_agent: Callable[..., dict],
+    logger: Optional[logging.Logger] = None,
+) -> FastAPI:
+    """Build the FastAPI app for one pilot agent."""
+    configure_logging()
+    log = logger if logger is not None else logging.getLogger(__name__)
+
+    executor = ThreadPoolExecutor(max_workers=_MAX_WORKERS)
+
+    optional_dict = (Optional[dict[str, Any]], None)
+    RunRequest = create_model(
+        "RunRequest",
+        session_id=(str, ...),
+        message=(str, ...),
+        **{name: optional_dict for name in config.context_fields},
+    )
+    RunResponse = create_model(
+        "RunResponse",
+        session_id=(str, ...),
+        reply=(str, ...),
+        **{config.data_key: optional_dict},
+    )
+
+    # Pre-render the variable part of the two per-request log lines so the
+    # emitted text is identical to the hand-written per-agent versions.
+    request_fmt = "[%s] ▶ request | session=%s | msg=%r" + "".join(
+        f" | {name}=%s" for name in config.context_fields
+    )
+    done_fmt = f"[%s] ■ done | session=%s | reply=%r | {config.data_key}=%s | %d ms"
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        model = os.environ.get("AGENT_MODEL", "<not set>")
+        log.info("[%s] starting — model: %s", config.label, model)
+        yield
+        log.info("[%s] shutting down", config.label)
+
+    app = FastAPI(title=config.title, version=config.version, lifespan=lifespan)
+
+    @app.post(f"/agents/{config.role}/run", response_model=RunResponse, tags=[config.role])
+    async def run(req: RunRequest) -> RunResponse:
+        context = [getattr(req, name) for name in config.context_fields]
+        log.info(
+            request_fmt,
+            config.label, req.session_id, req.message[:80], *[bool(v) for v in context],
+        )
+        t0 = asyncio.get_event_loop().time()
+        loop = asyncio.get_event_loop()
+        try:
+            result = await loop.run_in_executor(
+                executor, run_agent, req.session_id, req.message, *context
+            )
+        except Exception:
+            log.exception("[%s] ✗ executor error | session=%s", config.label, req.session_id)
+            raise
+        elapsed_ms = int((asyncio.get_event_loop().time() - t0) * 1000)
+        log.info(
+            done_fmt,
+            config.label, req.session_id, result["reply"][:80],
+            bool(result.get(config.data_key)), elapsed_ms,
+        )
+        return RunResponse(
+            session_id=req.session_id,
+            reply=result["reply"],
+            **{config.data_key: result.get(config.data_key)},
+        )
+
+    @app.get(f"/agents/{config.role}/info", tags=[config.role])
+    async def info():
+        return {
+            "name": config.label,
+            "model": os.environ.get("AGENT_MODEL", "<not set>"),
+            "description": config.description,
+        }
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok", "model": os.environ.get("AGENT_MODEL", "<not set>")}
+
+    return app

--- a/agents/common/agent_runner.py
+++ b/agents/common/agent_runner.py
@@ -1,0 +1,175 @@
+"""Generic ADK runner shared by the DEL / GND / TWR pilot agents.
+
+Every pilot agent used to ship its own ~85-line ``run_agent`` that differed only in
+four things: the ADK ``Agent`` object, the ADK app name, which context blocks the
+orchestrator attaches to the transmission, and the JSON keys the agent's prompt
+promises to emit. Everything else -- session handling, the ``run_async`` event loop,
+the regex JSON extraction, the error path and the log lines -- was identical.
+
+``build_run_agent()`` is that common body; each agent's ``runner.py`` supplies the
+configuration and re-exports a thin wrapper with its own public signature.
+
+Packaging note
+--------------
+This file is the single source of truth, but it is **vendored** into
+``agents/<phase>/shared/agent_runner.py`` because each agent is deployed with
+``gcloud run deploy --source agents/<phase>``: the Docker build context is the agent
+directory itself (``COPY . .``), so nothing above it can be imported at runtime. That
+is the same convention ``shared/callbacks.py`` already follows. Run
+``python scripts/sync_agent_common.py`` after editing this file;
+``tests/unit/agents/test_agent_common_vendoring.py`` fails if the copies drift.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai.types import Content, Part
+
+# Every agent runs its ADK session under the same synthetic user.
+_USER_ID = "pilot"
+
+# The prompts instruct the model to emit a single JSON object; it is usually
+# wrapped in prose or a markdown fence, hence the greedy DOTALL match.
+_JSON_BLOCK = re.compile(r"\{.*\}", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class ContextField:
+    """One optional context block the orchestrator may attach to a request.
+
+    ``name`` is the keyword argument the agent's ``run_agent`` accepts;
+    ``template`` is the line rendered into the ``[CONTEXT]`` section, with
+    ``{value}`` standing for the value itself.
+    """
+
+    name: str
+    template: str
+
+
+@dataclass(frozen=True)
+class AgentRunnerConfig:
+    """Everything that differs between the DEL, GND and TWR runners."""
+
+    label: str
+    """Short position name used in every log line, e.g. ``"DEL"``."""
+
+    app_name: str
+    """ADK application name, e.g. ``"airport_del"``."""
+
+    text_key: str
+    """JSON key holding the readback text, e.g. ``"clearance_text"``."""
+
+    data_key: str
+    """JSON key holding the structured payload, e.g. ``"clearance_data"``.
+
+    It is also the second key of the returned dict, so it is part of the
+    HTTP contract the orchestrator consumes.
+    """
+
+    context_fields: tuple[ContextField, ...] = ()
+    """Context blocks appended to the transmission, in render order."""
+
+    context_header: str = "\n\n[CONTEXT]"
+    """Header line that opens the context section."""
+
+
+def build_agent_context(
+    message: str, config: AgentRunnerConfig, values: dict[str, Any]
+) -> str:
+    """Append the non-empty context blocks to ``message``.
+
+    Returns ``message`` untouched when the orchestrator attached no context.
+    """
+    present = [(f, values.get(f.name)) for f in config.context_fields]
+    present = [(f, value) for f, value in present if value]
+    if not present:
+        return message
+
+    parts = [message, config.context_header]
+    parts.extend(f.template.format(value=value) for f, value in present)
+    return "\n".join(parts)
+
+
+def build_run_agent(
+    agent: Any,
+    config: AgentRunnerConfig,
+    logger: logging.Logger | None = None,
+) -> Callable[..., dict[str, Any]]:
+    """Build the ``run_agent`` callable for one pilot agent.
+
+    The returned function takes ``(session_id, message, **context)`` where the
+    accepted context keywords are ``config.context_fields``. It always returns
+    ``{"reply": <text>, config.data_key: <dict | None>}`` -- including on failure,
+    so the FastAPI layer never has to special-case errors.
+    """
+    log = logger if logger is not None else logging.getLogger(__name__)
+
+    session_service = InMemorySessionService()
+    adk_runner = Runner(agent=agent, app_name=config.app_name, session_service=session_service)
+
+    def run_agent(session_id: str, message: str, **context: Any) -> dict[str, Any]:
+        # Enrich the message with context pre-fetched by the orchestrator
+        enriched = build_agent_context(message, config, context)
+
+        log.info("[%s] run_agent | session=%s | msg=%r", config.label, session_id, enriched[:200])
+
+        async def _run() -> str:
+            existing = await session_service.get_session(
+                app_name=config.app_name, user_id=_USER_ID, session_id=session_id
+            )
+            if not existing:
+                await session_service.create_session(
+                    app_name=config.app_name, user_id=_USER_ID, session_id=session_id
+                )
+            reply_parts = []
+            async for event in adk_runner.run_async(
+                user_id=_USER_ID,
+                session_id=session_id,
+                new_message=Content(role="user", parts=[Part(text=enriched)]),
+            ):
+                log.debug("[%s] event: %s", config.label, event)
+                if event.is_final_response() and event.content:
+                    for part in event.content.parts:
+                        if hasattr(part, "text") and part.text:
+                            reply_parts.append(part.text)
+            return "".join(reply_parts).strip()
+
+        try:
+            raw_reply = asyncio.run(_run())
+        except Exception:
+            log.exception("[%s] agent error", config.label)
+            return {"reply": f"[{config.label} error] agent failed", config.data_key: None}
+
+        log.info("[%s] raw reply: %r", config.label, raw_reply[:300])
+
+        # Extract structured data from the JSON the agent is instructed to output
+        reply_text = raw_reply
+        reply_data = None
+        try:
+            match = _JSON_BLOCK.search(raw_reply)
+            if match:
+                parsed = json.loads(match.group())
+                reply_text = parsed.get(config.text_key, raw_reply)
+                reply_data = parsed.get(config.data_key)
+        except Exception as exc:
+            log.warning("[%s] could not parse JSON from reply: %s", config.label, exc)
+
+        log.info(
+            "[%s] result | %s=%r | %s=%s",
+            config.label,
+            config.text_key,
+            reply_text[:80],
+            config.data_key,
+            reply_data,
+        )
+        return {"reply": reply_text, config.data_key: reply_data}
+
+    return run_agent

--- a/agents/del/main.py
+++ b/agents/del/main.py
@@ -1,85 +1,25 @@
-import asyncio
+"""DEL agent service — the generic pilot FastAPI app configured for Delivery."""
+
 import logging
 import os
-from concurrent.futures import ThreadPoolExecutor
-from contextlib import asynccontextmanager
-from typing import Any
 
-from fastapi import FastAPI
-from pydantic import BaseModel
+from shared.agent_app import AgentAppConfig, create_app
 
 from runner import run_agent
 
-LOG_LEVEL = os.environ.get("LOG_LEVEL", "info").upper()
-logging.basicConfig(level=LOG_LEVEL, format="%(asctime)s %(levelname)s %(name)s — %(message)s")
 logger = logging.getLogger(__name__)
 
-_executor = ThreadPoolExecutor(max_workers=4)
+CONFIG = AgentAppConfig(
+    label="DEL",
+    role="delivery",
+    title="AIrport DEL Agent",
+    version="0.2.0",
+    description="ATC Delivery controller — issues IFR departure clearances",
+    data_key="clearance_data",
+    context_fields=("flight_plan", "atis"),
+)
 
-
-@asynccontextmanager
-async def lifespan(_app: FastAPI):
-    model = os.environ.get("AGENT_MODEL", "<not set>")
-    logger.info("[DEL] starting — model: %s", model)
-    yield
-    logger.info("[DEL] shutting down")
-
-
-app = FastAPI(title="AIrport DEL Agent", version="0.2.0", lifespan=lifespan)
-
-
-class RunRequest(BaseModel):
-    session_id: str
-    message: str
-    flight_plan: dict[str, Any] | None = None
-    atis: dict[str, Any] | None = None
-
-
-class RunResponse(BaseModel):
-    session_id: str
-    reply: str
-    clearance_data: dict[str, Any] | None = None
-
-
-@app.post("/agents/delivery/run", response_model=RunResponse, tags=["delivery"])
-async def run(req: RunRequest) -> RunResponse:
-    logger.info(
-        "[DEL] ▶ request | session=%s | msg=%r | flight_plan=%s | atis=%s",
-        req.session_id, req.message[:80], bool(req.flight_plan), bool(req.atis),
-    )
-    t0 = asyncio.get_event_loop().time()
-    loop = asyncio.get_event_loop()
-    try:
-        result = await loop.run_in_executor(
-            _executor, run_agent, req.session_id, req.message, req.flight_plan, req.atis
-        )
-    except Exception:
-        logger.exception("[DEL] ✗ executor error | session=%s", req.session_id)
-        raise
-    elapsed_ms = int((asyncio.get_event_loop().time() - t0) * 1000)
-    logger.info(
-        "[DEL] ■ done | session=%s | reply=%r | clearance_data=%s | %d ms",
-        req.session_id, result["reply"][:80], bool(result.get("clearance_data")), elapsed_ms,
-    )
-    return RunResponse(
-        session_id=req.session_id,
-        reply=result["reply"],
-        clearance_data=result.get("clearance_data"),
-    )
-
-
-@app.get("/agents/delivery/info", tags=["delivery"])
-async def info():
-    return {
-        "name": "DEL",
-        "model": os.environ.get("AGENT_MODEL", "<not set>"),
-        "description": "ATC Delivery controller — issues IFR departure clearances",
-    }
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok", "model": os.environ.get("AGENT_MODEL", "<not set>")}
+app = create_app(CONFIG, run_agent, logger=logger)
 
 
 if __name__ == "__main__":

--- a/agents/del/runner.py
+++ b/agents/del/runner.py
@@ -1,20 +1,25 @@
-import asyncio
-import json
+"""DEL runner — the generic pilot runner configured for Clearance Delivery."""
+
 import logging
-import re
 from typing import Any
 
-from google.adk.runners import Runner
-from google.adk.sessions import InMemorySessionService
-from google.genai.types import Content, Part
-
 from agent.agent import del_agent
+from shared.agent_runner import AgentRunnerConfig, ContextField, build_run_agent
 
 logger = logging.getLogger(__name__)
 
-_APP_NAME = "airport_del"
-_session_service = InMemorySessionService()
-_runner = Runner(agent=del_agent, app_name=_APP_NAME, session_service=_session_service)
+CONFIG = AgentRunnerConfig(
+    label="DEL",
+    app_name="airport_del",
+    text_key="clearance_text",
+    data_key="clearance_data",
+    context_fields=(
+        ContextField("flight_plan", "Flight plan: {value}"),
+        ContextField("atis", "ATIS: {value}"),
+    ),
+)
+
+_run_agent = build_run_agent(agent=del_agent, config=CONFIG, logger=logger)
 
 
 def run_agent(
@@ -23,62 +28,5 @@ def run_agent(
     flight_plan: dict | None = None,
     atis: dict | None = None,
 ) -> dict[str, Any]:
-    # Enrich message with context pre-fetched by the orchestrator
-    enriched = message
-    if flight_plan or atis:
-        parts = [message, "\n\n[CONTEXT]"]
-        if flight_plan:
-            parts.append(f"Flight plan: {flight_plan}")
-        if atis:
-            parts.append(f"ATIS: {atis}")
-        enriched = "\n".join(parts)
-
-    logger.info("[DEL] run_agent | session=%s | msg=%r", session_id, enriched[:200])
-
-    async def _run() -> str:
-        existing = await _session_service.get_session(
-            app_name=_APP_NAME, user_id="pilot", session_id=session_id
-        )
-        if not existing:
-            await _session_service.create_session(
-                app_name=_APP_NAME, user_id="pilot", session_id=session_id
-            )
-        reply_parts = []
-        async for event in _runner.run_async(
-            user_id="pilot",
-            session_id=session_id,
-            new_message=Content(role="user", parts=[Part(text=enriched)]),
-        ):
-            logger.debug("[DEL] event: %s", event)
-            if event.is_final_response() and event.content:
-                for part in event.content.parts:
-                    if hasattr(part, "text") and part.text:
-                        reply_parts.append(part.text)
-        return "".join(reply_parts).strip()
-
-    try:
-        raw_reply = asyncio.run(_run())
-    except Exception:
-        logger.exception("[DEL] agent error")
-        return {"reply": "[DEL error] agent failed", "clearance_data": None}
-
-    logger.info("[DEL] raw reply: %r", raw_reply[:300])
-
-    # Extract structured data from the JSON the agent is instructed to output
-    clearance_text = raw_reply
-    clearance_data = None
-    try:
-        match = re.search(r"\{.*\}", raw_reply, re.DOTALL)
-        if match:
-            parsed = json.loads(match.group())
-            clearance_text = parsed.get("clearance_text", raw_reply)
-            clearance_data = parsed.get("clearance_data")
-    except Exception as exc:
-        logger.warning("[DEL] could not parse JSON from reply: %s", exc)
-
-    logger.info(
-        "[DEL] result | clearance_text=%r | clearance_data=%s",
-        clearance_text[:80],
-        clearance_data,
-    )
-    return {"reply": clearance_text, "clearance_data": clearance_data}
+    """Draft the IFR clearance readback. Returns ``{"reply", "clearance_data"}``."""
+    return _run_agent(session_id, message, flight_plan=flight_plan, atis=atis)

--- a/agents/del/shared/agent_app.py
+++ b/agents/del/shared/agent_app.py
@@ -1,0 +1,158 @@
+"""Generic FastAPI wrapper shared by the DEL / GND / TWR pilot agents.
+
+The three ``main.py`` files were the same ~90-line app: a ``POST /agents/<role>/run``
+handler that hands ``run_agent`` to a four-worker ``ThreadPoolExecutor`` (the runner
+opens its own event loop with ``asyncio.run()``, so it cannot run inside FastAPI's),
+plus ``GET /agents/<role>/info`` and ``GET /health``. Only the position label, the
+route, the request/response field names and the OpenAPI metadata differed.
+
+``create_app()`` is that common body; each agent's ``main.py`` supplies the
+configuration and keeps only its ``uvicorn`` entry point.
+
+Note this module deliberately does **not** use ``from __future__ import annotations``:
+the request and response models are created per-app inside ``create_app()``, so the
+handler annotations must be real objects when FastAPI inspects them, not strings it
+would try to resolve against module globals.
+
+Packaging note
+--------------
+Same as ``agent_runner.py``: this file is the single source of truth and is vendored
+into ``agents/<phase>/shared/agent_app.py`` because each agent's Docker build context
+is its own directory. Run ``python scripts/sync_agent_common.py`` after editing.
+"""
+
+import asyncio
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from fastapi import FastAPI
+from pydantic import create_model
+
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s — %(message)s"
+
+# Requests are served by run_agent() on a worker thread because run_agent opens
+# its own event loop; four workers matches the original per-agent setting.
+_MAX_WORKERS = 4
+
+
+@dataclass(frozen=True)
+class AgentAppConfig:
+    """Everything that differs between the DEL, GND and TWR FastAPI apps."""
+
+    label: str
+    """Short position name used in every log line, e.g. ``"DEL"``."""
+
+    role: str
+    """URL segment and OpenAPI tag, e.g. ``"delivery"`` -> ``/agents/delivery/run``."""
+
+    title: str
+    """OpenAPI title, e.g. ``"AIrport DEL Agent"``."""
+
+    version: str
+    """OpenAPI version string."""
+
+    description: str
+    """Human-readable blurb returned by ``GET /agents/<role>/info``."""
+
+    data_key: str
+    """Structured-payload key of the JSON response, e.g. ``"clearance_data"``.
+
+    This is part of the contract the orchestrator consumes -- do not rename it.
+    """
+
+    context_fields: tuple[str, ...] = ()
+    """Optional context fields accepted in the request body, in payload order."""
+
+
+def configure_logging() -> None:
+    """Apply the agents' shared logging configuration from ``LOG_LEVEL``."""
+    level = os.environ.get("LOG_LEVEL", "info").upper()
+    logging.basicConfig(level=level, format=_LOG_FORMAT)
+
+
+def create_app(
+    config: AgentAppConfig,
+    run_agent: Callable[..., dict],
+    logger: Optional[logging.Logger] = None,
+) -> FastAPI:
+    """Build the FastAPI app for one pilot agent."""
+    configure_logging()
+    log = logger if logger is not None else logging.getLogger(__name__)
+
+    executor = ThreadPoolExecutor(max_workers=_MAX_WORKERS)
+
+    optional_dict = (Optional[dict[str, Any]], None)
+    RunRequest = create_model(
+        "RunRequest",
+        session_id=(str, ...),
+        message=(str, ...),
+        **{name: optional_dict for name in config.context_fields},
+    )
+    RunResponse = create_model(
+        "RunResponse",
+        session_id=(str, ...),
+        reply=(str, ...),
+        **{config.data_key: optional_dict},
+    )
+
+    # Pre-render the variable part of the two per-request log lines so the
+    # emitted text is identical to the hand-written per-agent versions.
+    request_fmt = "[%s] ▶ request | session=%s | msg=%r" + "".join(
+        f" | {name}=%s" for name in config.context_fields
+    )
+    done_fmt = f"[%s] ■ done | session=%s | reply=%r | {config.data_key}=%s | %d ms"
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        model = os.environ.get("AGENT_MODEL", "<not set>")
+        log.info("[%s] starting — model: %s", config.label, model)
+        yield
+        log.info("[%s] shutting down", config.label)
+
+    app = FastAPI(title=config.title, version=config.version, lifespan=lifespan)
+
+    @app.post(f"/agents/{config.role}/run", response_model=RunResponse, tags=[config.role])
+    async def run(req: RunRequest) -> RunResponse:
+        context = [getattr(req, name) for name in config.context_fields]
+        log.info(
+            request_fmt,
+            config.label, req.session_id, req.message[:80], *[bool(v) for v in context],
+        )
+        t0 = asyncio.get_event_loop().time()
+        loop = asyncio.get_event_loop()
+        try:
+            result = await loop.run_in_executor(
+                executor, run_agent, req.session_id, req.message, *context
+            )
+        except Exception:
+            log.exception("[%s] ✗ executor error | session=%s", config.label, req.session_id)
+            raise
+        elapsed_ms = int((asyncio.get_event_loop().time() - t0) * 1000)
+        log.info(
+            done_fmt,
+            config.label, req.session_id, result["reply"][:80],
+            bool(result.get(config.data_key)), elapsed_ms,
+        )
+        return RunResponse(
+            session_id=req.session_id,
+            reply=result["reply"],
+            **{config.data_key: result.get(config.data_key)},
+        )
+
+    @app.get(f"/agents/{config.role}/info", tags=[config.role])
+    async def info():
+        return {
+            "name": config.label,
+            "model": os.environ.get("AGENT_MODEL", "<not set>"),
+            "description": config.description,
+        }
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok", "model": os.environ.get("AGENT_MODEL", "<not set>")}
+
+    return app

--- a/agents/del/shared/agent_runner.py
+++ b/agents/del/shared/agent_runner.py
@@ -1,0 +1,175 @@
+"""Generic ADK runner shared by the DEL / GND / TWR pilot agents.
+
+Every pilot agent used to ship its own ~85-line ``run_agent`` that differed only in
+four things: the ADK ``Agent`` object, the ADK app name, which context blocks the
+orchestrator attaches to the transmission, and the JSON keys the agent's prompt
+promises to emit. Everything else -- session handling, the ``run_async`` event loop,
+the regex JSON extraction, the error path and the log lines -- was identical.
+
+``build_run_agent()`` is that common body; each agent's ``runner.py`` supplies the
+configuration and re-exports a thin wrapper with its own public signature.
+
+Packaging note
+--------------
+This file is the single source of truth, but it is **vendored** into
+``agents/<phase>/shared/agent_runner.py`` because each agent is deployed with
+``gcloud run deploy --source agents/<phase>``: the Docker build context is the agent
+directory itself (``COPY . .``), so nothing above it can be imported at runtime. That
+is the same convention ``shared/callbacks.py`` already follows. Run
+``python scripts/sync_agent_common.py`` after editing this file;
+``tests/unit/agents/test_agent_common_vendoring.py`` fails if the copies drift.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai.types import Content, Part
+
+# Every agent runs its ADK session under the same synthetic user.
+_USER_ID = "pilot"
+
+# The prompts instruct the model to emit a single JSON object; it is usually
+# wrapped in prose or a markdown fence, hence the greedy DOTALL match.
+_JSON_BLOCK = re.compile(r"\{.*\}", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class ContextField:
+    """One optional context block the orchestrator may attach to a request.
+
+    ``name`` is the keyword argument the agent's ``run_agent`` accepts;
+    ``template`` is the line rendered into the ``[CONTEXT]`` section, with
+    ``{value}`` standing for the value itself.
+    """
+
+    name: str
+    template: str
+
+
+@dataclass(frozen=True)
+class AgentRunnerConfig:
+    """Everything that differs between the DEL, GND and TWR runners."""
+
+    label: str
+    """Short position name used in every log line, e.g. ``"DEL"``."""
+
+    app_name: str
+    """ADK application name, e.g. ``"airport_del"``."""
+
+    text_key: str
+    """JSON key holding the readback text, e.g. ``"clearance_text"``."""
+
+    data_key: str
+    """JSON key holding the structured payload, e.g. ``"clearance_data"``.
+
+    It is also the second key of the returned dict, so it is part of the
+    HTTP contract the orchestrator consumes.
+    """
+
+    context_fields: tuple[ContextField, ...] = ()
+    """Context blocks appended to the transmission, in render order."""
+
+    context_header: str = "\n\n[CONTEXT]"
+    """Header line that opens the context section."""
+
+
+def build_agent_context(
+    message: str, config: AgentRunnerConfig, values: dict[str, Any]
+) -> str:
+    """Append the non-empty context blocks to ``message``.
+
+    Returns ``message`` untouched when the orchestrator attached no context.
+    """
+    present = [(f, values.get(f.name)) for f in config.context_fields]
+    present = [(f, value) for f, value in present if value]
+    if not present:
+        return message
+
+    parts = [message, config.context_header]
+    parts.extend(f.template.format(value=value) for f, value in present)
+    return "\n".join(parts)
+
+
+def build_run_agent(
+    agent: Any,
+    config: AgentRunnerConfig,
+    logger: logging.Logger | None = None,
+) -> Callable[..., dict[str, Any]]:
+    """Build the ``run_agent`` callable for one pilot agent.
+
+    The returned function takes ``(session_id, message, **context)`` where the
+    accepted context keywords are ``config.context_fields``. It always returns
+    ``{"reply": <text>, config.data_key: <dict | None>}`` -- including on failure,
+    so the FastAPI layer never has to special-case errors.
+    """
+    log = logger if logger is not None else logging.getLogger(__name__)
+
+    session_service = InMemorySessionService()
+    adk_runner = Runner(agent=agent, app_name=config.app_name, session_service=session_service)
+
+    def run_agent(session_id: str, message: str, **context: Any) -> dict[str, Any]:
+        # Enrich the message with context pre-fetched by the orchestrator
+        enriched = build_agent_context(message, config, context)
+
+        log.info("[%s] run_agent | session=%s | msg=%r", config.label, session_id, enriched[:200])
+
+        async def _run() -> str:
+            existing = await session_service.get_session(
+                app_name=config.app_name, user_id=_USER_ID, session_id=session_id
+            )
+            if not existing:
+                await session_service.create_session(
+                    app_name=config.app_name, user_id=_USER_ID, session_id=session_id
+                )
+            reply_parts = []
+            async for event in adk_runner.run_async(
+                user_id=_USER_ID,
+                session_id=session_id,
+                new_message=Content(role="user", parts=[Part(text=enriched)]),
+            ):
+                log.debug("[%s] event: %s", config.label, event)
+                if event.is_final_response() and event.content:
+                    for part in event.content.parts:
+                        if hasattr(part, "text") and part.text:
+                            reply_parts.append(part.text)
+            return "".join(reply_parts).strip()
+
+        try:
+            raw_reply = asyncio.run(_run())
+        except Exception:
+            log.exception("[%s] agent error", config.label)
+            return {"reply": f"[{config.label} error] agent failed", config.data_key: None}
+
+        log.info("[%s] raw reply: %r", config.label, raw_reply[:300])
+
+        # Extract structured data from the JSON the agent is instructed to output
+        reply_text = raw_reply
+        reply_data = None
+        try:
+            match = _JSON_BLOCK.search(raw_reply)
+            if match:
+                parsed = json.loads(match.group())
+                reply_text = parsed.get(config.text_key, raw_reply)
+                reply_data = parsed.get(config.data_key)
+        except Exception as exc:
+            log.warning("[%s] could not parse JSON from reply: %s", config.label, exc)
+
+        log.info(
+            "[%s] result | %s=%r | %s=%s",
+            config.label,
+            config.text_key,
+            reply_text[:80],
+            config.data_key,
+            reply_data,
+        )
+        return {"reply": reply_text, config.data_key: reply_data}
+
+    return run_agent

--- a/agents/gnd/main.py
+++ b/agents/gnd/main.py
@@ -1,84 +1,25 @@
-import asyncio
+"""GND agent service — the generic pilot FastAPI app configured for Ground."""
+
 import logging
 import os
-from concurrent.futures import ThreadPoolExecutor
-from contextlib import asynccontextmanager
-from typing import Any
 
-from fastapi import FastAPI
-from pydantic import BaseModel
+from shared.agent_app import AgentAppConfig, create_app
 
 from runner import run_agent
 
-LOG_LEVEL = os.environ.get("LOG_LEVEL", "info").upper()
-logging.basicConfig(level=LOG_LEVEL, format="%(asctime)s %(levelname)s %(name)s — %(message)s")
 logger = logging.getLogger(__name__)
 
-_executor = ThreadPoolExecutor(max_workers=4)
+CONFIG = AgentAppConfig(
+    label="GND",
+    role="ground",
+    title="AIrport GND Agent",
+    version="0.1.0",
+    description="ATC Ground controller — issues pushback and taxi instructions",
+    data_key="taxi_data",
+    context_fields=("clearance_data",),
+)
 
-
-@asynccontextmanager
-async def lifespan(_app: FastAPI):
-    model = os.environ.get("AGENT_MODEL", "<not set>")
-    logger.info("[GND] starting — model: %s", model)
-    yield
-    logger.info("[GND] shutting down")
-
-
-app = FastAPI(title="AIrport GND Agent", version="0.1.0", lifespan=lifespan)
-
-
-class RunRequest(BaseModel):
-    session_id: str
-    message: str
-    clearance_data: dict[str, Any] | None = None
-
-
-class RunResponse(BaseModel):
-    session_id: str
-    reply: str
-    taxi_data: dict[str, Any] | None = None
-
-
-@app.post("/agents/ground/run", response_model=RunResponse, tags=["ground"])
-async def run(req: RunRequest) -> RunResponse:
-    logger.info(
-        "[GND] ▶ request | session=%s | msg=%r | clearance_data=%s",
-        req.session_id, req.message[:80], bool(req.clearance_data),
-    )
-    t0 = asyncio.get_event_loop().time()
-    loop = asyncio.get_event_loop()
-    try:
-        result = await loop.run_in_executor(
-            _executor, run_agent, req.session_id, req.message, req.clearance_data
-        )
-    except Exception:
-        logger.exception("[GND] ✗ executor error | session=%s", req.session_id)
-        raise
-    elapsed_ms = int((asyncio.get_event_loop().time() - t0) * 1000)
-    logger.info(
-        "[GND] ■ done | session=%s | reply=%r | taxi_data=%s | %d ms",
-        req.session_id, result["reply"][:80], bool(result.get("taxi_data")), elapsed_ms,
-    )
-    return RunResponse(
-        session_id=req.session_id,
-        reply=result["reply"],
-        taxi_data=result.get("taxi_data"),
-    )
-
-
-@app.get("/agents/ground/info", tags=["ground"])
-async def info():
-    return {
-        "name": "GND",
-        "model": os.environ.get("AGENT_MODEL", "<not set>"),
-        "description": "ATC Ground controller — issues pushback and taxi instructions",
-    }
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok", "model": os.environ.get("AGENT_MODEL", "<not set>")}
+app = create_app(CONFIG, run_agent, logger=logger)
 
 
 if __name__ == "__main__":

--- a/agents/gnd/runner.py
+++ b/agents/gnd/runner.py
@@ -1,20 +1,24 @@
-import asyncio
-import json
+"""GND runner — the generic pilot runner configured for Ground."""
+
 import logging
-import re
 from typing import Any
 
-from google.adk.runners import Runner
-from google.adk.sessions import InMemorySessionService
-from google.genai.types import Content, Part
-
 from agent.agent import gnd_agent
+from shared.agent_runner import AgentRunnerConfig, ContextField, build_run_agent
 
 logger = logging.getLogger(__name__)
 
-_APP_NAME = "airport_gnd"
-_session_service = InMemorySessionService()
-_runner = Runner(agent=gnd_agent, app_name=_APP_NAME, session_service=_session_service)
+CONFIG = AgentRunnerConfig(
+    label="GND",
+    app_name="airport_gnd",
+    text_key="instruction_text",
+    data_key="taxi_data",
+    context_fields=(ContextField("clearance_data", "Clearance data: {value}"),),
+    # GND opens the context section with a single newline, unlike DEL and TWR.
+    context_header="\n[CONTEXT]",
+)
+
+_run_agent = build_run_agent(agent=gnd_agent, config=CONFIG, logger=logger)
 
 
 def run_agent(
@@ -22,57 +26,5 @@ def run_agent(
     message: str,
     clearance_data: dict | None = None,
 ) -> dict[str, Any]:
-    # Enrich message with pre-fetched clearance context from the orchestrator
-    enriched = message
-    if clearance_data:
-        enriched = "\n".join([message, "\n[CONTEXT]", f"Clearance data: {clearance_data}"])
-
-    logger.info("[GND] run_agent | session=%s | msg=%r", session_id, enriched[:200])
-
-    async def _run() -> str:
-        existing = await _session_service.get_session(
-            app_name=_APP_NAME, user_id="pilot", session_id=session_id
-        )
-        if not existing:
-            await _session_service.create_session(
-                app_name=_APP_NAME, user_id="pilot", session_id=session_id
-            )
-        reply_parts = []
-        async for event in _runner.run_async(
-            user_id="pilot",
-            session_id=session_id,
-            new_message=Content(role="user", parts=[Part(text=enriched)]),
-        ):
-            logger.debug("[GND] event: %s", event)
-            if event.is_final_response() and event.content:
-                for part in event.content.parts:
-                    if hasattr(part, "text") and part.text:
-                        reply_parts.append(part.text)
-        return "".join(reply_parts).strip()
-
-    try:
-        raw_reply = asyncio.run(_run())
-    except Exception:
-        logger.exception("[GND] agent error")
-        return {"reply": "[GND error] agent failed", "taxi_data": None}
-
-    logger.info("[GND] raw reply: %r", raw_reply[:300])
-
-    # Extract structured data from the JSON the agent is instructed to output
-    instruction_text = raw_reply
-    taxi_data = None
-    try:
-        match = re.search(r"\{.*\}", raw_reply, re.DOTALL)
-        if match:
-            parsed = json.loads(match.group())
-            instruction_text = parsed.get("instruction_text", raw_reply)
-            taxi_data = parsed.get("taxi_data")
-    except Exception as exc:
-        logger.warning("[GND] could not parse JSON from reply: %s", exc)
-
-    logger.info(
-        "[GND] result | instruction_text=%r | taxi_data=%s",
-        instruction_text[:80],
-        taxi_data,
-    )
-    return {"reply": instruction_text, "taxi_data": taxi_data}
+    """Draft the pushback/taxi readback. Returns ``{"reply", "taxi_data"}``."""
+    return _run_agent(session_id, message, clearance_data=clearance_data)

--- a/agents/gnd/shared/agent_app.py
+++ b/agents/gnd/shared/agent_app.py
@@ -1,0 +1,158 @@
+"""Generic FastAPI wrapper shared by the DEL / GND / TWR pilot agents.
+
+The three ``main.py`` files were the same ~90-line app: a ``POST /agents/<role>/run``
+handler that hands ``run_agent`` to a four-worker ``ThreadPoolExecutor`` (the runner
+opens its own event loop with ``asyncio.run()``, so it cannot run inside FastAPI's),
+plus ``GET /agents/<role>/info`` and ``GET /health``. Only the position label, the
+route, the request/response field names and the OpenAPI metadata differed.
+
+``create_app()`` is that common body; each agent's ``main.py`` supplies the
+configuration and keeps only its ``uvicorn`` entry point.
+
+Note this module deliberately does **not** use ``from __future__ import annotations``:
+the request and response models are created per-app inside ``create_app()``, so the
+handler annotations must be real objects when FastAPI inspects them, not strings it
+would try to resolve against module globals.
+
+Packaging note
+--------------
+Same as ``agent_runner.py``: this file is the single source of truth and is vendored
+into ``agents/<phase>/shared/agent_app.py`` because each agent's Docker build context
+is its own directory. Run ``python scripts/sync_agent_common.py`` after editing.
+"""
+
+import asyncio
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from fastapi import FastAPI
+from pydantic import create_model
+
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s — %(message)s"
+
+# Requests are served by run_agent() on a worker thread because run_agent opens
+# its own event loop; four workers matches the original per-agent setting.
+_MAX_WORKERS = 4
+
+
+@dataclass(frozen=True)
+class AgentAppConfig:
+    """Everything that differs between the DEL, GND and TWR FastAPI apps."""
+
+    label: str
+    """Short position name used in every log line, e.g. ``"DEL"``."""
+
+    role: str
+    """URL segment and OpenAPI tag, e.g. ``"delivery"`` -> ``/agents/delivery/run``."""
+
+    title: str
+    """OpenAPI title, e.g. ``"AIrport DEL Agent"``."""
+
+    version: str
+    """OpenAPI version string."""
+
+    description: str
+    """Human-readable blurb returned by ``GET /agents/<role>/info``."""
+
+    data_key: str
+    """Structured-payload key of the JSON response, e.g. ``"clearance_data"``.
+
+    This is part of the contract the orchestrator consumes -- do not rename it.
+    """
+
+    context_fields: tuple[str, ...] = ()
+    """Optional context fields accepted in the request body, in payload order."""
+
+
+def configure_logging() -> None:
+    """Apply the agents' shared logging configuration from ``LOG_LEVEL``."""
+    level = os.environ.get("LOG_LEVEL", "info").upper()
+    logging.basicConfig(level=level, format=_LOG_FORMAT)
+
+
+def create_app(
+    config: AgentAppConfig,
+    run_agent: Callable[..., dict],
+    logger: Optional[logging.Logger] = None,
+) -> FastAPI:
+    """Build the FastAPI app for one pilot agent."""
+    configure_logging()
+    log = logger if logger is not None else logging.getLogger(__name__)
+
+    executor = ThreadPoolExecutor(max_workers=_MAX_WORKERS)
+
+    optional_dict = (Optional[dict[str, Any]], None)
+    RunRequest = create_model(
+        "RunRequest",
+        session_id=(str, ...),
+        message=(str, ...),
+        **{name: optional_dict for name in config.context_fields},
+    )
+    RunResponse = create_model(
+        "RunResponse",
+        session_id=(str, ...),
+        reply=(str, ...),
+        **{config.data_key: optional_dict},
+    )
+
+    # Pre-render the variable part of the two per-request log lines so the
+    # emitted text is identical to the hand-written per-agent versions.
+    request_fmt = "[%s] ▶ request | session=%s | msg=%r" + "".join(
+        f" | {name}=%s" for name in config.context_fields
+    )
+    done_fmt = f"[%s] ■ done | session=%s | reply=%r | {config.data_key}=%s | %d ms"
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        model = os.environ.get("AGENT_MODEL", "<not set>")
+        log.info("[%s] starting — model: %s", config.label, model)
+        yield
+        log.info("[%s] shutting down", config.label)
+
+    app = FastAPI(title=config.title, version=config.version, lifespan=lifespan)
+
+    @app.post(f"/agents/{config.role}/run", response_model=RunResponse, tags=[config.role])
+    async def run(req: RunRequest) -> RunResponse:
+        context = [getattr(req, name) for name in config.context_fields]
+        log.info(
+            request_fmt,
+            config.label, req.session_id, req.message[:80], *[bool(v) for v in context],
+        )
+        t0 = asyncio.get_event_loop().time()
+        loop = asyncio.get_event_loop()
+        try:
+            result = await loop.run_in_executor(
+                executor, run_agent, req.session_id, req.message, *context
+            )
+        except Exception:
+            log.exception("[%s] ✗ executor error | session=%s", config.label, req.session_id)
+            raise
+        elapsed_ms = int((asyncio.get_event_loop().time() - t0) * 1000)
+        log.info(
+            done_fmt,
+            config.label, req.session_id, result["reply"][:80],
+            bool(result.get(config.data_key)), elapsed_ms,
+        )
+        return RunResponse(
+            session_id=req.session_id,
+            reply=result["reply"],
+            **{config.data_key: result.get(config.data_key)},
+        )
+
+    @app.get(f"/agents/{config.role}/info", tags=[config.role])
+    async def info():
+        return {
+            "name": config.label,
+            "model": os.environ.get("AGENT_MODEL", "<not set>"),
+            "description": config.description,
+        }
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok", "model": os.environ.get("AGENT_MODEL", "<not set>")}
+
+    return app

--- a/agents/gnd/shared/agent_runner.py
+++ b/agents/gnd/shared/agent_runner.py
@@ -1,0 +1,175 @@
+"""Generic ADK runner shared by the DEL / GND / TWR pilot agents.
+
+Every pilot agent used to ship its own ~85-line ``run_agent`` that differed only in
+four things: the ADK ``Agent`` object, the ADK app name, which context blocks the
+orchestrator attaches to the transmission, and the JSON keys the agent's prompt
+promises to emit. Everything else -- session handling, the ``run_async`` event loop,
+the regex JSON extraction, the error path and the log lines -- was identical.
+
+``build_run_agent()`` is that common body; each agent's ``runner.py`` supplies the
+configuration and re-exports a thin wrapper with its own public signature.
+
+Packaging note
+--------------
+This file is the single source of truth, but it is **vendored** into
+``agents/<phase>/shared/agent_runner.py`` because each agent is deployed with
+``gcloud run deploy --source agents/<phase>``: the Docker build context is the agent
+directory itself (``COPY . .``), so nothing above it can be imported at runtime. That
+is the same convention ``shared/callbacks.py`` already follows. Run
+``python scripts/sync_agent_common.py`` after editing this file;
+``tests/unit/agents/test_agent_common_vendoring.py`` fails if the copies drift.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai.types import Content, Part
+
+# Every agent runs its ADK session under the same synthetic user.
+_USER_ID = "pilot"
+
+# The prompts instruct the model to emit a single JSON object; it is usually
+# wrapped in prose or a markdown fence, hence the greedy DOTALL match.
+_JSON_BLOCK = re.compile(r"\{.*\}", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class ContextField:
+    """One optional context block the orchestrator may attach to a request.
+
+    ``name`` is the keyword argument the agent's ``run_agent`` accepts;
+    ``template`` is the line rendered into the ``[CONTEXT]`` section, with
+    ``{value}`` standing for the value itself.
+    """
+
+    name: str
+    template: str
+
+
+@dataclass(frozen=True)
+class AgentRunnerConfig:
+    """Everything that differs between the DEL, GND and TWR runners."""
+
+    label: str
+    """Short position name used in every log line, e.g. ``"DEL"``."""
+
+    app_name: str
+    """ADK application name, e.g. ``"airport_del"``."""
+
+    text_key: str
+    """JSON key holding the readback text, e.g. ``"clearance_text"``."""
+
+    data_key: str
+    """JSON key holding the structured payload, e.g. ``"clearance_data"``.
+
+    It is also the second key of the returned dict, so it is part of the
+    HTTP contract the orchestrator consumes.
+    """
+
+    context_fields: tuple[ContextField, ...] = ()
+    """Context blocks appended to the transmission, in render order."""
+
+    context_header: str = "\n\n[CONTEXT]"
+    """Header line that opens the context section."""
+
+
+def build_agent_context(
+    message: str, config: AgentRunnerConfig, values: dict[str, Any]
+) -> str:
+    """Append the non-empty context blocks to ``message``.
+
+    Returns ``message`` untouched when the orchestrator attached no context.
+    """
+    present = [(f, values.get(f.name)) for f in config.context_fields]
+    present = [(f, value) for f, value in present if value]
+    if not present:
+        return message
+
+    parts = [message, config.context_header]
+    parts.extend(f.template.format(value=value) for f, value in present)
+    return "\n".join(parts)
+
+
+def build_run_agent(
+    agent: Any,
+    config: AgentRunnerConfig,
+    logger: logging.Logger | None = None,
+) -> Callable[..., dict[str, Any]]:
+    """Build the ``run_agent`` callable for one pilot agent.
+
+    The returned function takes ``(session_id, message, **context)`` where the
+    accepted context keywords are ``config.context_fields``. It always returns
+    ``{"reply": <text>, config.data_key: <dict | None>}`` -- including on failure,
+    so the FastAPI layer never has to special-case errors.
+    """
+    log = logger if logger is not None else logging.getLogger(__name__)
+
+    session_service = InMemorySessionService()
+    adk_runner = Runner(agent=agent, app_name=config.app_name, session_service=session_service)
+
+    def run_agent(session_id: str, message: str, **context: Any) -> dict[str, Any]:
+        # Enrich the message with context pre-fetched by the orchestrator
+        enriched = build_agent_context(message, config, context)
+
+        log.info("[%s] run_agent | session=%s | msg=%r", config.label, session_id, enriched[:200])
+
+        async def _run() -> str:
+            existing = await session_service.get_session(
+                app_name=config.app_name, user_id=_USER_ID, session_id=session_id
+            )
+            if not existing:
+                await session_service.create_session(
+                    app_name=config.app_name, user_id=_USER_ID, session_id=session_id
+                )
+            reply_parts = []
+            async for event in adk_runner.run_async(
+                user_id=_USER_ID,
+                session_id=session_id,
+                new_message=Content(role="user", parts=[Part(text=enriched)]),
+            ):
+                log.debug("[%s] event: %s", config.label, event)
+                if event.is_final_response() and event.content:
+                    for part in event.content.parts:
+                        if hasattr(part, "text") and part.text:
+                            reply_parts.append(part.text)
+            return "".join(reply_parts).strip()
+
+        try:
+            raw_reply = asyncio.run(_run())
+        except Exception:
+            log.exception("[%s] agent error", config.label)
+            return {"reply": f"[{config.label} error] agent failed", config.data_key: None}
+
+        log.info("[%s] raw reply: %r", config.label, raw_reply[:300])
+
+        # Extract structured data from the JSON the agent is instructed to output
+        reply_text = raw_reply
+        reply_data = None
+        try:
+            match = _JSON_BLOCK.search(raw_reply)
+            if match:
+                parsed = json.loads(match.group())
+                reply_text = parsed.get(config.text_key, raw_reply)
+                reply_data = parsed.get(config.data_key)
+        except Exception as exc:
+            log.warning("[%s] could not parse JSON from reply: %s", config.label, exc)
+
+        log.info(
+            "[%s] result | %s=%r | %s=%s",
+            config.label,
+            config.text_key,
+            reply_text[:80],
+            config.data_key,
+            reply_data,
+        )
+        return {"reply": reply_text, config.data_key: reply_data}
+
+    return run_agent

--- a/agents/twr/main.py
+++ b/agents/twr/main.py
@@ -1,84 +1,25 @@
-import asyncio
+"""TWR agent service — the generic pilot FastAPI app configured for Tower."""
+
 import logging
 import os
-from concurrent.futures import ThreadPoolExecutor
-from contextlib import asynccontextmanager
-from typing import Any
 
-from fastapi import FastAPI
-from pydantic import BaseModel
+from shared.agent_app import AgentAppConfig, create_app
 
 from runner import run_agent
 
-LOG_LEVEL = os.environ.get("LOG_LEVEL", "info").upper()
-logging.basicConfig(level=LOG_LEVEL, format="%(asctime)s %(levelname)s %(name)s — %(message)s")
 logger = logging.getLogger(__name__)
 
-_executor = ThreadPoolExecutor(max_workers=4)
+CONFIG = AgentAppConfig(
+    label="TWR",
+    role="tower",
+    title="AIrport TWR Agent",
+    version="0.1.0",
+    description="Pilot on Tower frequency — reads back lineup, takeoff and landing clearances",
+    data_key="reply_data",
+    context_fields=("clearance_data",),
+)
 
-
-@asynccontextmanager
-async def lifespan(_app: FastAPI):
-    model = os.environ.get("AGENT_MODEL", "<not set>")
-    logger.info("[TWR] starting — model: %s", model)
-    yield
-    logger.info("[TWR] shutting down")
-
-
-app = FastAPI(title="AIrport TWR Agent", version="0.1.0", lifespan=lifespan)
-
-
-class RunRequest(BaseModel):
-    session_id: str
-    message: str
-    clearance_data: dict[str, Any] | None = None
-
-
-class RunResponse(BaseModel):
-    session_id: str
-    reply: str
-    reply_data: dict[str, Any] | None = None
-
-
-@app.post("/agents/tower/run", response_model=RunResponse, tags=["tower"])
-async def run(req: RunRequest) -> RunResponse:
-    logger.info(
-        "[TWR] ▶ request | session=%s | msg=%r | clearance_data=%s",
-        req.session_id, req.message[:80], bool(req.clearance_data),
-    )
-    t0 = asyncio.get_event_loop().time()
-    loop = asyncio.get_event_loop()
-    try:
-        result = await loop.run_in_executor(
-            _executor, run_agent, req.session_id, req.message, req.clearance_data
-        )
-    except Exception:
-        logger.exception("[TWR] ✗ executor error | session=%s", req.session_id)
-        raise
-    elapsed_ms = int((asyncio.get_event_loop().time() - t0) * 1000)
-    logger.info(
-        "[TWR] ■ done | session=%s | reply=%r | reply_data=%s | %d ms",
-        req.session_id, result["reply"][:80], bool(result.get("reply_data")), elapsed_ms,
-    )
-    return RunResponse(
-        session_id=req.session_id,
-        reply=result["reply"],
-        reply_data=result.get("reply_data"),
-    )
-
-
-@app.get("/agents/tower/info", tags=["tower"])
-async def info():
-    return {
-        "name": "TWR",
-        "model": os.environ.get("AGENT_MODEL", "<not set>"),
-        "description": "Pilot on Tower frequency — reads back lineup, takeoff and landing clearances",
-    }
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok", "model": os.environ.get("AGENT_MODEL", "<not set>")}
+app = create_app(CONFIG, run_agent, logger=logger)
 
 
 if __name__ == "__main__":

--- a/agents/twr/runner.py
+++ b/agents/twr/runner.py
@@ -1,20 +1,22 @@
-import asyncio
-import json
+"""TWR runner — the generic pilot runner configured for Tower."""
+
 import logging
-import re
 from typing import Any
 
-from google.adk.runners import Runner
-from google.adk.sessions import InMemorySessionService
-from google.genai.types import Content, Part
-
 from agent.agent import twr_agent
+from shared.agent_runner import AgentRunnerConfig, ContextField, build_run_agent
 
 logger = logging.getLogger(__name__)
 
-_APP_NAME = "airport_twr"
-_session_service = InMemorySessionService()
-_runner = Runner(agent=twr_agent, app_name=_APP_NAME, session_service=_session_service)
+CONFIG = AgentRunnerConfig(
+    label="TWR",
+    app_name="airport_twr",
+    text_key="reply_text",
+    data_key="reply_data",
+    context_fields=(ContextField("clearance_data", "Clearance data: {value}"),),
+)
+
+_run_agent = build_run_agent(agent=twr_agent, config=CONFIG, logger=logger)
 
 
 def run_agent(
@@ -22,58 +24,5 @@ def run_agent(
     message: str,
     clearance_data: dict | None = None,
 ) -> dict[str, Any]:
-    # Enrich message with pre-fetched clearance context from the orchestrator
-    enriched = message
-    if clearance_data:
-        parts = [message, "\n\n[CONTEXT]", f"Clearance data: {clearance_data}"]
-        enriched = "\n".join(parts)
-
-    logger.info("[TWR] run_agent | session=%s | msg=%r", session_id, enriched[:200])
-
-    async def _run() -> str:
-        existing = await _session_service.get_session(
-            app_name=_APP_NAME, user_id="pilot", session_id=session_id
-        )
-        if not existing:
-            await _session_service.create_session(
-                app_name=_APP_NAME, user_id="pilot", session_id=session_id
-            )
-        reply_parts = []
-        async for event in _runner.run_async(
-            user_id="pilot",
-            session_id=session_id,
-            new_message=Content(role="user", parts=[Part(text=enriched)]),
-        ):
-            logger.debug("[TWR] event: %s", event)
-            if event.is_final_response() and event.content:
-                for part in event.content.parts:
-                    if hasattr(part, "text") and part.text:
-                        reply_parts.append(part.text)
-        return "".join(reply_parts).strip()
-
-    try:
-        raw_reply = asyncio.run(_run())
-    except Exception:
-        logger.exception("[TWR] agent error")
-        return {"reply": "[TWR error] agent failed", "reply_data": None}
-
-    logger.info("[TWR] raw reply: %r", raw_reply[:300])
-
-    # Extract structured data from the JSON the agent is instructed to output
-    reply_text = raw_reply
-    reply_data = None
-    try:
-        match = re.search(r"\{.*\}", raw_reply, re.DOTALL)
-        if match:
-            parsed = json.loads(match.group())
-            reply_text = parsed.get("reply_text", raw_reply)
-            reply_data = parsed.get("reply_data")
-    except Exception as exc:
-        logger.warning("[TWR] could not parse JSON from reply: %s", exc)
-
-    logger.info(
-        "[TWR] result | reply_text=%r | reply_data=%s",
-        reply_text[:80],
-        reply_data,
-    )
-    return {"reply": reply_text, "reply_data": reply_data}
+    """Draft the tower readback. Returns ``{"reply", "reply_data"}``."""
+    return _run_agent(session_id, message, clearance_data=clearance_data)

--- a/agents/twr/shared/agent_app.py
+++ b/agents/twr/shared/agent_app.py
@@ -1,0 +1,158 @@
+"""Generic FastAPI wrapper shared by the DEL / GND / TWR pilot agents.
+
+The three ``main.py`` files were the same ~90-line app: a ``POST /agents/<role>/run``
+handler that hands ``run_agent`` to a four-worker ``ThreadPoolExecutor`` (the runner
+opens its own event loop with ``asyncio.run()``, so it cannot run inside FastAPI's),
+plus ``GET /agents/<role>/info`` and ``GET /health``. Only the position label, the
+route, the request/response field names and the OpenAPI metadata differed.
+
+``create_app()`` is that common body; each agent's ``main.py`` supplies the
+configuration and keeps only its ``uvicorn`` entry point.
+
+Note this module deliberately does **not** use ``from __future__ import annotations``:
+the request and response models are created per-app inside ``create_app()``, so the
+handler annotations must be real objects when FastAPI inspects them, not strings it
+would try to resolve against module globals.
+
+Packaging note
+--------------
+Same as ``agent_runner.py``: this file is the single source of truth and is vendored
+into ``agents/<phase>/shared/agent_app.py`` because each agent's Docker build context
+is its own directory. Run ``python scripts/sync_agent_common.py`` after editing.
+"""
+
+import asyncio
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from fastapi import FastAPI
+from pydantic import create_model
+
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s — %(message)s"
+
+# Requests are served by run_agent() on a worker thread because run_agent opens
+# its own event loop; four workers matches the original per-agent setting.
+_MAX_WORKERS = 4
+
+
+@dataclass(frozen=True)
+class AgentAppConfig:
+    """Everything that differs between the DEL, GND and TWR FastAPI apps."""
+
+    label: str
+    """Short position name used in every log line, e.g. ``"DEL"``."""
+
+    role: str
+    """URL segment and OpenAPI tag, e.g. ``"delivery"`` -> ``/agents/delivery/run``."""
+
+    title: str
+    """OpenAPI title, e.g. ``"AIrport DEL Agent"``."""
+
+    version: str
+    """OpenAPI version string."""
+
+    description: str
+    """Human-readable blurb returned by ``GET /agents/<role>/info``."""
+
+    data_key: str
+    """Structured-payload key of the JSON response, e.g. ``"clearance_data"``.
+
+    This is part of the contract the orchestrator consumes -- do not rename it.
+    """
+
+    context_fields: tuple[str, ...] = ()
+    """Optional context fields accepted in the request body, in payload order."""
+
+
+def configure_logging() -> None:
+    """Apply the agents' shared logging configuration from ``LOG_LEVEL``."""
+    level = os.environ.get("LOG_LEVEL", "info").upper()
+    logging.basicConfig(level=level, format=_LOG_FORMAT)
+
+
+def create_app(
+    config: AgentAppConfig,
+    run_agent: Callable[..., dict],
+    logger: Optional[logging.Logger] = None,
+) -> FastAPI:
+    """Build the FastAPI app for one pilot agent."""
+    configure_logging()
+    log = logger if logger is not None else logging.getLogger(__name__)
+
+    executor = ThreadPoolExecutor(max_workers=_MAX_WORKERS)
+
+    optional_dict = (Optional[dict[str, Any]], None)
+    RunRequest = create_model(
+        "RunRequest",
+        session_id=(str, ...),
+        message=(str, ...),
+        **{name: optional_dict for name in config.context_fields},
+    )
+    RunResponse = create_model(
+        "RunResponse",
+        session_id=(str, ...),
+        reply=(str, ...),
+        **{config.data_key: optional_dict},
+    )
+
+    # Pre-render the variable part of the two per-request log lines so the
+    # emitted text is identical to the hand-written per-agent versions.
+    request_fmt = "[%s] ▶ request | session=%s | msg=%r" + "".join(
+        f" | {name}=%s" for name in config.context_fields
+    )
+    done_fmt = f"[%s] ■ done | session=%s | reply=%r | {config.data_key}=%s | %d ms"
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        model = os.environ.get("AGENT_MODEL", "<not set>")
+        log.info("[%s] starting — model: %s", config.label, model)
+        yield
+        log.info("[%s] shutting down", config.label)
+
+    app = FastAPI(title=config.title, version=config.version, lifespan=lifespan)
+
+    @app.post(f"/agents/{config.role}/run", response_model=RunResponse, tags=[config.role])
+    async def run(req: RunRequest) -> RunResponse:
+        context = [getattr(req, name) for name in config.context_fields]
+        log.info(
+            request_fmt,
+            config.label, req.session_id, req.message[:80], *[bool(v) for v in context],
+        )
+        t0 = asyncio.get_event_loop().time()
+        loop = asyncio.get_event_loop()
+        try:
+            result = await loop.run_in_executor(
+                executor, run_agent, req.session_id, req.message, *context
+            )
+        except Exception:
+            log.exception("[%s] ✗ executor error | session=%s", config.label, req.session_id)
+            raise
+        elapsed_ms = int((asyncio.get_event_loop().time() - t0) * 1000)
+        log.info(
+            done_fmt,
+            config.label, req.session_id, result["reply"][:80],
+            bool(result.get(config.data_key)), elapsed_ms,
+        )
+        return RunResponse(
+            session_id=req.session_id,
+            reply=result["reply"],
+            **{config.data_key: result.get(config.data_key)},
+        )
+
+    @app.get(f"/agents/{config.role}/info", tags=[config.role])
+    async def info():
+        return {
+            "name": config.label,
+            "model": os.environ.get("AGENT_MODEL", "<not set>"),
+            "description": config.description,
+        }
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok", "model": os.environ.get("AGENT_MODEL", "<not set>")}
+
+    return app

--- a/agents/twr/shared/agent_runner.py
+++ b/agents/twr/shared/agent_runner.py
@@ -1,0 +1,175 @@
+"""Generic ADK runner shared by the DEL / GND / TWR pilot agents.
+
+Every pilot agent used to ship its own ~85-line ``run_agent`` that differed only in
+four things: the ADK ``Agent`` object, the ADK app name, which context blocks the
+orchestrator attaches to the transmission, and the JSON keys the agent's prompt
+promises to emit. Everything else -- session handling, the ``run_async`` event loop,
+the regex JSON extraction, the error path and the log lines -- was identical.
+
+``build_run_agent()`` is that common body; each agent's ``runner.py`` supplies the
+configuration and re-exports a thin wrapper with its own public signature.
+
+Packaging note
+--------------
+This file is the single source of truth, but it is **vendored** into
+``agents/<phase>/shared/agent_runner.py`` because each agent is deployed with
+``gcloud run deploy --source agents/<phase>``: the Docker build context is the agent
+directory itself (``COPY . .``), so nothing above it can be imported at runtime. That
+is the same convention ``shared/callbacks.py`` already follows. Run
+``python scripts/sync_agent_common.py`` after editing this file;
+``tests/unit/agents/test_agent_common_vendoring.py`` fails if the copies drift.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai.types import Content, Part
+
+# Every agent runs its ADK session under the same synthetic user.
+_USER_ID = "pilot"
+
+# The prompts instruct the model to emit a single JSON object; it is usually
+# wrapped in prose or a markdown fence, hence the greedy DOTALL match.
+_JSON_BLOCK = re.compile(r"\{.*\}", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class ContextField:
+    """One optional context block the orchestrator may attach to a request.
+
+    ``name`` is the keyword argument the agent's ``run_agent`` accepts;
+    ``template`` is the line rendered into the ``[CONTEXT]`` section, with
+    ``{value}`` standing for the value itself.
+    """
+
+    name: str
+    template: str
+
+
+@dataclass(frozen=True)
+class AgentRunnerConfig:
+    """Everything that differs between the DEL, GND and TWR runners."""
+
+    label: str
+    """Short position name used in every log line, e.g. ``"DEL"``."""
+
+    app_name: str
+    """ADK application name, e.g. ``"airport_del"``."""
+
+    text_key: str
+    """JSON key holding the readback text, e.g. ``"clearance_text"``."""
+
+    data_key: str
+    """JSON key holding the structured payload, e.g. ``"clearance_data"``.
+
+    It is also the second key of the returned dict, so it is part of the
+    HTTP contract the orchestrator consumes.
+    """
+
+    context_fields: tuple[ContextField, ...] = ()
+    """Context blocks appended to the transmission, in render order."""
+
+    context_header: str = "\n\n[CONTEXT]"
+    """Header line that opens the context section."""
+
+
+def build_agent_context(
+    message: str, config: AgentRunnerConfig, values: dict[str, Any]
+) -> str:
+    """Append the non-empty context blocks to ``message``.
+
+    Returns ``message`` untouched when the orchestrator attached no context.
+    """
+    present = [(f, values.get(f.name)) for f in config.context_fields]
+    present = [(f, value) for f, value in present if value]
+    if not present:
+        return message
+
+    parts = [message, config.context_header]
+    parts.extend(f.template.format(value=value) for f, value in present)
+    return "\n".join(parts)
+
+
+def build_run_agent(
+    agent: Any,
+    config: AgentRunnerConfig,
+    logger: logging.Logger | None = None,
+) -> Callable[..., dict[str, Any]]:
+    """Build the ``run_agent`` callable for one pilot agent.
+
+    The returned function takes ``(session_id, message, **context)`` where the
+    accepted context keywords are ``config.context_fields``. It always returns
+    ``{"reply": <text>, config.data_key: <dict | None>}`` -- including on failure,
+    so the FastAPI layer never has to special-case errors.
+    """
+    log = logger if logger is not None else logging.getLogger(__name__)
+
+    session_service = InMemorySessionService()
+    adk_runner = Runner(agent=agent, app_name=config.app_name, session_service=session_service)
+
+    def run_agent(session_id: str, message: str, **context: Any) -> dict[str, Any]:
+        # Enrich the message with context pre-fetched by the orchestrator
+        enriched = build_agent_context(message, config, context)
+
+        log.info("[%s] run_agent | session=%s | msg=%r", config.label, session_id, enriched[:200])
+
+        async def _run() -> str:
+            existing = await session_service.get_session(
+                app_name=config.app_name, user_id=_USER_ID, session_id=session_id
+            )
+            if not existing:
+                await session_service.create_session(
+                    app_name=config.app_name, user_id=_USER_ID, session_id=session_id
+                )
+            reply_parts = []
+            async for event in adk_runner.run_async(
+                user_id=_USER_ID,
+                session_id=session_id,
+                new_message=Content(role="user", parts=[Part(text=enriched)]),
+            ):
+                log.debug("[%s] event: %s", config.label, event)
+                if event.is_final_response() and event.content:
+                    for part in event.content.parts:
+                        if hasattr(part, "text") and part.text:
+                            reply_parts.append(part.text)
+            return "".join(reply_parts).strip()
+
+        try:
+            raw_reply = asyncio.run(_run())
+        except Exception:
+            log.exception("[%s] agent error", config.label)
+            return {"reply": f"[{config.label} error] agent failed", config.data_key: None}
+
+        log.info("[%s] raw reply: %r", config.label, raw_reply[:300])
+
+        # Extract structured data from the JSON the agent is instructed to output
+        reply_text = raw_reply
+        reply_data = None
+        try:
+            match = _JSON_BLOCK.search(raw_reply)
+            if match:
+                parsed = json.loads(match.group())
+                reply_text = parsed.get(config.text_key, raw_reply)
+                reply_data = parsed.get(config.data_key)
+        except Exception as exc:
+            log.warning("[%s] could not parse JSON from reply: %s", config.label, exc)
+
+        log.info(
+            "[%s] result | %s=%r | %s=%s",
+            config.label,
+            config.text_key,
+            reply_text[:80],
+            config.data_key,
+            reply_data,
+        )
+        return {"reply": reply_text, config.data_key: reply_data}
+
+    return run_agent

--- a/openwiki/agents.md
+++ b/openwiki/agents.md
@@ -96,14 +96,28 @@ back to the orchestrator today.
 ## Anatomy of an agent
 
 ```
+agents/common/                 # single source of truth for the shared code
+  agent_runner.py             # build_run_agent(): ADK Runner + sessions + JSON extraction
+  agent_app.py                # create_app(): the FastAPI wrapper
 agents/<phase>/
-  main.py                   # FastAPI: POST /agents/<role>/run, GET /health, GET /agents/<role>/info
-  runner.py                 # ADK Runner + InMemorySessionService, JSON extraction
+  main.py                   # AgentAppConfig + create_app() + the uvicorn entry point
+  runner.py                 # AgentRunnerConfig + build_run_agent(), wrapped in a typed run_agent
   agent/agent.py             # Agent(model=AGENT_MODEL, tools=[], instruction=SYSTEM_PROMPT)
   agent/prompts/system.py     # ICAO phraseology rules + the JSON output contract
   agent/tools/                # gnd, twr only - present but empty, nothing registered on the Agent
+  shared/agent_runner.py       # vendored copy of agents/common/agent_runner.py
+  shared/agent_app.py          # vendored copy of agents/common/agent_app.py
   shared/callbacks.py          # log_before / log_after - a local copy per agent
 ```
+
+The `shared/` package inside each agent is **vendored**, not imported: every agent is
+deployed on its own with `gcloud run deploy --source agents/<phase>`, so the Docker build
+context is that one directory (`COPY . .`) and nothing above it exists at runtime. The
+generic runner and app factory therefore live once in `agents/common/` and are copied into
+all three by [`scripts/sync_agent_common.py`](../scripts/sync_agent_common.py);
+`tests/unit/agents/test_agent_common_vendoring.py` fails the suite if a copy drifts. Edit
+`agents/common/`, never the copies. `shared/callbacks.py` is the exception — it is not
+generated, because each agent's version is tuned to its own state field names.
 
 The prompt in `agent/prompts/system.py` is where all the ATC knowledge actually lives:
 message-type classification (a clearance versus a greeting versus "say again"), the exact ICAO

--- a/scripts/sync_agent_common.py
+++ b/scripts/sync_agent_common.py
@@ -1,0 +1,78 @@
+"""Vendor agents/common/*.py into every agent's local ``shared/`` package.
+
+Each pilot agent is deployed on its own with
+``gcloud run deploy <x>-agent --source agents/<x>``, so the Docker build context is
+that single agent directory (``COPY . .``). Code shared between the agents therefore
+has to physically live inside each of them -- the same convention
+``shared/callbacks.py`` already follows.
+
+``agents/common/`` is the single source of truth; this script copies it into
+``agents/<phase>/shared/``. ``tests/unit/agents/test_agent_common_vendoring.py``
+fails the suite if the copies ever drift.
+
+Usage::
+
+    python scripts/sync_agent_common.py           # write the copies
+    python scripts/sync_agent_common.py --check   # exit 1 if out of date
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMMON_DIR = REPO_ROOT / "agents" / "common"
+AGENTS = ("del", "gnd", "twr")
+
+# Modules vendored into every agent. ``callbacks.py`` is intentionally absent:
+# each agent keeps its own, tuned to that position's state field names.
+VENDORED_MODULES = ("agent_runner.py", "agent_app.py")
+
+
+def vendored_path(agent: str, module: str) -> Path:
+    return REPO_ROOT / "agents" / agent / "shared" / module
+
+
+def sync(check_only: bool = False) -> int:
+    stale: list[Path] = []
+    for module in VENDORED_MODULES:
+        source = COMMON_DIR / module
+        if not source.is_file():
+            print(f"missing source module: {source}", file=sys.stderr)
+            return 1
+        for agent in AGENTS:
+            target = vendored_path(agent, module)
+            if target.is_file() and target.read_bytes() == source.read_bytes():
+                continue
+            if check_only:
+                stale.append(target)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, target)
+            print(f"updated {target.relative_to(REPO_ROOT)}")
+
+    if stale:
+        print("vendored copies are out of date:", file=sys.stderr)
+        for path in stale:
+            print(f"  {path.relative_to(REPO_ROOT)}", file=sys.stderr)
+        print("run: python scripts/sync_agent_common.py", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="do not write anything; exit 1 if a vendored copy is out of date",
+    )
+    args = parser.parse_args()
+    return sync(check_only=args.check)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/agents/test_agent_app.py
+++ b/tests/unit/agents/test_agent_app.py
@@ -1,0 +1,127 @@
+"""Unit tests for agents/common/agent_app.py — the generic pilot FastAPI app.
+
+Covers the HTTP surface the orchestrator talks to: the request body it sends, the
+response keys it reads back, and the two informational endpoints.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agents.common.agent_app import AgentAppConfig, create_app
+
+
+DEL_CONFIG = AgentAppConfig(
+    label="DEL",
+    role="delivery",
+    title="AIrport DEL Agent",
+    version="0.2.0",
+    description="ATC Delivery controller — issues IFR departure clearances",
+    data_key="clearance_data",
+    context_fields=("flight_plan", "atis"),
+)
+
+TWR_CONFIG = AgentAppConfig(
+    label="TWR",
+    role="tower",
+    title="AIrport TWR Agent",
+    version="0.1.0",
+    description="Pilot on Tower frequency",
+    data_key="reply_data",
+    context_fields=("clearance_data",),
+)
+
+
+def _client(config, run_agent):
+    return TestClient(create_app(config, run_agent))
+
+
+def test_run_forwards_context_positionally_and_returns_the_data_key():
+    seen = {}
+
+    def run_agent(session_id, message, flight_plan=None, atis=None):
+        seen.update(
+            session_id=session_id, message=message, flight_plan=flight_plan, atis=atis
+        )
+        return {"reply": "Cleared to LEPA", "clearance_data": {"squawk": "2341"}}
+
+    with _client(DEL_CONFIG, run_agent) as client:
+        resp = client.post(
+            "/agents/delivery/run",
+            json={
+                "session_id": "s1",
+                "message": "request clearance",
+                "flight_plan": {"id": 7},
+                "atis": {"letter": "C"},
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "session_id": "s1",
+        "reply": "Cleared to LEPA",
+        "clearance_data": {"squawk": "2341"},
+    }
+    assert seen == {
+        "session_id": "s1",
+        "message": "request clearance",
+        "flight_plan": {"id": 7},
+        "atis": {"letter": "C"},
+    }
+
+
+def test_context_fields_are_optional():
+    def run_agent(session_id, message, clearance_data=None):
+        assert clearance_data is None
+        return {"reply": "Runway 06R, cleared for takeoff", "reply_data": None}
+
+    with _client(TWR_CONFIG, run_agent) as client:
+        resp = client.post("/agents/tower/run", json={"session_id": "s1", "message": "hi"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "session_id": "s1",
+        "reply": "Runway 06R, cleared for takeoff",
+        "reply_data": None,
+    }
+
+
+def test_missing_message_is_a_validation_error():
+    with _client(TWR_CONFIG, lambda *a: {}) as client:
+        resp = client.post("/agents/tower/run", json={"session_id": "s1"})
+
+    assert resp.status_code == 422
+
+
+def test_runner_failure_surfaces_as_a_server_error():
+    def run_agent(*_):
+        raise RuntimeError("boom")
+
+    with _client(TWR_CONFIG, run_agent) as client:
+        with pytest.raises(RuntimeError):
+            client.post("/agents/tower/run", json={"session_id": "s1", "message": "hi"})
+
+
+def test_health_and_info_endpoints(monkeypatch):
+    monkeypatch.setenv("AGENT_MODEL", "gemini-test")
+
+    with _client(DEL_CONFIG, lambda *a: {}) as client:
+        health = client.get("/health")
+        info = client.get("/agents/delivery/info")
+
+    assert health.json() == {"status": "ok", "model": "gemini-test"}
+    assert info.json() == {
+        "name": "DEL",
+        "model": "gemini-test",
+        "description": "ATC Delivery controller — issues IFR departure clearances",
+    }
+
+
+def test_openapi_metadata_matches_the_config():
+    with _client(DEL_CONFIG, lambda *a: {}) as client:
+        schema = client.get("/openapi.json").json()
+
+    assert schema["info"]["title"] == "AIrport DEL Agent"
+    assert schema["info"]["version"] == "0.2.0"
+    assert "/agents/delivery/run" in schema["paths"]

--- a/tests/unit/agents/test_agent_common_vendoring.py
+++ b/tests/unit/agents/test_agent_common_vendoring.py
@@ -1,0 +1,44 @@
+"""The vendored copies of agents/common/ must not drift.
+
+Each pilot agent is built from its own directory (``gcloud run deploy --source
+agents/<phase>``, ``COPY . .``), so the shared modules physically live inside every
+agent under ``shared/``. ``agents/common/`` is the single source of truth and
+``scripts/sync_agent_common.py`` copies it; this test is the guard that keeps the
+copies honest.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.sync_agent_common import AGENTS, COMMON_DIR, VENDORED_MODULES, sync, vendored_path
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+@pytest.mark.parametrize("module", VENDORED_MODULES)
+def test_vendored_copy_matches_the_source_of_truth(agent, module):
+    source = COMMON_DIR / module
+    target = vendored_path(agent, module)
+
+    assert target.is_file(), f"{target} is missing — run scripts/sync_agent_common.py"
+    assert target.read_bytes() == source.read_bytes(), (
+        f"{target} drifted from agents/common/{module} — "
+        "edit agents/common/ and run scripts/sync_agent_common.py"
+    )
+
+
+def test_sync_check_mode_passes():
+    assert sync(check_only=True) == 0
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_agents_import_the_vendored_module_not_the_repo_shared_package(agent):
+    """Inside the container the agent directory is the import root.
+
+    ``from shared.agent_runner import ...`` therefore resolves to the vendored copy,
+    not to the repo-root ``shared/`` package (which is not in the build context).
+    """
+    for filename in ("runner.py", "main.py"):
+        source = (COMMON_DIR.parent / agent / filename).read_text(encoding="utf-8")
+        assert "from shared.agent_" in source
+        assert "agents.common" not in source

--- a/tests/unit/agents/test_agent_contract.py
+++ b/tests/unit/agents/test_agent_contract.py
@@ -1,0 +1,161 @@
+"""The DEL / GND / TWR wiring must keep emitting the keys the orchestrator reads.
+
+``services/orchestrator_service/agent/tools/forward.py`` reads ``reply``,
+``clearance_data`` and ``taxi_data`` off the agents' HTTP responses, and
+``agents_evaluation/benchmark_agents.py`` also expects ``reply_data`` from TWR.
+Those names, the ADK app names, the routes and the JSON keys the prompts promise
+are a contract: this module pins them.
+
+The agent packages cannot simply be imported here -- ``agents.del`` is not a legal
+Python name (``del`` is a keyword) and each agent expects its own directory on
+``sys.path`` (that is how its container runs). The configuration is therefore read
+straight out of the source with ``ast``, which is enough because both runners and
+apps are declared as plain literal ``CONFIG = ...(...)`` assignments.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_AGENTS_DIR = Path(__file__).resolve().parents[3] / "agents"
+
+
+def _config_kwargs(path: Path) -> dict:
+    """Return the keyword arguments of the module-level ``CONFIG = Call(...)``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if "CONFIG" not in targets or not isinstance(node.value, ast.Call):
+            continue
+        return {kw.arg: _literal(kw.value) for kw in node.value.keywords}
+    raise AssertionError(f"no module-level CONFIG assignment in {path}")
+
+
+def _literal(node: ast.AST):
+    """literal_eval, but rendering ``ContextField(...)`` calls as arg tuples."""
+    if isinstance(node, ast.Call):
+        return tuple(ast.literal_eval(a) for a in node.args)
+    if isinstance(node, ast.Tuple):
+        return tuple(_literal(e) for e in node.elts)
+    return ast.literal_eval(node)
+
+
+@pytest.fixture(scope="module")
+def runner_configs() -> dict[str, dict]:
+    return {a: _config_kwargs(_AGENTS_DIR / a / "runner.py") for a in ("del", "gnd", "twr")}
+
+
+@pytest.fixture(scope="module")
+def app_configs() -> dict[str, dict]:
+    return {a: _config_kwargs(_AGENTS_DIR / a / "main.py") for a in ("del", "gnd", "twr")}
+
+
+# ---------------------------------------------------------------------------
+# Runner configuration
+# ---------------------------------------------------------------------------
+
+EXPECTED_RUNNERS = {
+    "del": {
+        "label": "DEL",
+        "app_name": "airport_del",
+        "text_key": "clearance_text",
+        "data_key": "clearance_data",
+        "context_fields": (
+            ("flight_plan", "Flight plan: {value}"),
+            ("atis", "ATIS: {value}"),
+        ),
+        "context_header": "\n\n[CONTEXT]",
+    },
+    "gnd": {
+        "label": "GND",
+        "app_name": "airport_gnd",
+        "text_key": "instruction_text",
+        "data_key": "taxi_data",
+        "context_fields": (("clearance_data", "Clearance data: {value}"),),
+        "context_header": "\n[CONTEXT]",
+    },
+    "twr": {
+        "label": "TWR",
+        "app_name": "airport_twr",
+        "text_key": "reply_text",
+        "data_key": "reply_data",
+        "context_fields": (("clearance_data", "Clearance data: {value}"),),
+        "context_header": "\n\n[CONTEXT]",
+    },
+}
+
+
+@pytest.mark.parametrize("agent", sorted(EXPECTED_RUNNERS))
+def test_runner_config_is_unchanged(runner_configs, agent):
+    expected = dict(EXPECTED_RUNNERS[agent])
+    actual = dict(runner_configs[agent])
+    # ``context_header`` is defaulted in the dataclass; only GND overrides it.
+    actual.setdefault("context_header", "\n\n[CONTEXT]")
+
+    assert actual == expected
+
+
+# ---------------------------------------------------------------------------
+# FastAPI configuration
+# ---------------------------------------------------------------------------
+
+EXPECTED_APPS = {
+    "del": {
+        "label": "DEL",
+        "role": "delivery",
+        "title": "AIrport DEL Agent",
+        "version": "0.2.0",
+        "description": "ATC Delivery controller — issues IFR departure clearances",
+        "data_key": "clearance_data",
+        "context_fields": ("flight_plan", "atis"),
+    },
+    "gnd": {
+        "label": "GND",
+        "role": "ground",
+        "title": "AIrport GND Agent",
+        "version": "0.1.0",
+        "description": "ATC Ground controller — issues pushback and taxi instructions",
+        "data_key": "taxi_data",
+        "context_fields": ("clearance_data",),
+    },
+    "twr": {
+        "label": "TWR",
+        "role": "tower",
+        "title": "AIrport TWR Agent",
+        "version": "0.1.0",
+        "description": (
+            "Pilot on Tower frequency — reads back lineup, takeoff and landing clearances"
+        ),
+        "data_key": "reply_data",
+        "context_fields": ("clearance_data",),
+    },
+}
+
+
+@pytest.mark.parametrize("agent", sorted(EXPECTED_APPS))
+def test_app_config_is_unchanged(app_configs, agent):
+    assert dict(app_configs[agent]) == EXPECTED_APPS[agent]
+
+
+@pytest.mark.parametrize("agent", sorted(EXPECTED_APPS))
+def test_runner_and_app_agree_on_the_data_key(runner_configs, app_configs, agent):
+    assert runner_configs[agent]["data_key"] == app_configs[agent]["data_key"]
+
+
+@pytest.mark.parametrize("agent", sorted(EXPECTED_APPS))
+def test_app_context_fields_match_the_runner_ones(runner_configs, app_configs, agent):
+    runner_names = tuple(name for name, _ in runner_configs[agent]["context_fields"])
+
+    assert app_configs[agent]["context_fields"] == runner_names
+
+
+@pytest.mark.parametrize("agent,port", [("del", "8080"), ("gnd", "8080"), ("twr", "8082")])
+def test_uvicorn_default_port_is_unchanged(agent, port):
+    source = (_AGENTS_DIR / agent / "main.py").read_text(encoding="utf-8")
+
+    assert f'os.environ.get("PORT", "{port}")' in source

--- a/tests/unit/agents/test_agent_runner.py
+++ b/tests/unit/agents/test_agent_runner.py
@@ -1,0 +1,206 @@
+"""Unit tests for agents/common/agent_runner.py — the generic pilot runner.
+
+The DEL, GND and TWR runners are now three configurations of ``build_run_agent``,
+so this module covers the behavior all three used to duplicate:
+
+* context enrichment (the ``[CONTEXT]`` block appended to the transmission),
+* extraction of the agent's JSON block into ``{"reply", <data_key>}``,
+* the degraded paths: no JSON, malformed JSON, and an exploding ADK call.
+
+The JSON keys asserted here are the contract the orchestrator's
+``forward_to_agent`` consumes — see tests/unit/agents/test_agent_contract.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agents.common.agent_runner import (
+    AgentRunnerConfig,
+    ContextField,
+    build_agent_context,
+    build_run_agent,
+)
+from tests.fixtures.adk_runner import install_fake_runner
+import agents.common.agent_runner as agent_runner_mod
+
+
+DEL_CONFIG = AgentRunnerConfig(
+    label="DEL",
+    app_name="airport_del",
+    text_key="clearance_text",
+    data_key="clearance_data",
+    context_fields=(
+        ContextField("flight_plan", "Flight plan: {value}"),
+        ContextField("atis", "ATIS: {value}"),
+    ),
+)
+
+GND_CONFIG = AgentRunnerConfig(
+    label="GND",
+    app_name="airport_gnd",
+    text_key="instruction_text",
+    data_key="taxi_data",
+    context_fields=(ContextField("clearance_data", "Clearance data: {value}"),),
+    context_header="\n[CONTEXT]",
+)
+
+
+def _build(monkeypatch, config, final_text: str):
+    """Build a run_agent backed by a scripted FakeADKRunner."""
+    fake = install_fake_runner(monkeypatch, agent_runner_mod)
+    fake.script(final_text=final_text)
+    run_agent = build_run_agent(agent=object(), config=config)
+    return run_agent, fake
+
+
+def _sent_text(fake) -> str:
+    """The prompt text handed to the ADK runner on the last call."""
+    return fake.calls[-1]["new_message"].parts[0].text
+
+
+# ---------------------------------------------------------------------------
+# Context enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_context_is_omitted_when_nothing_was_attached():
+    assert build_agent_context("Iberia 123, taxi?", DEL_CONFIG, {}) == "Iberia 123, taxi?"
+    assert (
+        build_agent_context("msg", DEL_CONFIG, {"flight_plan": None, "atis": {}}) == "msg"
+    )
+
+
+def test_context_renders_only_the_fields_that_are_present():
+    enriched = build_agent_context("msg", DEL_CONFIG, {"atis": {"letter": "C"}})
+
+    assert enriched == "msg\n\n\n[CONTEXT]\nATIS: {'letter': 'C'}"
+
+
+def test_context_renders_fields_in_declaration_order():
+    enriched = build_agent_context(
+        "msg", DEL_CONFIG, {"flight_plan": {"id": 1}, "atis": {"letter": "C"}}
+    )
+
+    assert enriched == (
+        "msg\n\n\n[CONTEXT]\nFlight plan: {'id': 1}\nATIS: {'letter': 'C'}"
+    )
+
+
+def test_gnd_keeps_its_single_newline_context_header():
+    # GND's header historically differs from DEL/TWR; kept as-is on purpose.
+    enriched = build_agent_context("msg", GND_CONFIG, {"clearance_data": {"stand": "A1"}})
+
+    assert enriched == "msg\n\n[CONTEXT]\nClearance data: {'stand': 'A1'}"
+
+
+def test_run_agent_sends_the_enriched_message_to_the_adk_runner(monkeypatch):
+    run_agent, fake = _build(monkeypatch, DEL_CONFIG, final_text="ok")
+
+    run_agent("s1", "Iberia 123, request clearance", flight_plan={"id": 7})
+
+    assert _sent_text(fake) == (
+        "Iberia 123, request clearance\n\n\n[CONTEXT]\nFlight plan: {'id': 7}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction and the returned contract
+# ---------------------------------------------------------------------------
+
+
+def test_returns_reply_and_data_under_the_configured_keys(monkeypatch):
+    raw = (
+        'Here you go: {"clearance_text": "Cleared to LEPA, squawk 2341", '
+        '"clearance_data": {"squawk": "2341"}}'
+    )
+    run_agent, _ = _build(monkeypatch, DEL_CONFIG, final_text=raw)
+
+    result = run_agent("s1", "msg")
+
+    assert result == {
+        "reply": "Cleared to LEPA, squawk 2341",
+        "clearance_data": {"squawk": "2341"},
+    }
+
+
+def test_gnd_uses_its_own_json_keys(monkeypatch):
+    raw = '{"instruction_text": "Taxi via B, C", "taxi_data": {"pushback_approved": true}}'
+    run_agent, _ = _build(monkeypatch, GND_CONFIG, final_text=raw)
+
+    result = run_agent("s1", "msg")
+
+    assert result == {
+        "reply": "Taxi via B, C",
+        "taxi_data": {"pushback_approved": True},
+    }
+
+
+def test_plain_text_reply_falls_back_to_the_raw_text(monkeypatch):
+    run_agent, _ = _build(monkeypatch, DEL_CONFIG, final_text="Say again")
+
+    result = run_agent("s1", "msg")
+
+    assert result == {"reply": "Say again", "clearance_data": None}
+
+
+def test_json_without_the_expected_keys_falls_back_to_the_raw_text(monkeypatch):
+    run_agent, _ = _build(monkeypatch, DEL_CONFIG, final_text='{"unrelated": 1}')
+
+    result = run_agent("s1", "msg")
+
+    assert result == {"reply": '{"unrelated": 1}', "clearance_data": None}
+
+
+def test_malformed_json_is_swallowed_and_logged(monkeypatch, caplog):
+    run_agent, _ = _build(monkeypatch, DEL_CONFIG, final_text='{"clearance_text": oops}')
+
+    with caplog.at_level("WARNING"):
+        result = run_agent("s1", "msg")
+
+    assert result == {"reply": '{"clearance_text": oops}', "clearance_data": None}
+    assert "could not parse JSON" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Session handling and failures
+# ---------------------------------------------------------------------------
+
+
+def test_session_is_created_once_and_reused(monkeypatch):
+    run_agent, fake = _build(monkeypatch, DEL_CONFIG, final_text="ok")
+    session_service = fake.session_service
+
+    run_agent("s1", "first")
+    fake.script(final_text="ok")
+    run_agent("s1", "second")
+
+    sessions = [k for k in session_service._sessions if k[2] == "s1"]
+    assert sessions == [("airport_del", "pilot", "s1")]
+    assert len(fake.calls) == 2
+
+
+def test_adk_failure_returns_the_error_contract(monkeypatch, caplog):
+    fake = install_fake_runner(monkeypatch, agent_runner_mod)
+
+    async def _boom(**_):
+        raise RuntimeError("vertex is down")
+        yield  # pragma: no cover - makes _boom an async generator
+
+    monkeypatch.setattr(fake, "run_async", _boom)
+    run_agent = build_run_agent(agent=object(), config=GND_CONFIG)
+
+    with caplog.at_level("ERROR"):
+        result = run_agent("s1", "msg")
+
+    assert result == {"reply": "[GND error] agent failed", "taxi_data": None}
+    assert "[GND] agent error" in caplog.text
+
+
+@pytest.mark.parametrize("config", [DEL_CONFIG, GND_CONFIG])
+def test_result_always_carries_exactly_two_keys(monkeypatch, config):
+    run_agent, _ = _build(monkeypatch, config, final_text="whatever")
+
+    result = run_agent("s1", "msg")
+
+    assert set(result) == {"reply", config.data_key}


### PR DESCRIPTION
## What

`agents/{del,gnd,twr}/runner.py` (84 / 78 / 79 lines) and their `main.py` files were the same code three times. Only five things ever differed: the ADK `Agent` object, the ADK app name, the context blocks the orchestrator attaches, the JSON keys the prompt promises, and the OpenAPI/route metadata.

Both bodies now live once in `agents/common/`:

| Module | Entry point | Absorbs |
|---|---|---|
| `agents/common/agent_runner.py` | `build_run_agent(agent, AgentRunnerConfig)` | ADK session get-or-create, the `run_async` event loop, the regex JSON extraction, the error path, every log line |
| `agents/common/agent_app.py` | `create_app(AgentAppConfig, run_agent)` | logging setup, lifespan, the `ThreadPoolExecutor` hand-off, `POST /agents/<role>/run`, `GET /agents/<role>/info`, `GET /health`, and the request/response models built from the config |

Each agent is now configuration only. `runner.py` still exposes its original typed signature, so nothing calling `run_agent(session_id, message, flight_plan=..., atis=...)` changes:

```python
CONFIG = AgentRunnerConfig(
    label="DEL", app_name="airport_del",
    text_key="clearance_text", data_key="clearance_data",
    context_fields=(ContextField("flight_plan", "Flight plan: {value}"),
                    ContextField("atis", "ATIS: {value}")),
)
_run_agent = build_run_agent(agent=del_agent, config=CONFIG, logger=logger)

def run_agent(session_id, message, flight_plan=None, atis=None) -> dict[str, Any]:
    return _run_agent(session_id, message, flight_plan=flight_plan, atis=atis)
```

Net: **-420 / +105** lines across the six agent files.

## Where the shared code lives, and why

Not in the repo-root `shared/` package — that would break every container.

Each agent is deployed on its own with `gcloud run deploy <x>-agent --source agents/<x>` (see [Cloud Agents Deployment](../blob/dev/openwiki/guides/cloud-agents-deployment.md)), so the Docker build context **is** the agent directory. Its `Dockerfile` does `WORKDIR /app` + `COPY . .`, which means `/app` holds only the contents of `agents/<x>/` and nothing above it exists at runtime. That is exactly why `shared/callbacks.py` is already vendored once per agent — three near-identical copies inside the deployable unit.

This PR follows that same convention rather than inventing a new packaging scheme:

- `agents/common/` is the **single source of truth** and the module tests import (`agents.del` is not even a legal Python name — `del` is a keyword — so a canonical, importable location is worth having).
- `scripts/sync_agent_common.py` copies it into `agents/{del,gnd,twr}/shared/`. `--check` mode exits 1 when stale.
- `tests/unit/agents/test_agent_common_vendoring.py` fails the suite if any copy drifts, so the copies can never silently diverge the way three hand-written runners did.

Rejected alternatives: importing from repo-root `shared/` (breaks `COPY . .`), and moving the build context up to the repo root with `gcloud builds submit` + a cloudbuild config (a real packaging change, invalidating the documented deploy commands and the `gcloud-deployer` agent).

`shared/callbacks.py` is deliberately **not** deduplicated — the three copies genuinely differ (per-position log prefixes and state field names, and DEL uses `▶`/`■` glyphs the others do not). It is also out of scope for this issue. Left as follow-up.

## Contract preserved

The JSON keys are consumed by `services/orchestrator_service/agent/tools/forward.py` (`reply`, `clearance_data`, `taxi_data`) and by `agents_evaluation/benchmark_agents.py` (`reply_data` for TWR). Grepped before touching anything; unchanged:

| Agent | Route | Prompt keys | Response keys |
|---|---|---|---|
| DEL | `/agents/delivery/run` | `clearance_text` / `clearance_data` | `session_id`, `reply`, `clearance_data` |
| GND | `/agents/ground/run` | `instruction_text` / `taxi_data` | `session_id`, `reply`, `taxi_data` |
| TWR | `/agents/tower/run` | `reply_text` / `reply_data` | `session_id`, `reply`, `reply_data` |

Also unchanged: ADK app names, the `pilot` user id, the `\{.*\}` DOTALL extraction, the `[<LABEL>] ...` log text (each agent passes its own `logging.getLogger(__name__)` in, so the logger *names* in the output stay `runner` / `main` too), the `[<LABEL>] error] agent failed` fallback, the four executor workers, and the default ports (8080 / 8080 / 8082).

`tests/unit/agents/test_agent_contract.py` pins all of the above by reading each agent's `CONFIG` out of the source with `ast`, so a future edit that renames a key fails the suite.

## Latent inconsistency found (not fixed)

GND opens its context section with `"\n[CONTEXT]"` while DEL and TWR use `"\n\n[CONTEXT]"` — one newline fewer in the prompt GND sees. Since this is a pure refactor it is preserved verbatim via the `context_header` config field, with a comment in `agents/gnd/runner.py` and a test pinning it. Harmonizing it would change the model input for GND and should be a separate, benchmarked change.

## Verification

- `pytest` — **333 passed, 1 skipped, 4 xfailed** (baseline on `dev` was 288 passed with the same skip/xfails; the 45 new tests are this PR's).
- New coverage in `tests/unit/agents/`: generic-runner behavior (context enrichment per agent shape, JSON extraction, plain-text fallback, malformed JSON, ADK failure, session reuse), the FastAPI surface via `TestClient` (payload → positional context args, optional fields, 422, `/health`, `/info`, OpenAPI metadata), the config contract, and the vendoring drift guard.
- **No `docker build` was run** — the Docker daemon is not available in this environment. Instead the container layout was simulated for all three agents: agent directory as `sys.path[0]`, ADK stubbed, `import main`, then real requests through `TestClient`. All three resolved `shared.agent_runner` to their own vendored copy (e.g. `agents/del/shared/agent_runner.py`) and returned the expected response keys. Reasoning over the Dockerfiles agrees: they are untouched, `COPY . .` now also picks up `shared/agent_runner.py` and `shared/agent_app.py`, and `requirements.txt` needs no new entries (`fastapi`, `pydantic`, `google-adk` were already there). A real `docker build` before deploying is still worth doing.

Docs: `openwiki/agents.md` anatomy section updated for the new file layout and the vendoring rule.

Closes #51
