### PR TITLE
refactor: break up forward_to_agent into a named pipeline (closes #57)

### DIFF
--- a/services/orchestrator_service/agent/tools/forward.py
+++ b/services/orchestrator_service/agent/tools/forward.py
@@ -1,3 +1,17 @@
+"""The orchestrator's central routing tool.
+
+`forward_to_agent` is what actually talks to the DEL/GND/TWR pilot agents on
+Cloud Run. Around that one HTTP call it does five other things, each extracted
+into a named helper below so the tool itself reads as the pipeline it is:
+
+    resolve target -> build payload -> call agent -> record reply
+                   -> maybe dispatch a taxi plan -> write session state
+
+The order matters and is part of the contract: the debrief entry is written
+before the taxi dispatch (so an exploding router still leaves a timeline), and
+the state keys `runner.py` reads are written last.
+"""
+
 import logging
 import os
 from typing import Any
@@ -18,27 +32,239 @@ _ROUTES: dict[str, tuple[str, str]] = {
     "TWR": (os.environ.get("TWR_AGENT_URL", ""), "/agents/tower/run"),
 }
 
+_DEFAULT_DEPENDENCY = "DEL"
+_CONTEXT_TIMEOUT_S = 5
+_AGENT_TIMEOUT_S = 60
 
-def _fetch_flight_plan(registration: str) -> dict | None:
-    if not _FLIGHT_PLAN_URL:
+# Bookkeeping columns that stay on the orchestrator side — the pilot agents
+# receive the clearance fields only.
+_NON_CLEARANCE_KEYS = ("registration", "dependency", "source")
+
+
+# ---------------------------------------------------------------------------
+# Target resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_dependency(dependency: str) -> str:
+    """Normalise the phase the LLM asked for; anything unknown becomes DEL."""
+    dep = dependency.upper()
+    return dep if dep in _ROUTES else _DEFAULT_DEPENDENCY
+
+
+# ---------------------------------------------------------------------------
+# Context fetching
+# ---------------------------------------------------------------------------
+
+
+def _fetch_context(base_url: str, path: str, label: str, subject: str) -> dict | None:
+    """GET ``{base_url}{path}`` and return the JSON body, or None.
+
+    Context is a nice-to-have: an unconfigured service, an unreachable one, or
+    any non-200 answer all degrade to None so the pilot agent is still called.
+
+    Args:
+        base_url: Service root; empty means "not configured", skip the call.
+        path:     Path to append, already containing the subject.
+        label:    Human name of the resource, for the warning log only.
+        subject:  What is being looked up (registration / ICAO). Empty means
+                  there is nothing to ask for, so the call is skipped.
+    """
+    if not base_url or not subject:
         return None
     try:
-        resp = httpx.get(f"{_FLIGHT_PLAN_URL}/plans/{registration}", timeout=5)
+        resp = httpx.get(f"{base_url}{path}", timeout=_CONTEXT_TIMEOUT_S)
         return resp.json() if resp.status_code == 200 else None
     except Exception as exc:
-        logger.warning("[ORCH] could not fetch flight plan for %s: %s", registration, exc)
+        logger.warning("[ORCH] could not fetch %s for %s: %s", label, subject, exc)
         return None
 
 
-def _fetch_atis(departure_icao: str) -> dict | None:
-    if not _WEATHER_URL or not departure_icao:
-        return None
+# ---------------------------------------------------------------------------
+# Payload building
+# ---------------------------------------------------------------------------
+
+
+def _departure_icao_of(flight_plan: dict | None) -> str:
+    """The flight plan service has shipped both spellings of this field."""
+    plan = flight_plan or {}
+    return plan.get("departure_ICAO") or plan.get("departure_icao", "")
+
+
+def _del_context(registration: str) -> dict[str, Any]:
+    """Flight plan + ATIS for the DEL agent, which has no state of its own."""
+    flight_plan = _fetch_context(
+        _FLIGHT_PLAN_URL, f"/plans/{registration}", "flight plan", registration
+    )
+    atis = _fetch_context(
+        _WEATHER_URL,
+        f"/atis/{_departure_icao_of(flight_plan)}",
+        "ATIS",
+        _departure_icao_of(flight_plan),
+    )
+    logger.debug("[ORCH] DEL payload — flight_plan=%s atis=%s", bool(flight_plan), bool(atis))
+    return {"flight_plan": flight_plan, "atis": atis}
+
+
+def _clearance_context(
+    dep: str,
+    registration: str,
+    tool_context: ToolContext,
+    taxi_route: dict | None,
+) -> dict[str, Any]:
+    """The clearance record GND/TWR need, taken from the pre-fetched state.
+
+    Returns an empty dict — no ``clearance_data`` key at all — when nothing is
+    known about the aircraft and no taxi route was computed.
+    """
+    known = tool_context.state.get("known_aircraft", [])
+    aircraft_data = next(
+        (a for a in known if a.get("registration") == registration), {}
+    )
+    clearance_fields = {
+        k: v for k, v in aircraft_data.items() if k not in _NON_CLEARANCE_KEYS
+    }
+    # Merge the pre-computed taxi route so the GND agent knows the exact
+    # waypoints and can produce a correct pilot readback.
+    if taxi_route and taxi_route.get("success"):
+        clearance_fields["taxi_route"] = taxi_route
+    if not clearance_fields:
+        return {}
+    logger.debug("[ORCH] %s payload — clearance_data=%s", dep, clearance_fields)
+    return {"clearance_data": clearance_fields}
+
+
+def _build_payload(
+    dep: str,
+    registration: str,
+    message: str,
+    session_id: str,
+    tool_context: ToolContext,
+    taxi_route: dict | None,
+) -> dict[str, Any]:
+    """Assemble the agent request: the message plus phase-specific context."""
+    payload: dict[str, Any] = {"session_id": session_id, "message": message}
+    if dep == "DEL" and registration:
+        payload.update(_del_context(registration))
+    else:
+        payload.update(_clearance_context(dep, registration, tool_context, taxi_route))
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# The agent call
+# ---------------------------------------------------------------------------
+
+
+def _call_agent(dep: str, target: str, payload: dict[str, Any]) -> tuple[str, Any, Any]:
+    """POST to a pilot agent and unpack its answer.
+
+    Never raises: transport and HTTP failures come back as an ``[ERROR] …``
+    reply string, which is what the controller ends up hearing.
+
+    Returns:
+        ``(reply, clearance_data, taxi_data)``.
+    """
     try:
-        resp = httpx.get(f"{_WEATHER_URL}/atis/{departure_icao}", timeout=5)
-        return resp.json() if resp.status_code == 200 else None
+        resp = httpx.post(target, json=payload, timeout=_AGENT_TIMEOUT_S)
+        resp.raise_for_status()
+        data = resp.json()
+        reply = data.get("reply", "")
+        logger.info("[ORCH] %s reply: %r", dep, reply[:100])
+        return reply, data.get("clearance_data"), data.get("taxi_data")
+    except httpx.HTTPStatusError as exc:
+        logger.error("[ORCH] %s HTTP error: %s", dep, exc)
+        return f"[ERROR] {dep} agent returned HTTP {exc.response.status_code}", None, None
+    except httpx.RequestError as exc:
+        logger.error("[ORCH] %s unreachable: %s", dep, exc)
+        return f"[ERROR] could not reach {dep} agent at {target}: {exc}", None, None
+
+
+# ---------------------------------------------------------------------------
+# Side effects
+# ---------------------------------------------------------------------------
+
+
+def _record_reply(
+    session_id: str, dep: str, registration: str, reply: str, taxi_data: Any
+) -> None:
+    """Persist the reply for the debrief timeline (fire-and-forget).
+
+    Error replies count: an outage the controller heard belongs in the
+    timeline. Without a session there is nowhere to write it.
+    """
+    if not (reply and session_id):
+        return
+    append_agent_reply(
+        session_id=session_id,
+        dep=dep,
+        registration=registration,
+        callsign=(taxi_data or {}).get("aircraft_registration") if taxi_data else None,
+        reply=reply,
+        taxi_data=taxi_data,
+    )
+
+
+def _should_dispatch_taxi(dep: str, registration: str, taxi_data: Any) -> bool:
+    """GND only, and only once the pilot has acknowledged movement.
+
+    That acknowledgement is either a pushback approval or a non-blank taxi
+    route; taxi-only clearances are the typical follow-up after pushback
+    completes.
+    """
+    acknowledged = bool(taxi_data) and (
+        taxi_data.get("pushback_approved") or (taxi_data.get("taxi_route") or "").strip()
+    )
+    return bool(dep == "GND" and registration and acknowledged)
+
+
+def _dispatch_taxi(
+    registration: str,
+    message: str,
+    reply: str,
+    taxi_route: dict | None,
+    taxi_data: Any,
+    session_id: str,
+) -> None:
+    """Hand the acknowledged clearance to the shared taxi router.
+
+    Imported lazily: the router pulls in the airport graph, which the tool
+    module must not need at import time. Failures are swallowed — the readback
+    has already been produced and the controller must still hear it.
+    """
+    try:
+        from shared.services.taxi_router import dispatch_taxi_plan
+        merged_clearance = {
+            "taxi_route": taxi_route,
+            "taxi_data": taxi_data,
+            "instruction_text": reply,
+        }
+        dispatch_taxi_plan(
+            merged_clearance,
+            pilot_readback_text=reply,
+            registration=registration,
+            controller_instruction=message,
+            callsign=taxi_data.get("aircraft_registration") or registration,
+            session_id=session_id,
+        )
     except Exception as exc:
-        logger.warning("[ORCH] could not fetch ATIS for %s: %s", departure_icao, exc)
-        return None
+        logger.error("[ORCH] taxi dispatch failed for %s: %s", registration, exc)
+
+
+def _write_state(
+    tool_context: ToolContext, reply: str, dep: str, registration: str, clearance_data: Any
+) -> None:
+    """Publish the outcome to session state — `runner.py` reads these after
+    the agent run finishes."""
+    tool_context.state["reply"] = reply
+    tool_context.state["dependency"] = dep
+    tool_context.state["registration"] = registration or None
+    tool_context.state["clearance_data"] = clearance_data
+
+
+# ---------------------------------------------------------------------------
+# The tool itself
+# ---------------------------------------------------------------------------
 
 
 def forward_to_agent(
@@ -61,9 +287,7 @@ def forward_to_agent(
                       clearance_data so the GND agent can produce a correct
                       readback without needing to call any routing tool itself.
     """
-    dep = dependency.upper()
-    if dep not in _ROUTES:
-        dep = "DEL"
+    dep = _resolve_dependency(dependency)
 
     agent_url, agent_path = _ROUTES[dep]
     if not agent_url:
@@ -76,93 +300,12 @@ def forward_to_agent(
     logger.info("[ORCH] forwarding to %s | reg=%s | session=%s | msg=%r",
                 dep, registration, session_id, message[:80])
 
-    payload: dict[str, Any] = {"session_id": session_id, "message": message}
+    payload = _build_payload(dep, registration, message, session_id, tool_context, taxi_route)
+    reply, clearance_data, taxi_data = _call_agent(dep, target, payload)
 
-    if dep == "DEL" and registration:
-        # Pre-fetch flight plan and ATIS for the DEL agent
-        flight_plan = _fetch_flight_plan(registration)
-        payload["flight_plan"] = flight_plan
-        departure_icao = (flight_plan or {}).get("departure_ICAO") or (flight_plan or {}).get("departure_icao", "")
-        payload["atis"] = _fetch_atis(departure_icao)
-        logger.debug("[ORCH] DEL payload — flight_plan=%s atis=%s",
-                     bool(flight_plan), bool(payload.get("atis")))
-    else:
-        # For GND/TWR pass the full clearance data already stored in state
-        known = tool_context.state.get("known_aircraft", [])
-        aircraft_data = next(
-            (a for a in known if a.get("registration") == registration), {}
-        )
-        clearance_fields = {
-            k: v for k, v in aircraft_data.items()
-            if k not in ("registration", "dependency", "source")
-        }
-        # Merge the pre-computed taxi route so the GND agent knows the exact
-        # waypoints and can produce a correct pilot readback.
-        if taxi_route and taxi_route.get("success"):
-            clearance_fields["taxi_route"] = taxi_route
-        if clearance_fields:
-            payload["clearance_data"] = clearance_fields
-            logger.debug("[ORCH] %s payload — clearance_data=%s", dep, clearance_fields)
-
-    reply = ""
-    clearance_data = None
-    taxi_data = None
-    try:
-        resp = httpx.post(target, json=payload, timeout=60)
-        resp.raise_for_status()
-        data = resp.json()
-        reply = data.get("reply", "")
-        clearance_data = data.get("clearance_data")
-        taxi_data = data.get("taxi_data")
-        logger.info("[ORCH] %s reply: %r", dep, reply[:100])
-    except httpx.HTTPStatusError as exc:
-        reply = f"[ERROR] {dep} agent returned HTTP {exc.response.status_code}"
-        logger.error("[ORCH] %s HTTP error: %s", dep, exc)
-    except httpx.RequestError as exc:
-        reply = f"[ERROR] could not reach {dep} agent at {target}: {exc}"
-        logger.error("[ORCH] %s unreachable: %s", dep, exc)
-
-    # Persist the reply for the debrief timeline (fire-and-forget).
-    if reply and session_id:
-        append_agent_reply(
-            session_id=session_id,
-            dep=dep,
-            registration=registration,
-            callsign=(taxi_data or {}).get("aircraft_registration") if taxi_data else None,
-            reply=reply,
-            taxi_data=taxi_data,
-        )
-
-    # GND: dispatch a taxi plan when the pilot has acknowledged either a
-    # pushback clearance or a taxi route (or both). Taxi-only clearances are
-    # the typical follow-up after pushback completes.
-    _trigger_taxi = bool(taxi_data) and (
-        taxi_data.get("pushback_approved")
-        or (taxi_data.get("taxi_route") or "").strip()
-    )
-    if dep == "GND" and registration and _trigger_taxi:
-        try:
-            from shared.services.taxi_router import dispatch_taxi_plan
-            merged_clearance = {
-                "taxi_route": taxi_route,
-                "taxi_data": taxi_data,
-                "instruction_text": reply,
-            }
-            dispatch_taxi_plan(
-                merged_clearance,
-                pilot_readback_text=reply,
-                registration=registration,
-                controller_instruction=message,
-                callsign=taxi_data.get("aircraft_registration") or registration,
-                session_id=tool_context.state.get("session_id", ""),
-            )
-        except Exception as exc:
-            logger.error("[ORCH] taxi dispatch failed for %s: %s", registration, exc)
-
-    # Write results to session state — runner.py reads these after the agent finishes
-    tool_context.state["reply"] = reply
-    tool_context.state["dependency"] = dep
-    tool_context.state["registration"] = registration or None
-    tool_context.state["clearance_data"] = clearance_data
+    _record_reply(session_id, dep, registration, reply, taxi_data)
+    if _should_dispatch_taxi(dep, registration, taxi_data):
+        _dispatch_taxi(registration, message, reply, taxi_route, taxi_data, session_id)
+    _write_state(tool_context, reply, dep, registration, clearance_data)
 
     return reply


### PR DESCRIPTION
> Stacked on #99 → #96 → #93. This PR's own diff is a single file: `services/orchestrator_service/agent/tools/forward.py`.

## What

`forward_to_agent` was 125 lines doing six things inline. It now reads as the pipeline it always was, at **42 lines** including the docstring:

```
resolve target -> build payload -> call agent -> record reply
               -> maybe dispatch a taxi plan -> write session state
```

| Helper | Responsibility |
|---|---|
| `_resolve_dependency` | uppercase the phase, fall back to DEL |
| `_fetch_context` | **the merged fetcher** — one GET, degrades to `None` |
| `_departure_icao_of` | the two `departure_ICAO` / `departure_icao` spellings |
| `_del_context` / `_clearance_context` | the two phase-specific payload halves |
| `_build_payload` | picks between them |
| `_call_agent` | the POST plus both error-to-`[ERROR]`-string paths |
| `_record_reply` | the debrief timeline entry |
| `_should_dispatch_taxi` / `_dispatch_taxi` | the GND movement trigger |
| `_write_state` | the four keys `runner.py` reads |

`_fetch_flight_plan` and `_fetch_atis` — the near-identical pair the issue calls out — are gone, replaced by `_fetch_context(base_url, path, label, subject)`. Its "nothing to ask for" guard now also covers an empty `subject`; for the flight plan that means an empty registration, a case the DEL branch **cannot reach** because it already requires a truthy registration (pinned by a characterization test in #96).

## Behaviour is unchanged — including the awkward parts

The branch-2 characterization tests are the guard, and a few details were preserved deliberately rather than "cleaned up":

- **Ordering**: the state writes still happen *after* the taxi dispatch, so a router failure leaves the debrief entry written and the state keys untouched. Tidying this would change what `runner.py` sees on a dispatch failure.
- `_should_dispatch_taxi` evaluates `taxi_data` **before** the phase check, matching the original expression order, instead of the more natural `if dep != "GND": return False` short-circuit.
- The unconfigured-agent-URL guard still returns before any side effect — no state writes, no debrief entry.
- Both `departure_ICAO` spellings, the non-200-means-`None` rule, the `[ERROR] …` reply strings, and the fact that error replies *do* reach the debrief log are all untouched.

The public `forward_to_agent` signature and docstring — the ADK tool contract, 21 callers — are byte-identical. The two timeouts moved to named constants (`_CONTEXT_TIMEOUT_S = 5`, `_AGENT_TIMEOUT_S = 60`) with the same values.

## Testing

`pytest tests/unit/orchestrator tests/integration tests/debrief` — 259 passed, 2 xfailed (the pre-existing documented runner bug), with the 50 characterization tests from #96 and the 22 pre-existing `test_forward_tool.py` tests unmodified. Full suite: 375 passed, 1 skipped, 4 xfailed.

Closes #57.