### PR TITLE
refactor(weather): async httpx client, typed upstream errors, tests/weather

### DIFF
--- a/openwiki/data-and-testing.md
+++ b/openwiki/data-and-testing.md
@@ -124,6 +124,7 @@ socket anywhere in the run.
 | Taxi routing | [`tests/taxi_router/`](../tests/taxi_router/) | graph construction, token resolution, routing e2e, pushback leg, HMI chat |
 | Arrivals | [`tests/arrivals/`](../tests/arrivals/) | phases, runway config, arrival planner, geo |
 | Debrief | [`tests/debrief/`](../tests/debrief/) | debrief builder |
+| Weather | [`tests/weather/`](../tests/weather/) | METAR/TAF fetcher over `respx`, `_parse_metar` characterization, ATIS generation, route error mapping |
 
 Run with `uv run pytest` (or plain `pytest`). The honest gap sits outside this table entirely:
 `xplane_plugin/` — the in-sim motion engine — appears nowhere in the coverage `source` list and

--- a/openwiki/services/weather_service.md
+++ b/openwiki/services/weather_service.md
@@ -20,10 +20,18 @@ aviationweather.gov directly.
 ## From METAR to ATIS
 
 Two thin layers sit around one real upstream API. `core/metar_taf_fetcher.py` is a small,
-key-less client with a 10 s timeout that hits `/api/data/metar` and `/api/data/taf` on
-aviationweather.gov; `api/routes.py` exposes both as pass-through endpoints
-(`/metar/{icao}`, `/metar/{icao}/raw`, `/taf/{icao}`, `/taf/{icao}/raw`) that reshape the JSON —
-or hand back the raw string — without ever touching the database.
+key-less **async** client — one shared `httpx.AsyncClient` with a 10 s timeout, closed by the
+FastAPI lifespan — that hits `/api/data/metar` and `/api/data/taf` on aviationweather.gov;
+`api/routes.py` exposes both as pass-through endpoints (`/metar/{icao}`, `/metar/{icao}/raw`,
+`/taf/{icao}`, `/taf/{icao}/raw`) that reshape the JSON — or hand back the raw string — without
+ever touching the database.
+
+Upstream failures are typed, not swallowed: the fetcher raises `WeatherUpstreamError`
+(carrying the status the API should answer with — 502 for an unreachable host, a bad status or an
+undecodable body; 504 for a timeout) and `NoWeatherDataError` when the upstream is healthy but has
+no observation for that airport. `routes.py` maps them to 502/504/404 respectively, and turns a
+payload it cannot parse into a 502 rather than a 500 — an outage upstream is never reported as a
+bug here.
 
 The real work happens one layer up, in `core/atis_generator.py`. `ATISGenerator.generate()`
 fetches the current METAR for the requested ICAO and parses wind direction/speed/gust,

--- a/services/weather_service/api/routes.py
+++ b/services/weather_service/api/routes.py
@@ -1,15 +1,31 @@
-from fastapi import APIRouter, HTTPException, Depends, Query
-from sqlalchemy.orm import Session
+import logging
 from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Depends, Query
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 from models.schemas import ATISResponse, ATISRequest, MetarResponse, HealthResponse, CloudLayer
 from core.atis_generator import ATISGenerator
-from core.metar_taf_fetcher import get_metar, get_taf
+from core.metar_taf_fetcher import (
+    NoWeatherDataError,
+    WeatherUpstreamError,
+    get_metar,
+    get_taf,
+)
 from core.database.connection import get_db, check_connection
 from core.database.repositories.atis import ATISRepository
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 generator = ATISGenerator()
+
+#: Exceptions raised while decoding an aviationweather.gov JSON payload whose
+#: shape does not match what we expect (missing key, wrong type, unparsable
+#: number or timestamp, ``None`` where a string was promised). They mean "bad
+#: upstream data", i.e. a 502, never a 500.
+MALFORMED_PAYLOAD_ERRORS = (AttributeError, IndexError, KeyError, TypeError, ValueError)
 
 
 #  Health
@@ -41,7 +57,7 @@ async def generate_atis(
 ):
     """Generate ATIS for an airport"""
     try:
-        atis = generator.generate(
+        atis = await generator.generate(
             icao_code=icao_code,
             departure_runway=departure_runway,
             arrival_runway=arrival_runway,
@@ -52,14 +68,25 @@ async def generate_atis(
             remarks=remarks,
             preview=preview,
         )
-        if not preview:
+    except NoWeatherDataError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except WeatherUpstreamError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+    except MALFORMED_PAYLOAD_ERRORS:
+        logger.exception("Malformed METAR payload while generating ATIS for %s", icao_code)
+        raise HTTPException(
+            status_code=502, detail=f"Malformed METAR data for {icao_code.upper()}"
+        )
+
+    if not preview:
+        try:
             repo = ATISRepository(db)
             repo.create(atis)
-        return atis
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        except SQLAlchemyError:
+            logger.exception("Failed to persist ATIS for %s", icao_code)
+            raise HTTPException(status_code=500, detail="Failed to store the generated ATIS")
+
+    return atis
 
 
 @router.get("/atis/{icao_code}/latest", response_model=ATISResponse, tags=["ATIS"])
@@ -97,10 +124,14 @@ async def delete_atis_by_airport(icao_code: str, db: Session = Depends(get_db)):
 async def get_metar_data(icao_code: str):
     """Fetch current METAR for an airport"""
     try:
-        data = get_metar(icao_code, output_format="json")
-        if not data or len(data) == 0:
-            raise HTTPException(status_code=404, detail=f"No METAR for {icao_code.upper()}")
+        data = await get_metar(icao_code, output_format="json")
+    except WeatherUpstreamError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
 
+    if not data or len(data) == 0:
+        raise HTTPException(status_code=404, detail=f"No METAR for {icao_code.upper()}")
+
+    try:
         metar = data[0]
 
         # Wind
@@ -151,20 +182,21 @@ async def get_metar_data(icao_code: str):
             qnh_hpa=qnh,
             flight_category=flight_cat
         )
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except MALFORMED_PAYLOAD_ERRORS:
+        logger.exception("Malformed METAR payload for %s", icao_code)
+        raise HTTPException(
+            status_code=502, detail=f"Malformed METAR data for {icao_code.upper()}"
+        )
 
 
 @router.get("/metar/{icao_code}/raw", tags=["METAR"])
 async def get_metar_raw(icao_code: str):
     """Get raw METAR string"""
     try:
-        data = get_metar(icao_code, output_format="raw")
-        return {"icao_code": icao_code.upper(), "raw_metar": data.get("data", "")}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        data = await get_metar(icao_code, output_format="raw")
+    except WeatherUpstreamError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+    return {"icao_code": icao_code.upper(), "raw_metar": data.get("data", "")}
 
 
 #  TAF 
@@ -172,24 +204,23 @@ async def get_metar_raw(icao_code: str):
 async def get_taf_data(icao_code: str):
     """Fetch TAF for an airport"""
     try:
-        data = get_taf(icao_code, output_format="json", include_metar=False)
-        if not data or len(data) == 0:
-            raise HTTPException(status_code=404, detail=f"No TAF for {icao_code.upper()}")
-        return {"icao_code": icao_code.upper(), "taf": data}
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        data = await get_taf(icao_code, output_format="json", include_metar=False)
+    except WeatherUpstreamError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+
+    if not data or len(data) == 0:
+        raise HTTPException(status_code=404, detail=f"No TAF for {icao_code.upper()}")
+    return {"icao_code": icao_code.upper(), "taf": data}
 
 
 @router.get("/taf/{icao_code}/raw", tags=["TAF"])
 async def get_taf_raw(icao_code: str):
     """Get raw TAF string"""
     try:
-        data = get_taf(icao_code, output_format="raw")
-        return {"icao_code": icao_code.upper(), "raw_taf": data.get("data", "")}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        data = await get_taf(icao_code, output_format="raw")
+    except WeatherUpstreamError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+    return {"icao_code": icao_code.upper(), "raw_taf": data.get("data", "")}
 
 
 #  Helpers

--- a/services/weather_service/core/atis_generator.py
+++ b/services/weather_service/core/atis_generator.py
@@ -1,9 +1,12 @@
 from datetime import datetime
 from typing import Optional
+import logging
 import string
 
 from models.schemas import ATISResponse, CloudLayer
-from core.metar_taf_fetcher import get_metar
+from core.metar_taf_fetcher import NoWeatherDataError, get_metar
+
+logger = logging.getLogger(__name__)
 
 
 # dummy data
@@ -128,7 +131,7 @@ class ATISGenerator:
         self.airports = AIRPORT_DATA
         self._atis_counters: dict[str, int] = {}
 
-    def generate(
+    async def generate(
         self,
         icao_code: str,
         departure_runway = None,
@@ -155,7 +158,7 @@ class ATISGenerator:
         icao_code = icao_code.upper()
 
         # Fetch current METAR
-        metar_data = self._fetch_metar(icao_code)
+        metar_data = await self._fetch_metar(icao_code)
 
         # Parse METAR data
         parsed = self._parse_metar(metar_data)
@@ -229,15 +232,21 @@ class ATISGenerator:
             atis_text=atis_text
         )
 
-    def _fetch_metar(self, icao_code: str) -> dict:
-        """Fetch METAR data from API"""
-        try:
-            data = get_metar(icao_code, output_format="json")
-            if data and len(data) > 0:
-                return data[0]
-            raise ValueError(f"No METAR data available for {icao_code}")
-        except Exception as e:
-            raise ValueError(f"Failed to fetch METAR for {icao_code}: {str(e)}")
+    async def _fetch_metar(self, icao_code: str) -> dict:
+        """Fetch METAR data from the upstream API.
+
+        Raises:
+            NoWeatherDataError: the upstream has no observation for this
+                airport (the API layer maps this to a 404).
+            WeatherUpstreamError: the upstream is unreachable or answered with
+                an error status. Deliberately *not* converted to ``ValueError``:
+                an upstream outage is a 502, not "airport not found".
+        """
+        data = await get_metar(icao_code, output_format="json")
+        if data and len(data) > 0:
+            return data[0]
+        logger.info("No METAR data available for %s", icao_code)
+        raise NoWeatherDataError(f"No METAR data available for {icao_code}")
 
     def _parse_metar(self, metar_data: dict) -> dict:
         """Parse METAR JSON data into structured format"""

--- a/services/weather_service/core/database/connection.py
+++ b/services/weather_service/core/database/connection.py
@@ -1,6 +1,11 @@
+import logging
 import os
+
 from sqlalchemy import create_engine, text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import sessionmaker, declarative_base
+
+logger = logging.getLogger(__name__)
 
 # Database configuration env variables
 DB_HOST = os.getenv("POSTGRES_HOST")
@@ -34,5 +39,7 @@ def check_connection() -> bool:
         with engine.connect() as conn:
             conn.execute(text("SELECT 1"))
         return True
-    except Exception:
+    except SQLAlchemyError as exc:
+        # Health probe: never raise, but do not swallow the reason either.
+        logger.warning("Database health check failed: %s", exc)
         return False

--- a/services/weather_service/core/metar_taf_fetcher.py
+++ b/services/weather_service/core/metar_taf_fetcher.py
@@ -1,72 +1,153 @@
-import requests
-from typing import Optional, Dict, Any
+"""Async METAR/TAF fetcher backed by aviationweather.gov.
+
+This module is imported from async FastAPI request handlers, so every network
+call goes through a shared ``httpx.AsyncClient`` instead of the blocking
+``requests`` library (which stalls the event loop for the whole process).
+
+The client is created lazily and reused across requests; ``close_client()`` is
+wired into the service lifespan so the connection pool is released on shutdown.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://aviationweather.gov/api/data"
+
+#: Explicit timeout for every upstream call (connect/read/write/pool).
+DEFAULT_TIMEOUT = httpx.Timeout(10.0)
+
+_client: Optional[httpx.AsyncClient] = None
 
 
-def get_metar(
+class WeatherUpstreamError(RuntimeError):
+    """aviationweather.gov could not be used for this request.
+
+    Covers transport failures, error statuses and undecodable payloads. The
+    original ``httpx``/``ValueError`` exception is kept as ``__cause__``;
+    ``status_code`` is the HTTP status the API layer should surface.
+    """
+
+    def __init__(self, message: str, *, status_code: int = 502) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class NoWeatherDataError(ValueError):
+    """The upstream is healthy but has no observation for this airport (404).
+
+    Subclasses ``ValueError`` so existing callers that catch ``ValueError``
+    keep working.
+    """
+
+
+def get_client() -> httpx.AsyncClient:
+    """Return the shared ``AsyncClient``, creating it on first use."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(timeout=DEFAULT_TIMEOUT)
+    return _client
+
+
+async def close_client() -> None:
+    """Close the shared client (called from the FastAPI lifespan shutdown)."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+    _client = None
+
+
+async def _fetch(endpoint: str, params: Dict[str, Any], output_format: str) -> Dict[str, Any]:
+    """GET ``endpoint`` on aviationweather.gov and decode the payload.
+
+    Raises:
+        WeatherUpstreamError: the upstream is unreachable, timed out, answered
+            with an error status, or returned a body that is not valid JSON.
+    """
+    url = f"{BASE_URL}/{endpoint}"
+    ids = params.get("ids")
+    client = get_client()
+
+    try:
+        response = await client.get(url, params=params)
+        response.raise_for_status()
+    except httpx.TimeoutException as exc:
+        logger.warning("aviationweather %s timed out for %s: %s", endpoint, ids, exc)
+        raise WeatherUpstreamError(
+            f"Weather upstream timed out for {ids}", status_code=504
+        ) from exc
+    except httpx.HTTPStatusError as exc:
+        logger.warning(
+            "aviationweather %s returned HTTP %s for %s",
+            endpoint,
+            exc.response.status_code,
+            ids,
+        )
+        raise WeatherUpstreamError(
+            f"Weather upstream returned HTTP {exc.response.status_code} for {ids}"
+        ) from exc
+    except httpx.RequestError as exc:
+        logger.warning("aviationweather %s unreachable for %s: %s", endpoint, ids, exc)
+        raise WeatherUpstreamError(f"Weather upstream unreachable for {ids}") from exc
+
+    if output_format != "json":
+        return {"data": response.text}
+
+    try:
+        return response.json()
+    except ValueError as exc:
+        logger.warning(
+            "aviationweather %s returned a non-JSON payload for %s: %s", endpoint, ids, exc
+        )
+        raise WeatherUpstreamError(
+            f"Weather upstream returned an undecodable payload for {ids}"
+        ) from exc
+
+
+async def get_metar(
     icao_code: str,
     output_format: str = "json",
-    hours: Optional[int] = None
+    hours: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """
-    Obtiene el METAR para un aeropuerto dado su código ICAO.
+    """Fetch the METAR for an airport given its ICAO code.
 
     Args:
-        icao_code: Código ICAO del aeropuerto
-        output_format: raw, json, geojson, xml, iwxxm
-        hours: Número de horas hacia atrás para buscar
+        icao_code: ICAO airport code.
+        output_format: raw, json, geojson, xml or iwxxm.
+        hours: How many hours back to search.
 
     Returns:
-        Dict con los datos del METAR en formato JSON
+        The decoded JSON payload, or ``{"data": <raw text>}`` for non-JSON formats.
     """
-    url = 'https://aviationweather.gov/api/data/metar'
-
-    params = {
-        "ids": icao_code.upper(),
-        "format": output_format
-    }
-
+    params: Dict[str, Any] = {"ids": icao_code.upper(), "format": output_format}
     if hours:
         params["hours"] = hours
 
-    response = requests.get(url, params=params, timeout=10)
-    response.raise_for_status()
-
-    if output_format == "json":
-        return response.json()
-    else:
-        return {"data": response.text}
+    return await _fetch("metar", params, output_format)
 
 
-def get_taf(
+async def get_taf(
     icao_code: str,
     output_format: str = "json",
-    include_metar: bool = True
+    include_metar: bool = True,
 ) -> Dict[str, Any]:
-    """
-    Obtiene TAF para un aeropuerto dado su código ICAO.
+    """Fetch the TAF for an airport given its ICAO code.
 
     Args:
-        icao_code: Código ICAO del aeropuerto
-        output_format: raw, json, geojson, xml, iwxxm
-        include_metar: bool
+        icao_code: ICAO airport code.
+        output_format: raw, json, geojson, xml or iwxxm.
+        include_metar: Ask the upstream to bundle the current METAR.
 
     Returns:
-        Dict con los datos del TAF en formato JSON
+        The decoded JSON payload, or ``{"data": <raw text>}`` for non-JSON formats.
     """
-    url = 'https://aviationweather.gov/api/data/taf'
-
-    params = {
-        "ids": icao_code.upper(),
-        "format": output_format
-    }
-
+    params: Dict[str, Any] = {"ids": icao_code.upper(), "format": output_format}
     if include_metar:
         params["metar"] = "true"
 
-    response = requests.get(url, params=params, timeout=10)
-    response.raise_for_status()
-
-    if output_format == "json":
-        return response.json()
-    else:
-        return {"data": response.text}
+    return await _fetch("taf", params, output_format)

--- a/services/weather_service/main.py
+++ b/services/weather_service/main.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -6,9 +7,18 @@ from fastapi.middleware.cors import CORSMiddleware
 from api.routes import router
 from core.database.connection import engine, Base
 from core.database.models import ATISModel
+from core.metar_taf_fetcher import close_client
 
 # Create database tables
 Base.metadata.create_all(bind=engine)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """Release the shared httpx client used for METAR/TAF on shutdown."""
+    yield
+    await close_client()
+
 
 app = FastAPI(
     title="Weather Service",
@@ -16,6 +26,7 @@ app = FastAPI(
     version="1.0.0",
     docs_url="/docs",
     redoc_url="/redoc",
+    lifespan=lifespan,
 )
 
 _cors_origins = [o.strip() for o in os.environ.get("CORS_ORIGINS", "http://localhost:8005").split(",") if o.strip()]

--- a/services/weather_service/requirements.txt
+++ b/services/weather_service/requirements.txt
@@ -1,3 +1,2 @@
 sqlalchemy==2.0.25
 psycopg2-binary==2.9.9
-requests==2.31.0

--- a/tests/weather/conftest.py
+++ b/tests/weather/conftest.py
@@ -1,0 +1,41 @@
+"""Local fixtures for the weather_service suite.
+
+Self-contained on purpose: the root ``tests/conftest.py`` is shared with every
+other suite and is not touched here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.weather.service_imports import metar_taf_fetcher
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_http_client():
+    """Drop the module-level ``httpx.AsyncClient`` between tests.
+
+    ``metar_taf_fetcher`` caches one client for the whole process; each test
+    runs in its own event loop, so the cache must not survive a test.
+    """
+    metar_taf_fetcher._client = None
+    yield
+    metar_taf_fetcher._client = None
+
+
+@pytest.fixture
+def metar_payload() -> dict:
+    """A nominal aviationweather.gov METAR record (LEST, wind 170/10, BKN 2500)."""
+    return {
+        "rawOb": "LEST 051200Z 17010KT 9999 BKN025 15/10 Q1013",
+        "reportTime": "2026-08-05 12:00:00",
+        "wdir": 170,
+        "wspd": 10,
+        "wgst": None,
+        "visib": "6+",
+        "wxString": None,
+        "clouds": [{"cover": "BKN", "base": 2500}],
+        "temp": 15,
+        "dewp": 10,
+        "altim": 1013.0,
+    }

--- a/tests/weather/service_imports.py
+++ b/tests/weather/service_imports.py
@@ -1,0 +1,101 @@
+"""Isolated importer for ``services/weather_service`` modules.
+
+The weather service assumes its own directory is on ``sys.path`` (it imports
+``api.*``, ``core.*`` and ``models.*`` as top-level packages), exactly like the
+other services in this repo. Those package names collide with
+``services/orchestrator_service`` (``api``) and
+``services/arrival_simulator_service`` (``core``), both of which are already on
+``sys.path`` when the full suite runs.
+
+To keep the suites independent, the weather modules are imported here inside a
+context that temporarily takes over those names and restores whatever was there
+before. Nothing leaks into ``sys.path`` or ``sys.modules`` once this module
+finishes importing.
+
+Everything is imported inside a *single* context so that, for example, the
+``WeatherUpstreamError`` seen by the tests is the very same class object the API
+layer catches.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+_SVC = Path(__file__).resolve().parents[2] / "services" / "weather_service"
+
+#: Top-level package names the weather service expects to own.
+_OWNED_ROOTS = ("api", "core", "models")
+
+#: ``core.database.connection`` builds the SQLAlchemy URL at import time from
+#: these variables. The engine is lazy, so no connection is ever attempted.
+_DB_ENV_DEFAULTS = {
+    "POSTGRES_HOST": "localhost",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "weather_test",
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+}
+
+
+def _owned(module_name: str) -> bool:
+    return module_name.split(".")[0] in _OWNED_ROOTS
+
+
+@contextmanager
+def _weather_service_on_path():
+    """Temporarily make ``services/weather_service`` the owner of its package names."""
+    saved_path = list(sys.path)
+    saved_modules = {name: mod for name, mod in list(sys.modules.items()) if _owned(name)}
+    saved_env = {key: os.environ.get(key) for key in _DB_ENV_DEFAULTS}
+
+    for name in saved_modules:
+        del sys.modules[name]
+    for key, value in _DB_ENV_DEFAULTS.items():
+        os.environ.setdefault(key, value)
+
+    sys.path.insert(0, str(_SVC))
+    try:
+        yield
+    finally:
+        sys.path[:] = saved_path
+        for name in [n for n in list(sys.modules) if _owned(n)]:
+            del sys.modules[name]
+        sys.modules.update(saved_modules)
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+with _weather_service_on_path():
+    # ``api.routes`` transitively imports every other module we need, so a
+    # single pass keeps all of them consistent with each other.
+    routes = importlib.import_module("api.routes")
+    metar_taf_fetcher = importlib.import_module("core.metar_taf_fetcher")
+    atis_generator = importlib.import_module("core.atis_generator")
+    schemas = importlib.import_module("models.schemas")
+
+ATISGenerator = atis_generator.ATISGenerator
+CloudLayer = schemas.CloudLayer
+NoWeatherDataError = metar_taf_fetcher.NoWeatherDataError
+WeatherUpstreamError = metar_taf_fetcher.WeatherUpstreamError
+get_metar = metar_taf_fetcher.get_metar
+get_taf = metar_taf_fetcher.get_taf
+
+__all__ = [
+    "ATISGenerator",
+    "CloudLayer",
+    "NoWeatherDataError",
+    "WeatherUpstreamError",
+    "atis_generator",
+    "get_metar",
+    "get_taf",
+    "metar_taf_fetcher",
+    "routes",
+    "schemas",
+]

--- a/tests/weather/test_atis_generator_fetch.py
+++ b/tests/weather/test_atis_generator_fetch.py
@@ -1,0 +1,150 @@
+"""Tests for the async METAR fetch path of ``ATISGenerator`` (issue #63).
+
+``generate`` and ``_fetch_metar`` became coroutines when the fetcher moved from
+``requests`` to ``httpx``. These tests pin the end-to-end behavior and, most
+importantly, that an upstream outage is no longer flattened into a
+``ValueError`` (which the API layer used to report as a 404 "airport not
+found").
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from tests.weather.service_imports import (
+    ATISGenerator,
+    NoWeatherDataError,
+    WeatherUpstreamError,
+)
+
+METAR_URL = "https://aviationweather.gov/api/data/metar"
+
+
+@pytest.fixture
+def generator() -> ATISGenerator:
+    return ATISGenerator()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_metar
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_fetch_metar_returns_the_first_observation(generator, metar_payload):
+    respx.get(METAR_URL).mock(
+        return_value=httpx.Response(200, json=[metar_payload, {"rawOb": "second"}])
+    )
+
+    data = await generator._fetch_metar("LEST")
+
+    assert data == metar_payload
+
+
+@respx.mock
+async def test_fetch_metar_raises_no_weather_data_on_an_empty_list(generator):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[]))
+
+    with pytest.raises(NoWeatherDataError, match="No METAR data available for LEST"):
+        await generator._fetch_metar("LEST")
+
+
+@respx.mock
+async def test_upstream_outage_is_not_disguised_as_missing_data(generator):
+    """Regression for #63: a 500 upstream must not become a 404 "unknown airport"."""
+    respx.get(METAR_URL).mock(return_value=httpx.Response(500))
+
+    with pytest.raises(WeatherUpstreamError) as excinfo:
+        await generator._fetch_metar("LEST")
+
+    assert not isinstance(excinfo.value, ValueError)
+    assert excinfo.value.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# generate
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_generate_builds_a_full_atis_response(generator, metar_payload):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    atis = await generator.generate("LEST", departure_runway="17", arrival_runway="17")
+
+    assert atis.icao_code == "LEST"
+    assert atis.atis_letter == "A"
+    assert atis.wind_direction == 170
+    assert atis.qnh_hpa == 1013
+    assert atis.transition_level == "FL75"  # QNH 1013 falls in the 996-1013 band
+    assert atis.departure_runway == "17"
+    assert atis.arrival_runway == "17"
+    assert "Santiago information ALFA." in atis.atis_text
+    assert "Wind 170 degrees, 10 knots." in atis.atis_text
+
+
+@respx.mock
+async def test_generate_auto_selects_the_runway_from_the_wind(generator, metar_payload):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    atis = await generator.generate("LEST")
+
+    # LEST has 17/35; wind 170 favours runway 17.
+    assert atis.arrival_runway == "17"
+    assert atis.departure_runway == "17"
+    assert atis.approach_type == "ILS"
+
+
+@respx.mock
+async def test_preview_mode_does_not_advance_the_atis_letter(generator, metar_payload):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    first = await generator.generate("LEST", preview=True)
+    second = await generator.generate("LEST", preview=True)
+
+    assert first.atis_letter == second.atis_letter == "A"
+
+
+@respx.mock
+async def test_the_atis_letter_advances_between_broadcasts(generator, metar_payload):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    first = await generator.generate("LEST")
+    second = await generator.generate("LEST")
+
+    assert (first.atis_letter, second.atis_letter) == ("A", "B")
+
+
+@respx.mock
+async def test_unknown_airports_fall_back_to_default_airport_data(generator, metar_payload):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    atis = await generator.generate("ZZZZ")
+
+    assert atis.transition_altitude == 6000
+    assert atis.arrival_runway in {"09", "27"}
+    assert "ZZZZ information ALFA." in atis.atis_text
+
+
+@respx.mock
+async def test_remarks_and_qfe_are_appended_to_the_broadcast(generator, metar_payload):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    atis = await generator.generate("LEST", qfe=990, remarks="birds reported")
+
+    assert "QFE 990 hectopascals." in atis.atis_text
+    assert atis.atis_text.endswith("RMK birds reported")
+
+
+@respx.mock
+async def test_transition_level_and_altitude_can_be_suppressed(generator, metar_payload):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    atis = await generator.generate("LEST", include_tl=False, include_ta=False)
+
+    assert "Transition level" not in atis.atis_text
+    assert "Transition altitude" not in atis.atis_text
+    # Still reported in the structured response.
+    assert atis.transition_level == "FL75"

--- a/tests/weather/test_atis_generator_parse_metar.py
+++ b/tests/weather/test_atis_generator_parse_metar.py
@@ -1,0 +1,285 @@
+"""Characterization tests for ``ATISGenerator._parse_metar`` (issues #63, #49).
+
+``_parse_metar`` turns an aviationweather.gov JSON record into the dict that
+feeds both the ATIS text and the ATIS response model. It is pure (no I/O), it
+is the highest-fan-out helper of the weather service, and every fallback in it
+is load-bearing for the broadcast. These tests pin down the behavior as it is
+today so it can be refactored safely.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from tests.weather.service_imports import ATISGenerator, CloudLayer
+
+
+@pytest.fixture
+def generator() -> ATISGenerator:
+    return ATISGenerator()
+
+
+def parse(generator: ATISGenerator, **overrides) -> dict:
+    """Parse a minimal METAR record, overriding individual upstream fields."""
+    record = {
+        "rawOb": "LEST 051200Z 17010KT BKN025 15/10 Q1013",
+        "reportTime": "2026-08-05 12:00:00",
+        "wdir": 170,
+        "wspd": 10,
+        "temp": 15,
+        "dewp": 10,
+        "altim": 1013.0,
+    }
+    record.update(overrides)
+    return generator._parse_metar(record)
+
+
+# ---------------------------------------------------------------------------
+# Nominal record
+# ---------------------------------------------------------------------------
+
+
+def test_parses_a_nominal_record(generator, metar_payload):
+    parsed = generator._parse_metar(metar_payload)
+
+    assert parsed["raw_metar"] == metar_payload["rawOb"]
+    assert parsed["observation_time"] == datetime(2026, 8, 5, 12, 0, 0)
+    assert parsed["wind_direction"] == 170
+    assert parsed["wind_variable"] is False
+    assert parsed["wind_speed"] == 10
+    assert parsed["wind_gust"] is None
+    assert parsed["temperature_c"] == 15
+    assert parsed["dewpoint_c"] == 10
+    assert parsed["qnh_hpa"] == 1013
+
+
+def test_report_time_zulu_suffix_is_converted_to_an_offset(generator):
+    parsed = parse(generator, reportTime="2026-08-05T12:00:00Z")
+
+    assert parsed["observation_time"].utcoffset().total_seconds() == 0
+
+
+def test_absent_report_time_falls_back_to_now(generator):
+    before = datetime.utcnow()
+
+    parsed = generator._parse_metar({"rawOb": "", "wdir": 170, "wspd": 5})
+
+    assert parsed["observation_time"] >= before
+
+
+def test_null_report_time_is_not_handled(generator):
+    """A ``null`` upstream ``reportTime`` is a hard failure, not a fallback.
+
+    ``dict.get`` only substitutes the default when the key is *missing*, so an
+    explicit ``None`` reaches ``.replace()``. The API layer maps the resulting
+    ``AttributeError`` to a 502 (malformed upstream payload).
+    """
+    with pytest.raises(AttributeError):
+        parse(generator, reportTime=None)
+
+
+# ---------------------------------------------------------------------------
+# Wind
+# ---------------------------------------------------------------------------
+
+
+def test_variable_wind_string_zeroes_the_direction(generator):
+    parsed = parse(generator, wdir="VRB")
+
+    assert parsed["wind_direction"] == 0
+    assert parsed["wind_variable"] is True
+
+
+def test_absent_wind_direction_is_treated_as_variable(generator):
+    parsed = parse(generator, wdir=None)
+
+    assert parsed["wind_direction"] == 0
+    assert parsed["wind_variable"] is True
+
+
+def test_wind_direction_is_coerced_to_int(generator):
+    parsed = parse(generator, wdir="240")
+
+    assert parsed["wind_direction"] == 240
+    assert parsed["wind_variable"] is False
+
+
+def test_missing_wind_speed_defaults_to_zero(generator):
+    record = {
+        "rawOb": "",
+        "reportTime": "2026-08-05 12:00:00",
+        "wdir": 170,
+        "temp": 15,
+        "dewp": 10,
+    }
+
+    parsed = generator._parse_metar(record)
+
+    assert parsed["wind_speed"] == 0
+
+
+def test_gusts_are_reported_when_present(generator):
+    parsed = parse(generator, wgst="25")
+
+    assert parsed["wind_gust"] == 25
+
+
+def test_zero_gusts_are_reported_as_none(generator):
+    """A falsy ``wgst`` is dropped rather than reported as 0 knots of gust."""
+    parsed = parse(generator, wgst=0)
+
+    assert parsed["wind_gust"] is None
+
+
+# ---------------------------------------------------------------------------
+# Visibility
+# ---------------------------------------------------------------------------
+
+
+def test_raw_9999_wins_over_the_numeric_visibility(generator):
+    parsed = parse(
+        generator, rawOb="LEST 051200Z 17010KT 9999 BKN025 15/10 Q1013", visib="3"
+    )
+
+    assert parsed["visibility_m"] == 9999
+
+
+def test_statute_miles_are_converted_to_metres(generator):
+    parsed = parse(generator, visib="3")
+
+    assert parsed["visibility_m"] == 4828  # int(3 * 1609.34)
+
+
+def test_visibility_is_capped_at_9999_metres(generator):
+    parsed = parse(generator, visib="10")
+
+    assert parsed["visibility_m"] == 9999
+
+
+def test_the_plus_suffix_is_stripped_before_converting(generator):
+    parsed = parse(generator, visib="6+")
+
+    assert parsed["visibility_m"] == 9656  # int(6 * 1609.34)
+
+
+def test_missing_visibility_defaults_to_9999(generator):
+    parsed = parse(generator, visib=None)
+
+    assert parsed["visibility_m"] == 9999
+
+
+# ---------------------------------------------------------------------------
+# Weather phenomena
+# ---------------------------------------------------------------------------
+
+
+def test_known_weather_code_is_expanded(generator):
+    parsed = parse(generator, wxString="TSRA")
+
+    assert parsed["weather"] == "TSRA"
+    assert parsed["weather_description"] == "thunderstorm with rain"
+
+
+def test_unknown_weather_code_is_passed_through_verbatim(generator):
+    parsed = parse(generator, wxString="FZDZ")
+
+    assert parsed["weather"] == "FZDZ"
+    assert parsed["weather_description"] == "FZDZ"
+
+
+def test_absent_weather_leaves_both_keys_unset(generator):
+    parsed = parse(generator, wxString=None)
+
+    assert "weather" not in parsed
+    assert "weather_description" not in parsed
+
+
+# ---------------------------------------------------------------------------
+# Clouds and ceiling
+# ---------------------------------------------------------------------------
+
+
+def test_cloud_layers_are_mapped_to_the_response_model(generator):
+    parsed = parse(generator, clouds=[{"cover": "FEW", "base": 1200}])
+
+    assert parsed["clouds"] == [CloudLayer(coverage="FEW", base_ft=1200)]
+
+
+def test_ceiling_is_the_lowest_broken_or_overcast_layer(generator):
+    parsed = parse(
+        generator,
+        clouds=[
+            {"cover": "FEW", "base": 800},
+            {"cover": "OVC", "base": 3000},
+            {"cover": "BKN", "base": 1500},
+        ],
+    )
+
+    assert parsed["ceiling_ft"] == 1500
+    assert len(parsed["clouds"]) == 3
+
+
+def test_few_and_scattered_layers_do_not_set_a_ceiling(generator):
+    parsed = parse(
+        generator,
+        clouds=[{"cover": "FEW", "base": 900}, {"cover": "SCT", "base": 1200}],
+    )
+
+    assert parsed["ceiling_ft"] is None
+
+
+def test_layers_without_a_base_are_dropped(generator):
+    parsed = parse(
+        generator,
+        clouds=[{"cover": "BKN", "base": None}, {"cover": None, "base": 2000}],
+    )
+
+    assert parsed["clouds"] == []
+    assert parsed["ceiling_ft"] is None
+
+
+def test_no_clouds_key_yields_an_empty_layer_list(generator):
+    parsed = parse(generator)
+
+    assert parsed["clouds"] == []
+    assert parsed["ceiling_ft"] is None
+
+
+# ---------------------------------------------------------------------------
+# Temperature and pressure
+# ---------------------------------------------------------------------------
+
+
+def test_missing_temperatures_fall_back_to_isa_ish_defaults(generator):
+    record = {
+        "rawOb": "",
+        "reportTime": "2026-08-05 12:00:00",
+        "wdir": 170,
+        "wspd": 5,
+    }
+
+    parsed = generator._parse_metar(record)
+
+    assert parsed["temperature_c"] == 15
+    assert parsed["dewpoint_c"] == 10
+
+
+def test_negative_temperatures_survive_the_int_coercion(generator):
+    parsed = parse(generator, temp=-4, dewp=-9)
+
+    assert parsed["temperature_c"] == -4
+    assert parsed["dewpoint_c"] == -9
+
+
+def test_altimeter_is_truncated_to_whole_hectopascals(generator):
+    parsed = parse(generator, altim="1013.7")
+
+    assert parsed["qnh_hpa"] == 1013
+
+
+def test_missing_altimeter_defaults_to_standard_pressure(generator):
+    parsed = parse(generator, altim=None)
+
+    assert parsed["qnh_hpa"] == 1013

--- a/tests/weather/test_metar_taf_fetcher.py
+++ b/tests/weather/test_metar_taf_fetcher.py
@@ -1,0 +1,211 @@
+"""Tests for ``services/weather_service/core/metar_taf_fetcher.py``.
+
+Covers the httpx migration (issue #63): the fetcher must be async, must reuse a
+single ``AsyncClient``, must always carry an explicit timeout, and must convert
+upstream failures into ``WeatherUpstreamError`` with a sensible HTTP status
+instead of letting raw transport errors escape into the API layer.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from tests.weather.service_imports import (
+    WeatherUpstreamError,
+    get_metar,
+    get_taf,
+    metar_taf_fetcher,
+)
+
+METAR_URL = "https://aviationweather.gov/api/data/metar"
+TAF_URL = "https://aviationweather.gov/api/data/taf"
+
+
+# ---------------------------------------------------------------------------
+# Shared client
+# ---------------------------------------------------------------------------
+
+
+def test_get_client_reuses_a_single_instance():
+    first = metar_taf_fetcher.get_client()
+    second = metar_taf_fetcher.get_client()
+
+    assert first is second
+    assert isinstance(first, httpx.AsyncClient)
+
+
+def test_client_has_an_explicit_timeout():
+    client = metar_taf_fetcher.get_client()
+
+    assert client.timeout.connect == 10.0
+    assert client.timeout.read == 10.0
+
+
+async def test_close_client_is_idempotent():
+    client = metar_taf_fetcher.get_client()
+
+    await metar_taf_fetcher.close_client()
+    await metar_taf_fetcher.close_client()
+
+    assert client.is_closed
+    assert metar_taf_fetcher._client is None
+
+
+async def test_get_client_replaces_a_closed_client():
+    first = metar_taf_fetcher.get_client()
+    await first.aclose()
+
+    second = metar_taf_fetcher.get_client()
+
+    assert second is not first
+    assert not second.is_closed
+
+
+# ---------------------------------------------------------------------------
+# get_metar
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_metar_returns_decoded_json_and_uppercases_the_icao():
+    route = respx.get(METAR_URL).mock(
+        return_value=httpx.Response(200, json=[{"rawOb": "LEST 051200Z"}])
+    )
+
+    data = await get_metar("lest")
+
+    assert data == [{"rawOb": "LEST 051200Z"}]
+    request = route.calls[0].request
+    assert dict(request.url.params) == {"ids": "LEST", "format": "json"}
+
+
+@respx.mock
+async def test_get_metar_forwards_the_hours_parameter():
+    route = respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[]))
+
+    await get_metar("LEST", hours=3)
+
+    assert dict(route.calls[0].request.url.params) == {
+        "ids": "LEST",
+        "format": "json",
+        "hours": "3",
+    }
+
+
+@respx.mock
+async def test_get_metar_omits_hours_when_zero_or_none():
+    route = respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[]))
+
+    await get_metar("LEST", hours=0)
+
+    assert "hours" not in dict(route.calls[0].request.url.params)
+
+
+@respx.mock
+async def test_get_metar_raw_format_returns_the_body_verbatim():
+    respx.get(METAR_URL).mock(
+        return_value=httpx.Response(200, text="LEST 051200Z 17010KT CAVOK 15/10 Q1013")
+    )
+
+    data = await get_metar("LEST", output_format="raw")
+
+    assert data == {"data": "LEST 051200Z 17010KT CAVOK 15/10 Q1013"}
+
+
+# ---------------------------------------------------------------------------
+# get_taf
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_taf_requests_the_bundled_metar_by_default():
+    route = respx.get(TAF_URL).mock(return_value=httpx.Response(200, json=[]))
+
+    await get_taf("LEST")
+
+    assert dict(route.calls[0].request.url.params) == {
+        "ids": "LEST",
+        "format": "json",
+        "metar": "true",
+    }
+
+
+@respx.mock
+async def test_get_taf_can_skip_the_bundled_metar():
+    route = respx.get(TAF_URL).mock(return_value=httpx.Response(200, json=[]))
+
+    await get_taf("LEST", include_metar=False)
+
+    assert "metar" not in dict(route.calls[0].request.url.params)
+
+
+# ---------------------------------------------------------------------------
+# Error mapping
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_upstream_error_status_becomes_a_502():
+    respx.get(METAR_URL).mock(return_value=httpx.Response(503))
+
+    with pytest.raises(WeatherUpstreamError) as excinfo:
+        await get_metar("LEST")
+
+    assert excinfo.value.status_code == 502
+    assert "503" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, httpx.HTTPStatusError)
+
+
+@respx.mock
+async def test_upstream_timeout_becomes_a_504():
+    respx.get(METAR_URL).mock(side_effect=httpx.ConnectTimeout("too slow"))
+
+    with pytest.raises(WeatherUpstreamError) as excinfo:
+        await get_metar("LEST")
+
+    assert excinfo.value.status_code == 504
+    assert isinstance(excinfo.value.__cause__, httpx.TimeoutException)
+
+
+@respx.mock
+async def test_unreachable_upstream_becomes_a_502():
+    respx.get(TAF_URL).mock(side_effect=httpx.ConnectError("no route to host"))
+
+    with pytest.raises(WeatherUpstreamError) as excinfo:
+        await get_taf("LEST")
+
+    assert excinfo.value.status_code == 502
+    assert isinstance(excinfo.value.__cause__, httpx.ConnectError)
+
+
+@respx.mock
+async def test_undecodable_json_becomes_a_502():
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, text="<html>oops</html>"))
+
+    with pytest.raises(WeatherUpstreamError) as excinfo:
+        await get_metar("LEST")
+
+    assert excinfo.value.status_code == 502
+    assert "undecodable" in str(excinfo.value)
+
+
+@respx.mock
+async def test_upstream_failures_are_logged_with_context(caplog):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(500))
+
+    with caplog.at_level("WARNING"), pytest.raises(WeatherUpstreamError):
+        await get_metar("LEST")
+
+    assert any("LEST" in record.getMessage() for record in caplog.records)
+
+
+@respx.mock
+async def test_raw_format_does_not_try_to_decode_json():
+    """A raw request must not fail just because the body is not JSON."""
+    respx.get(TAF_URL).mock(return_value=httpx.Response(200, text="TAF LEST 051100Z"))
+
+    data = await get_taf("LEST", output_format="raw")
+
+    assert data == {"data": "TAF LEST 051100Z"}

--- a/tests/weather/test_routes_error_mapping.py
+++ b/tests/weather/test_routes_error_mapping.py
@@ -1,0 +1,238 @@
+"""HTTP-contract tests for ``services/weather_service/api/routes.py`` (issue #63).
+
+The endpoints used to funnel every failure through ``except Exception`` and
+answer ``500 <str(exc)>``, which made an upstream outage indistinguishable from
+a bug in this service. These tests pin the narrowed mapping:
+
+* no observation for the airport -> 404
+* aviationweather.gov unreachable / error status -> 502
+* aviationweather.gov timeout -> 504
+* payload we cannot parse -> 502
+* database write failure -> 500 with a generic message
+
+They also pin the field names of the successful responses, so the request-model
+refactor in #64 cannot silently change the contract.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import OperationalError
+
+from tests.weather.service_imports import routes
+
+METAR_URL = "https://aviationweather.gov/api/data/metar"
+TAF_URL = "https://aviationweather.gov/api/data/taf"
+PREFIX = "/api/v1/weather"
+
+
+class _FakeRepository:
+    """Stand-in for ATISRepository: records what would have been persisted."""
+
+    created: list = []
+
+    def __init__(self, db):
+        self.db = db
+
+    def create(self, atis):
+        type(self).created.append(atis)
+        return atis
+
+
+@pytest.fixture
+def client(monkeypatch):
+    _FakeRepository.created = []
+    monkeypatch.setattr(routes, "ATISRepository", _FakeRepository)
+    # Fresh generator per test so the ATIS letter sequence is deterministic.
+    monkeypatch.setattr(routes, "generator", routes.ATISGenerator())
+
+    app = FastAPI()
+    app.include_router(routes.router, prefix=PREFIX)
+    app.dependency_overrides[routes.get_db] = lambda: None
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+# ---------------------------------------------------------------------------
+# Happy paths (contract baseline for #64)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_generate_atis_returns_the_broadcast_and_persists_it(client, metar_payload):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    response = client.get(
+        f"{PREFIX}/atis/LEST",
+        params={"departure_runway": "17", "arrival_runway": "17", "approach": "ILS"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["icao_code"] == "LEST"
+    assert body["atis_letter"] == "A"
+    assert body["departure_runway"] == "17"
+    assert body["approach_type"] == "ILS"
+    assert "Santiago information ALFA." in body["atis_text"]
+    assert len(_FakeRepository.created) == 1
+
+
+@respx.mock
+def test_preview_mode_skips_persistence(client, metar_payload):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    response = client.get(f"{PREFIX}/atis/LEST", params={"preview": "true"})
+
+    assert response.status_code == 200
+    assert _FakeRepository.created == []
+
+
+@respx.mock
+def test_metar_endpoint_shapes_the_upstream_record(client, metar_payload):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    response = client.get(f"{PREFIX}/metar/LEST")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["icao_code"] == "LEST"
+    assert body["wind_direction"] == 170
+    assert body["visibility_m"] == 9999
+    assert body["qnh_hpa"] == 1013
+    # BKN at 2500 ft is a ceiling below 3000 ft -> marginal VFR.
+    assert body["flight_category"] == "MVFR"
+
+
+@respx.mock
+def test_raw_metar_endpoint_returns_the_body_verbatim(client):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, text="LEST 051200Z CAVOK"))
+
+    response = client.get(f"{PREFIX}/metar/lest/raw")
+
+    assert response.status_code == 200
+    assert response.json() == {"icao_code": "LEST", "raw_metar": "LEST 051200Z CAVOK"}
+
+
+@respx.mock
+def test_taf_endpoint_wraps_the_upstream_list(client):
+    respx.get(TAF_URL).mock(return_value=httpx.Response(200, json=[{"rawTAF": "TAF LEST"}]))
+
+    response = client.get(f"{PREFIX}/taf/LEST")
+
+    assert response.status_code == 200
+    assert response.json() == {"icao_code": "LEST", "taf": [{"rawTAF": "TAF LEST"}]}
+
+
+@respx.mock
+def test_raw_taf_endpoint_returns_the_body_verbatim(client):
+    respx.get(TAF_URL).mock(return_value=httpx.Response(200, text="TAF LEST 051100Z"))
+
+    response = client.get(f"{PREFIX}/taf/LEST/raw")
+
+    assert response.status_code == 200
+    assert response.json() == {"icao_code": "LEST", "raw_taf": "TAF LEST 051100Z"}
+
+
+# ---------------------------------------------------------------------------
+# Error mapping
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_no_observation_is_a_404(client):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[]))
+
+    response = client.get(f"{PREFIX}/atis/LEST")
+
+    assert response.status_code == 404
+    assert "No METAR data available" in response.json()["detail"]
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    "path",
+    ["/atis/LEST", "/metar/LEST", "/metar/LEST/raw", "/taf/LEST", "/taf/LEST/raw"],
+)
+def test_upstream_outage_is_a_502_everywhere(client, path):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(503))
+    respx.get(TAF_URL).mock(return_value=httpx.Response(503))
+
+    response = client.get(f"{PREFIX}{path}")
+
+    assert response.status_code == 502
+    assert "LEST" in response.json()["detail"]
+
+
+@respx.mock
+def test_upstream_timeout_is_a_504(client):
+    respx.get(METAR_URL).mock(side_effect=httpx.ReadTimeout("too slow"))
+
+    response = client.get(f"{PREFIX}/atis/LEST")
+
+    assert response.status_code == 504
+
+
+@respx.mock
+def test_malformed_upstream_payload_is_a_502_not_a_500(client):
+    """A ``null`` reportTime blows up inside the parser; the client sees 502."""
+    respx.get(METAR_URL).mock(
+        return_value=httpx.Response(200, json=[{"rawOb": "LEST", "reportTime": None}])
+    )
+
+    response = client.get(f"{PREFIX}/atis/LEST")
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Malformed METAR data for LEST"
+
+
+@respx.mock
+def test_malformed_payload_on_the_metar_endpoint_is_a_502(client):
+    respx.get(METAR_URL).mock(
+        return_value=httpx.Response(200, json=[{"rawOb": "LEST", "wdir": "north"}])
+    )
+
+    response = client.get(f"{PREFIX}/metar/LEST")
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Malformed METAR data for LEST"
+
+
+@respx.mock
+def test_database_failure_is_a_500_without_leaking_the_driver_error(
+    client, monkeypatch, metar_payload
+):
+    respx.get(METAR_URL).mock(return_value=httpx.Response(200, json=[metar_payload]))
+
+    class _BrokenRepository(_FakeRepository):
+        def create(self, atis):
+            raise OperationalError("INSERT", {}, Exception("connection refused"))
+
+    monkeypatch.setattr(routes, "ATISRepository", _BrokenRepository)
+
+    response = client.get(f"{PREFIX}/atis/LEST")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to store the generated ATIS"
+    assert "connection refused" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+
+def test_health_reports_degraded_when_the_database_is_down(client, monkeypatch):
+    monkeypatch.setattr(routes, "check_connection", lambda: False)
+
+    response = client.get(f"{PREFIX}/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "degraded"
+    assert body["service"] == "weather_service"
+    assert body["db_connected"] is False


### PR DESCRIPTION
## What

`services/weather_service` was calling `requests.get` from inside async FastAPI handlers. Every METAR/TAF lookup blocked the event loop for the whole process (up to the 10 s timeout), and every failure was funnelled through `except Exception -> HTTPException(500, str(e))`, which made an upstream outage indistinguishable from a bug in this service.

### 1. `requests` -> shared `httpx.AsyncClient`

- `core/metar_taf_fetcher.py` rewritten around one lazily-created `httpx.AsyncClient` with an explicit `httpx.Timeout(10.0)`, reused across requests instead of one client per call.
- New `close_client()` wired into a FastAPI `lifespan` in `main.py` so the connection pool is released on shutdown.
- Async-correct end to end: `get_metar`, `get_taf`, `ATISGenerator._fetch_metar` and `ATISGenerator.generate` are coroutines; `api/routes.py` awaits them.
- `requests` dropped from `services/weather_service/requirements.txt` (the image already installs `httpx==0.26.0`).

### 2. Broad exception handlers narrowed

| Location | Before | After |
|---|---|---|
| `metar_taf_fetcher._fetch` | none (raw `requests` exceptions escaped) | `httpx.TimeoutException` / `HTTPStatusError` / `RequestError` / JSON `ValueError` -> typed `WeatherUpstreamError` carrying the status the API should answer with (504 for timeouts, 502 otherwise), logged with ICAO + endpoint, original kept as `__cause__` |
| `atis_generator._fetch_metar` | `except Exception -> ValueError(...)` | removed. A missing observation raises `NoWeatherDataError`; an upstream outage propagates instead of being reported as a 404 "airport not found" |
| `routes.generate_atis` | `except Exception -> 500 str(e)` | 404 `NoWeatherDataError` · 502/504 `WeatherUpstreamError` · 502 malformed payload (logged with `exc_info`) · 500 only for `SQLAlchemyError` on the ATIS write, with a generic detail so the driver message never reaches the client |
| `routes.get_metar_data` | `except Exception -> 500 str(e)` | 502/504 upstream · 502 malformed payload · 404 no observation |
| `routes.get_metar_raw` / `get_taf_data` / `get_taf_raw` | `except Exception -> 500 str(e)` | 502/504 upstream only |
| `database/connection.check_connection` | `except Exception: return False` | `except SQLAlchemyError` + `logger.warning` (still returns False — it is a health probe) |

**Intentionally kept broad:** none in this service. The only wide catch left is the `MALFORMED_PAYLOAD_ERRORS` tuple in `routes.py` (`AttributeError, IndexError, KeyError, TypeError, ValueError`), which is an explicit, documented list rather than a bare `except Exception`: those are exactly the ways an unexpected aviationweather.gov payload shape can blow up the parser, and they mean "bad upstream data" (502), never "bug here" (500).

Also checked from the issue body: `xplane_plugin/services/hmi_service.py:15` **already** passes `timeout=5` and catches `requests.RequestException` — no change needed. The remaining `requests` usage in `xplane_plugin/` stays as-is (synchronous desktop context, as the issue notes).

### 3. `tests/weather/` — new suite (issue #49 hotspot)

There was no weather test directory at all. Added 70 hermetic tests (no network, `respx` for HTTP):

- `test_metar_taf_fetcher.py` — URL/param construction, ICAO upper-casing, raw vs JSON, client reuse and timeout, and the full error-mapping matrix.
- `test_atis_generator_parse_metar.py` — **characterization tests for `ATISGenerator._parse_metar`** (part of the #49 hotspot list): wind VRB/missing/coerced, the `9999`-in-`rawOb` precedence over `visib`, statute-mile conversion and the 9999 cap, the `+` suffix strip, weather-code expansion, ceiling = lowest BKN/OVC layer, layers without a base being dropped, and every default (15/10 °C, 1013 hPa, `utcnow` report time). Includes the `null` `reportTime` -> `AttributeError` case that the new 502 mapping covers.
- `test_atis_generator_fetch.py` — the async fetch path, ATIS letter sequencing, preview mode, runway/approach auto-selection, QFE/remarks, and a regression test that an upstream 500 is **not** disguised as missing data.
- `test_routes_error_mapping.py` — `TestClient` tests for every endpoint: response field names (a contract baseline for #64) plus the 404/502/504/500 mapping.

`tests/conftest.py` is untouched. The suite imports the service through `tests/weather/service_imports.py`, which temporarily takes over the `api`/`core`/`models` top-level names (they collide with `orchestrator_service` and `arrival_simulator_service`, both already on `sys.path`) and restores `sys.path`/`sys.modules` afterwards, so suite ordering does not matter.

## Testing

`pytest -q` -> **358 passed, 1 skipped, 4 xfailed** (was 288 passed before this branch; the 4 xfails and the skip are pre-existing).

## Notes

- Issue #53 (unify the two METAR/TAF modules) was verified stale and closed: `services/weather_service/metar_taf.py` was already deleted in `b002864`/`38743b7`, and repo-wide grep finds no reference to it. `core/metar_taf_fetcher.py` was already the single source of truth, so the httpx swap landed there.
- References #49 for the `_parse_metar` characterization tests — **not** closing it, the rest of its hotspot list is handled elsewhere.
- openwiki refreshed: `services/weather_service.md` (async client + typed errors) and `data-and-testing.md` (new suite row).

Closes #63
