### PR TITLE
refactor: unify the three advance tools behind one implementation (closes #52)

### DIFF
--- a/services/orchestrator_service/agent/tools/advance_to_gnd.py
+++ b/services/orchestrator_service/agent/tools/advance_to_gnd.py
@@ -1,7 +1,6 @@
-import logging
 from google.adk.tools import ToolContext
 
-logger = logging.getLogger(__name__)
+from agent.tools.phase_advance import advance_phase
 
 
 def advance_to_gnd(registration: str, frequency: str, tool_context: ToolContext) -> str:
@@ -19,13 +18,11 @@ def advance_to_gnd(registration: str, frequency: str, tool_context: ToolContext)
     Returns:
         The standard ICAO pilot readback for a frequency change.
     """
-    known = tool_context.state.get("known_aircraft", [])
-    aircraft_data = next((a for a in known if a.get("registration") == registration), {})
-    callsign = aircraft_data.get("callsign") or registration
-    readback = f"{frequency}, {callsign}"
-    tool_context.state["advance_registration_gnd"] = registration
-    tool_context.state["reply"] = readback
-    tool_context.state["dependency"] = "GND"
-    tool_context.state["registration"] = registration
-    logger.info("[ORCH] advance_to_gnd called for %s on %s", registration, frequency)
-    return readback
+    return advance_phase(
+        registration,
+        frequency,
+        tool_context,
+        tool_name="advance_to_gnd",
+        advance_state_key="advance_registration_gnd",
+        dependency="GND",
+    )

--- a/services/orchestrator_service/agent/tools/advance_to_gnd_arrival.py
+++ b/services/orchestrator_service/agent/tools/advance_to_gnd_arrival.py
@@ -1,7 +1,6 @@
-import logging
 from google.adk.tools import ToolContext
 
-logger = logging.getLogger(__name__)
+from agent.tools.phase_advance import advance_phase
 
 
 def advance_to_gnd_arrival(registration: str, frequency: str, tool_context: ToolContext) -> str:
@@ -23,13 +22,11 @@ def advance_to_gnd_arrival(registration: str, frequency: str, tool_context: Tool
     Returns:
         The standard ICAO pilot readback for a frequency change.
     """
-    known = tool_context.state.get("known_aircraft", [])
-    aircraft_data = next((a for a in known if a.get("registration") == registration), {})
-    callsign = aircraft_data.get("callsign") or registration
-    readback = f"{frequency}, {callsign}"
-    tool_context.state["advance_registration_gnd_arrival"] = registration
-    tool_context.state["reply"] = readback
-    tool_context.state["dependency"] = "GND"
-    tool_context.state["registration"] = registration
-    logger.info("[ORCH] advance_to_gnd_arrival called for %s on %s", registration, frequency)
-    return readback
+    return advance_phase(
+        registration,
+        frequency,
+        tool_context,
+        tool_name="advance_to_gnd_arrival",
+        advance_state_key="advance_registration_gnd_arrival",
+        dependency="GND",
+    )

--- a/services/orchestrator_service/agent/tools/advance_twr.py
+++ b/services/orchestrator_service/agent/tools/advance_twr.py
@@ -1,7 +1,6 @@
-import logging
 from google.adk.tools import ToolContext
 
-logger = logging.getLogger(__name__)
+from agent.tools.phase_advance import advance_phase
 
 
 def advance_to_twr(registration: str, frequency: str, tool_context: ToolContext) -> str:
@@ -20,13 +19,11 @@ def advance_to_twr(registration: str, frequency: str, tool_context: ToolContext)
     Returns:
         The standard ICAO pilot readback for a frequency change.
     """
-    known = tool_context.state.get("known_aircraft", [])
-    aircraft_data = next((a for a in known if a.get("registration") == registration), {})
-    callsign = aircraft_data.get("callsign") or registration
-    readback = f"{frequency}, {callsign}"
-    tool_context.state["advance_registration_twr"] = registration
-    tool_context.state["reply"] = readback
-    tool_context.state["dependency"] = "TWR"
-    tool_context.state["registration"] = registration
-    logger.info("[ORCH] advance_to_twr called for %s on %s", registration, frequency)
-    return readback
+    return advance_phase(
+        registration,
+        frequency,
+        tool_context,
+        tool_name="advance_to_twr",
+        advance_state_key="advance_registration_twr",
+        dependency="TWR",
+    )

--- a/services/orchestrator_service/agent/tools/phase_advance.py
+++ b/services/orchestrator_service/agent/tools/phase_advance.py
@@ -1,0 +1,57 @@
+"""Shared implementation behind the three frequency-change "advance" tools.
+
+`advance_to_gnd`, `advance_to_twr` and `advance_to_gnd_arrival` differ only in
+the controller phase they hand the aircraft to, the state key `runner.py` reads
+afterwards, and the docstring the LLM sees. Everything else — the callsign
+lookup, the ICAO readback format and the four state writes — is identical, and
+lives here.
+
+The tools themselves stay in their own modules as thin wrappers so the ADK keeps
+seeing three distinct names, signatures and descriptions; see #52.
+"""
+
+import logging
+
+from google.adk.tools import ToolContext
+
+logger = logging.getLogger(__name__)
+
+
+def advance_phase(
+    registration: str,
+    frequency: str,
+    tool_context: ToolContext,
+    *,
+    tool_name: str,
+    advance_state_key: str,
+    dependency: str,
+) -> str:
+    """Emit the frequency-change readback and flag the handoff in state.
+
+    Args:
+        registration:      Aircraft registration in canonical form ("EC-MIG").
+        frequency:         The new frequency as spoken ("121.9").
+        tool_context:      ADK tool context; ``state["known_aircraft"]`` is read
+                           and four keys are written back.
+        tool_name:         Name of the calling tool, for the log line only.
+        advance_state_key: The single state key `runner.py` inspects to know
+                           which handoff happened. Exactly one of
+                           ``advance_registration_gnd``,
+                           ``advance_registration_twr`` or
+                           ``advance_registration_gnd_arrival`` — never more,
+                           or the runner would double-dispatch.
+        dependency:        Controller phase the aircraft moves to.
+
+    Returns:
+        The standard ICAO pilot readback for a frequency change.
+    """
+    known = tool_context.state.get("known_aircraft", [])
+    aircraft_data = next((a for a in known if a.get("registration") == registration), {})
+    callsign = aircraft_data.get("callsign") or registration
+    readback = f"{frequency}, {callsign}"
+    tool_context.state[advance_state_key] = registration
+    tool_context.state["reply"] = readback
+    tool_context.state["dependency"] = dependency
+    tool_context.state["registration"] = registration
+    logger.info("[ORCH] %s called for %s on %s", tool_name, registration, frequency)
+    return readback

--- a/tests/unit/orchestrator/test_advance_tools.py
+++ b/tests/unit/orchestrator/test_advance_tools.py
@@ -190,3 +190,50 @@ def test_readback_format_with_decimal_frequency():
     ctx = _ctx([{"registration": "EC-MIG", "callsign": "IBE3421"}])
     assert advance_to_gnd("EC-MIG", "121.9", ctx) == "121.9, IBE3421"
     assert advance_to_twr("EC-MIG", "118.330", ctx) == "118.330, IBE3421"
+
+
+# ---------------------------------------------------------------------------
+# ADK contract guard
+# ---------------------------------------------------------------------------
+#
+# The three tools share one implementation (agent/tools/phase_advance.py), but
+# the ADK derives each tool's JSON schema from the *wrapper's* name, signature
+# and docstring, and the system prompt calls them by name. The tests below fail
+# loudly if the shared implementation ever leaks into that public surface.
+
+
+@pytest.mark.parametrize(
+    "tool, expected_name",
+    [
+        (advance_to_gnd, "advance_to_gnd"),
+        (advance_to_twr, "advance_to_twr"),
+        (advance_to_gnd_arrival, "advance_to_gnd_arrival"),
+    ],
+)
+def test_tool_keeps_its_own_name_signature_and_description(tool, expected_name):
+    import inspect
+
+    assert tool.__name__ == expected_name
+    sig = inspect.signature(tool)
+    assert list(sig.parameters) == ["registration", "frequency", "tool_context"]
+    assert all(p.default is inspect.Parameter.empty for p in sig.parameters.values())
+    assert sig.return_annotation is str
+    # The docstring IS the tool description the LLM reads when choosing, so it
+    # must survive on the wrapper rather than moving to the shared helper.
+    assert tool.__doc__ is not None
+    assert "Args:" in tool.__doc__ and "Returns:" in tool.__doc__
+
+
+def test_the_three_tools_have_distinct_descriptions():
+    """A shared implementation must not collapse the three descriptions — the
+    LLM distinguishes departure GND, TWR and the arrival reverse handoff only
+    by this text."""
+    docs = {advance_to_gnd.__doc__, advance_to_twr.__doc__, advance_to_gnd_arrival.__doc__}
+    assert len(docs) == 3
+
+
+def test_agent_registers_the_three_tools_under_their_public_names():
+    from agent.agent import orch_agent
+
+    tool_names = {getattr(t, "__name__", None) for t in orch_agent.tools}
+    assert {"advance_to_gnd", "advance_to_twr", "advance_to_gnd_arrival"} <= tool_names


### PR DESCRIPTION
> Stacked on #96 → #93. Review those first; this PR's own diff is the four tool files plus a contract guard in the existing test module.

## What

`advance_to_gnd`, `advance_to_twr` and `advance_to_gnd_arrival` were three copies of the same twelve lines: look up the callsign in `known_aircraft`, build the `"{frequency}, {callsign}"` readback, write four keys into tool state, log.

That body now lives once in **`agent/tools/phase_advance.py::advance_phase`**, parameterized by three things:

| Tool | `advance_state_key` | `dependency` |
|---|---|---|
| `advance_to_gnd` | `advance_registration_gnd` | `GND` |
| `advance_to_twr` | `advance_registration_twr` | `TWR` |
| `advance_to_gnd_arrival` | `advance_registration_gnd_arrival` | `GND` |

The three tool modules stay exactly where they were, as thin wrappers.

## The agent contract is untouched

This is the part that matters — the LLM calls these by name and the ADK builds each tool's JSON schema from the wrapper's signature and docstring:

- same module paths (`agent.tools.advance_to_gnd`, …), same function names, same `(registration, frequency, tool_context) -> str` signatures
- **byte-identical docstrings** — verified by diffing each `__doc__` against the pre-refactor version
- same registration order in `agent/agent.py`; `agent/prompts.py` needed no change
- each tool still writes exactly one `advance_registration_*` key — the existing cross-tool leak test covers this, since `runner.py` inspects those keys to decide which handoff happened

The one observable difference: the `"[ORCH] advance_* called for …"` log record now comes from the `agent.tools.phase_advance` logger instead of `agent.tools.advance_*`. The message text is unchanged and nothing in the stack filters on that logger name.

`services/orchestrator_service/runner.py:174-187` reads the state keys, not the tools, so it is unaffected.

## Tests

Added to `tests/unit/orchestrator/test_advance_tools.py` (the existing 33 parameterized cases are untouched and still pass):

- each tool keeps its own `__name__`, its exact three-parameter signature with no defaults, its `str` return annotation, and a docstring carrying the `Args:`/`Returns:` sections the ADK parses
- the three descriptions remain **distinct** — a shared implementation must not collapse them, since the LLM tells departure-GND, TWR and the arrival reverse handoff apart by that text alone
- `agent.agent.orch_agent` still registers all three under their public names

`pytest tests/unit/orchestrator tests/integration tests/debrief` — 259 passed, 2 xfailed (the pre-existing documented runner bug). Full suite: 375 passed, 1 skipped, 4 xfailed.

Closes #52.