### PR TITLE
refactor: split run_orchestrator_agent and flatten _fetch_known_aircraft (closes #56)

### DIFF
--- a/services/orchestrator_service/runner.py
+++ b/services/orchestrator_service/runner.py
@@ -1,3 +1,15 @@
+"""Runs the routing agent and does the bookkeeping no LLM is trusted with.
+
+Three phases, in this order:
+
+1. **Pre-fetch** — merge every aircraft the system knows about from PostgreSQL,
+   the flight plan service and Redis, so the agent never has to ask.
+2. **Agent run** — one ADK session in its own event loop (`asyncio.run`,
+   because a FastAPI handler is already inside one), driven to completion.
+3. **Side effects** — persist the DEL clearance, apply the phase handoff the
+   agent flagged, and resolve the callsign for the response.
+"""
+
 import asyncio
 import logging
 import os
@@ -17,77 +29,157 @@ from db.repository import ClearanceRepository
 logger = logging.getLogger(__name__)
 
 _APP_NAME = "airport_orchestrator"
+_USER_ID = "pilot"
 
 _FLIGHT_PLAN_URL = os.environ.get("FLIGHT_PLAN_SERVICE_URL", "")
 _REDIS_HOST = os.environ.get("REDIS_HOST", "redis")
 _REDIS_PORT = int(os.environ.get("REDIS_PORT", "6379"))
+
+_FLIGHT_PLAN_TIMEOUT_S = 5
+
+# Clearance columns that only make sense once an aircraft has left DEL. Sending
+# them for a DEL aircraft would just be a row of Nones.
+_POST_DEL_CLEARANCE_FIELDS = (
+    "squawk",
+    "initial_altitude",
+    "instrumental_departure",
+    "runway_in_use",
+    "altimeter",
+    "destination_icao",
+    "clearance_text",
+)
+
+# The three phase handoffs, each flagged by its own state key. Tuple order is
+# the order they are applied in.
+#   (state key, target phase, create the row when missing, success log, error log)
+_DEPENDENCY_ADVANCES = (
+    (
+        "advance_registration_gnd",
+        "GND",
+        True,
+        "[ORCH] ground release — %s advanced to GND",
+        "[ORCH] failed to advance %s to GND: %s",
+    ),
+    (
+        "advance_registration_twr",
+        "TWR",
+        False,
+        "[ORCH] released to TWR — %s advanced to TWR",
+        "[ORCH] failed to advance %s to TWR: %s",
+    ),
+    (
+        "advance_registration_gnd_arrival",
+        "GND",
+        True,
+        "[ORCH] arrival ground release — %s advanced to GND",
+        "[ORCH] failed to reverse-advance %s to GND: %s",
+    ),
+)
 
 
 # ---------------------------------------------------------------------------
 # Pre-fetch helpers (run before the agent starts, in the sync thread)
 # ---------------------------------------------------------------------------
 
+
+def _db_entry(row: AircraftClearance) -> dict[str, Any]:
+    """One aircraft as PostgreSQL knows it — the authoritative phase."""
+    entry: dict[str, Any] = {
+        "registration": row.aircraft_registration,
+        "dependency": row.dependency,
+        "source": "db",
+    }
+    if row.dependency == "DEL":
+        return entry
+    # Include the full clearance for GND/TWR so sub-agents have context
+    entry.update({field: getattr(row, field) for field in _POST_DEL_CLEARANCE_FIELDS})
+    return entry
+
+
+def _collect_from_db(aircraft: dict[str, dict[str, Any]], db: Session) -> None:
+    """Source 1: PostgreSQL — most authoritative, it owns the phase."""
+    try:
+        for row in db.query(AircraftClearance).all():
+            aircraft[row.aircraft_registration] = _db_entry(row)
+    except Exception as exc:
+        logger.warning("[ORCH] DB query failed in pre-fetch: %s", exc)
+
+
+def _merge_plan(aircraft: dict[str, dict[str, Any]], plan: dict) -> None:
+    reg = plan.get("aircraft_registration")
+    if not reg:
+        return
+    callsign = plan.get("callsign", reg)
+    if reg in aircraft:
+        # Merge callsign into DB-sourced entry (DB has no callsign column)
+        aircraft[reg]["callsign"] = callsign
+        return
+    aircraft[reg] = {
+        "registration": reg,
+        "callsign": callsign,
+        "dependency": "DEL",
+        "source": "flight_plan",
+    }
+
+
+def _collect_from_flight_plans(aircraft: dict[str, dict[str, Any]]) -> None:
+    """Source 2: the flight plan service — filed but not yet cleared."""
+    if not _FLIGHT_PLAN_URL:
+        return
+    try:
+        resp = httpx.get(f"{_FLIGHT_PLAN_URL}/plans", timeout=_FLIGHT_PLAN_TIMEOUT_S)
+        if resp.status_code != 200:
+            return
+        for plan in resp.json():
+            _merge_plan(aircraft, plan)
+    except Exception as exc:
+        logger.warning("[ORCH] flight_plan_service unavailable: %s", exc)
+
+
+def _merge_live_aircraft(
+    aircraft: dict[str, dict[str, Any]], reg: str, state_callsign: str | None
+) -> None:
+    if reg not in aircraft:
+        aircraft[reg] = {
+            "registration": reg,
+            "callsign": state_callsign,
+            "dependency": "DEL",
+            "source": "redis",
+        }
+        return
+    if state_callsign and not aircraft[reg].get("callsign"):
+        aircraft[reg]["callsign"] = state_callsign
+
+
+def _collect_from_redis(aircraft: dict[str, dict[str, Any]]) -> None:
+    """Source 3: the Redis active set — aircraft alive in the sim right now.
+
+    The callsign lives in the state hash, not in the set itself.
+    """
+    try:
+        r = redis_lib.Redis(
+            host=_REDIS_HOST, port=_REDIS_PORT, db=0, decode_responses=True
+        )
+        for reg in r.smembers("aircraft:active_set"):
+            state_callsign = r.hget(f"aircraft:state:{reg}", "callsign") or None
+            _merge_live_aircraft(aircraft, reg, state_callsign)
+    except Exception as exc:
+        logger.warning("[ORCH] Redis unavailable: %s", exc)
+
+
 def _fetch_known_aircraft(db: Session) -> list[dict[str, Any]]:
     """
     Collect all known aircraft from three sources and merge them.
     PostgreSQL is authoritative; flight_plan_service and Redis fill in the rest.
     For GND/TWR aircraft the full clearance record is included.
+
+    Every source degrades independently: an outage in one drops its
+    contribution and logs, it never fails the dispatch.
     """
     aircraft: dict[str, dict[str, Any]] = {}
-
-    # 1. PostgreSQL — most authoritative
-    try:
-        rows = db.query(AircraftClearance).all()
-        for row in rows:
-            entry: dict[str, Any] = {
-                "registration": row.aircraft_registration,
-                "dependency": row.dependency,
-                "source": "db",
-            }
-            # Include full clearance for GND/TWR so sub-agents have context
-            if row.dependency != "DEL":
-                entry.update({
-                    "squawk": row.squawk,
-                    "initial_altitude": row.initial_altitude,
-                    "instrumental_departure": row.instrumental_departure,
-                    "runway_in_use": row.runway_in_use,
-                    "altimeter": row.altimeter,
-                    "destination_icao": row.destination_icao,
-                    "clearance_text": row.clearance_text,
-                })
-            aircraft[row.aircraft_registration] = entry
-    except Exception as exc:
-        logger.warning("[ORCH] DB query failed in pre-fetch: %s", exc)
-
-    # 2. Flight plan service — filed but not yet cleared
-    if _FLIGHT_PLAN_URL:
-        try:
-            resp = httpx.get(f"{_FLIGHT_PLAN_URL}/plans", timeout=5)
-            if resp.status_code == 200:
-                for plan in resp.json():
-                    reg = plan.get("aircraft_registration")
-                    if not reg:
-                        continue
-                    callsign = plan.get("callsign", reg)
-                    if reg in aircraft:
-                        # Merge callsign into DB-sourced entry (DB has no callsign column)
-                        aircraft[reg]["callsign"] = callsign
-                    else:
-                        aircraft[reg] = {"registration": reg, "callsign": callsign, "dependency": "DEL", "source": "flight_plan"}
-        except Exception as exc:
-            logger.warning("[ORCH] flight_plan_service unavailable: %s", exc)
-
-    # 3. Redis active set — aircraft with live position data; callsign lives in the state hash
-    try:
-        r = redis_lib.Redis(host=_REDIS_HOST, port=_REDIS_PORT, db=0, decode_responses=True)
-        for reg in r.smembers("aircraft:active_set"):
-            state_callsign = r.hget(f"aircraft:state:{reg}", "callsign") or None
-            if reg not in aircraft:
-                aircraft[reg] = {"registration": reg, "callsign": state_callsign, "dependency": "DEL", "source": "redis"}
-            elif state_callsign and not aircraft[reg].get("callsign"):
-                aircraft[reg]["callsign"] = state_callsign
-    except Exception as exc:
-        logger.warning("[ORCH] Redis unavailable: %s", exc)
+    _collect_from_db(aircraft, db)
+    _collect_from_flight_plans(aircraft)
+    _collect_from_redis(aircraft)
 
     result = list(aircraft.values())
     logger.info("[ORCH] pre-fetch: %d aircraft known", len(result))
@@ -95,8 +187,194 @@ def _fetch_known_aircraft(db: Session) -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
+# Agent invocation
+# ---------------------------------------------------------------------------
+
+
+async def _drain_events(runner: Runner, session_id: str, message: str) -> str:
+    """Run the agent to completion, keeping the last final-response text.
+
+    That text is only the fallback: when a tool ran, the reply the controller
+    hears comes from session state instead.
+    """
+    final_text = ""
+    async for event in runner.run_async(
+        user_id=_USER_ID,
+        session_id=session_id,
+        new_message=Content(role="user", parts=[Part(text=message)]),
+    ):
+        logger.debug("[ORCH] event: %s", event)
+        if event.is_final_response() and event.content and event.content.parts:
+            final_text = "".join(
+                p.text for p in event.content.parts if hasattr(p, "text")
+            )
+    return final_text
+
+
+async def _read_agent_outcome(
+    session_service: InMemorySessionService, session_id: str, final_text: str
+) -> dict[str, Any]:
+    """Everything the tools left behind in session state."""
+    session = await session_service.get_session(
+        app_name=_APP_NAME, user_id=_USER_ID, session_id=session_id
+    )
+    state = session.state or {}
+    return {
+        "reply": state.get("reply") or final_text,
+        "dependency": state.get("dependency", "DEL"),
+        "registration": state.get("registration"),
+        "clearance_data": state.get("clearance_data"),
+        # KNOWN BUG, preserved deliberately by this refactor: only the GND key
+        # is forwarded. `advance_registration_twr` and
+        # `advance_registration_gnd_arrival` are set by their tools but never
+        # read here, so those two handoffs never reach the database. Covered by
+        # two strict xfail tests in tests/unit/orchestrator/test_runner.py;
+        # fixing it is a behaviour change and belongs in its own PR.
+        "advance_registration_gnd": state.get("advance_registration_gnd"),
+    }
+
+
+def _invoke_agent(
+    session_id: str, message: str, known_aircraft: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Run one ADK session start to finish and return what it left in state.
+
+    Opens its own event loop: the caller is a sync function running in a
+    thread-pool executor precisely because a FastAPI handler is already inside
+    a loop of its own.
+    """
+    session_service = InMemorySessionService()
+    runner = Runner(agent=orch_agent, app_name=_APP_NAME, session_service=session_service)
+
+    async def _run() -> dict[str, Any]:
+        await session_service.create_session(
+            app_name=_APP_NAME,
+            user_id=_USER_ID,
+            session_id=session_id,
+            state={
+                "session_id": session_id,
+                "raw_transcription": message,
+                "known_aircraft": known_aircraft,
+            },
+        )
+        final_text = await _drain_events(runner, session_id, message)
+        return await _read_agent_outcome(session_service, session_id, final_text)
+
+    return asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Side effects (sync, after the async agent run)
+# ---------------------------------------------------------------------------
+
+
+def _persist_clearance(db: Session, session_id: str, result: dict[str, Any]) -> None:
+    """Write the DEL clearance fields the agent obtained.
+
+    NOTE: this does NOT advance to GND. The aircraft stays in DEL until the
+    controller says "contact ground on {freq}"; the advance_to_gnd tool sets
+    state["advance_registration_gnd"] when it detects that phrase.
+    """
+    cd = result.get("clearance_data")
+    registration = result.get("registration")
+    if not (cd and registration):
+        return
+    try:
+        repo = ClearanceRepository(db)
+        repo.upsert(
+            registration=cd.get("aircraft_registration", registration),
+            session_id=session_id,
+            squawk=cd.get("squawk", 2000),
+            initial_altitude=cd.get("initial_altitude", 6000),
+            instrumental_departure=cd.get("instrumental_departure", ""),
+            runway_in_use=cd.get("runway_in_use", ""),
+            altimeter=cd.get("altimeter", 1013.0),
+            destination_icao=cd.get("destination_icao", ""),
+            clearance_text=cd.get("clearance_text", ""),
+        )
+        logger.info(
+            "[ORCH] clearance persisted for %s — waiting for ground frequency release",
+            registration,
+        )
+    except Exception as exc:
+        logger.error("[ORCH] failed to persist clearance: %s", exc)
+
+
+def _advance_dependency(
+    db: Session,
+    session_id: str,
+    registration: str,
+    dependency: str,
+    *,
+    create_if_missing: bool,
+    success_log: str,
+    error_log: str,
+) -> None:
+    """Move one aircraft to another controller phase.
+
+    ``create_if_missing`` is the safety net for aircraft with no clearance row
+    yet — an arrival, or a departure the LLM handed off early — so the next
+    message still routes to the right controller.
+    """
+    try:
+        repo = ClearanceRepository(db)
+        updated = repo.update_dependency(registration, dependency)
+        if not updated and create_if_missing:
+            repo.upsert(
+                registration=registration,
+                session_id=session_id,
+                squawk=0,
+                initial_altitude=0,
+                instrumental_departure="",
+                runway_in_use="",
+                altimeter=0.0,
+                destination_icao="",
+                clearance_text="",
+                dependency=dependency,
+            )
+        logger.info(success_log, registration)
+    except Exception as exc:
+        logger.error(error_log, registration, exc)
+
+
+def _apply_dependency_advances(
+    db: Session, session_id: str, result: dict[str, Any]
+) -> None:
+    """Apply whichever handoff the agent flagged, if any.
+
+    Only an explicit release phrase gets here — the handoff tools set exactly
+    one of the three state keys when they fire.
+    """
+    for state_key, dependency, create_if_missing, success_log, error_log in _DEPENDENCY_ADVANCES:
+        registration = result.get(state_key)
+        if not registration:
+            continue
+        _advance_dependency(
+            db,
+            session_id,
+            registration,
+            dependency,
+            create_if_missing=create_if_missing,
+            success_log=success_log,
+            error_log=error_log,
+        )
+
+
+def _callsign_for(
+    known_aircraft: list[dict[str, Any]], registration: str | None
+) -> str | None:
+    if not registration:
+        return None
+    aircraft = next(
+        (a for a in known_aircraft if a.get("registration") == registration), None
+    )
+    return aircraft.get("callsign") if aircraft else None
+
+
+# ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
+
 
 def run_orchestrator_agent(
     session_id: str,
@@ -109,140 +387,15 @@ def run_orchestrator_agent(
     Returns dict with keys: reply, dependency, registration.
     """
     known_aircraft = _fetch_known_aircraft(db)
+    result = _invoke_agent(session_id, message, known_aircraft)
 
-    session_service = InMemorySessionService()
-    runner = Runner(agent=orch_agent, app_name=_APP_NAME, session_service=session_service)
-
-    async def _run() -> dict[str, Any]:
-        await session_service.create_session(
-            app_name=_APP_NAME,
-            user_id="pilot",
-            session_id=session_id,
-            state={
-                "session_id": session_id,
-                "raw_transcription": message,
-                "known_aircraft": known_aircraft,
-            },
-        )
-
-        final_text = ""
-        async for event in runner.run_async(
-            user_id="pilot",
-            session_id=session_id,
-            new_message=Content(role="user", parts=[Part(text=message)]),
-        ):
-            logger.debug("[ORCH] event: %s", event)
-            if event.is_final_response() and event.content and event.content.parts:
-                final_text = "".join(
-                    p.text for p in event.content.parts if hasattr(p, "text")
-                )
-
-        session = await session_service.get_session(
-            app_name=_APP_NAME, user_id="pilot", session_id=session_id
-        )
-        state = session.state or {}
-        return {
-            "reply": state.get("reply") or final_text,
-            "dependency": state.get("dependency", "DEL"),
-            "registration": state.get("registration"),
-            "clearance_data": state.get("clearance_data"),
-            "advance_registration_gnd": state.get("advance_registration_gnd"),
-        }
-
-    result = asyncio.run(_run())
-
-    # Persist clearance to DB (sync, after the async agent run)
-    clearance_data = result.get("clearance_data")
-    registration = result.get("registration")
-    if clearance_data and registration:
-        try:
-            cd = clearance_data
-            repo = ClearanceRepository(db)
-            repo.upsert(
-                registration=cd.get("aircraft_registration", registration),
-                session_id=session_id,
-                squawk=cd.get("squawk", 2000),
-                initial_altitude=cd.get("initial_altitude", 6000),
-                instrumental_departure=cd.get("instrumental_departure", ""),
-                runway_in_use=cd.get("runway_in_use", ""),
-                altimeter=cd.get("altimeter", 1013.0),
-                destination_icao=cd.get("destination_icao", ""),
-                clearance_text=cd.get("clearance_text", ""),
-            )
-            # NOTE: do NOT advance to GND here.
-            # The aircraft stays in DEL until the controller says
-            # "contact ground on {freq}". The advance_to_gnd tool sets
-            # state["advance_registration_gnd"] when it detects that phrase.
-            logger.info("[ORCH] clearance persisted for %s — waiting for ground frequency release", registration)
-        except Exception as exc:
-            logger.error("[ORCH] failed to persist clearance: %s", exc)
-
-    # Advance to GND only after controller says "contact ground on {freq}"
-    advance_reg_gnd = result.get("advance_registration_gnd")
-    if advance_reg_gnd:
-        try:
-            repo = ClearanceRepository(db)
-            updated = repo.update_dependency(advance_reg_gnd, "GND")
-            if not updated:
-                # Safety net: if the LLM picked advance_to_gnd for an arrival
-                # (which has no row yet), upsert anyway so the next message
-                # routes correctly to GND.
-                repo.upsert(
-                    registration=advance_reg_gnd,
-                    session_id=session_id,
-                    squawk=0, initial_altitude=0,
-                    instrumental_departure="", runway_in_use="",
-                    altimeter=0.0, destination_icao="",
-                    clearance_text="", dependency="GND",
-                )
-            logger.info("[ORCH] ground release — %s advanced to GND", advance_reg_gnd)
-        except Exception as exc:
-            logger.error("[ORCH] failed to advance %s to GND: %s", advance_reg_gnd, exc)
-
-    # Advance to TWR only after controller releases with "contact tower on {freq}"
-    advance_reg_twr = result.get("advance_registration_twr")
-    if advance_reg_twr:
-        try:
-            repo = ClearanceRepository(db)
-            repo.update_dependency(advance_reg_twr, "TWR")
-            logger.info("[ORCH] released to TWR — %s advanced to TWR", advance_reg_twr)
-        except Exception as exc:
-            logger.error("[ORCH] failed to advance %s to TWR: %s", advance_reg_twr, exc)
-
-    # Reverse handoff: an aircraft that just landed is released BACK to GND.
-    advance_reg_gnd_arrival = result.get("advance_registration_gnd_arrival")
-    if advance_reg_gnd_arrival:
-        try:
-            repo = ClearanceRepository(db)
-            updated = repo.update_dependency(advance_reg_gnd_arrival, "GND")
-            if not updated:
-                # Arrivals may not have a DEL-phase clearance row yet — create one.
-                repo.upsert(
-                    registration=advance_reg_gnd_arrival,
-                    session_id=session_id,
-                    squawk=0,
-                    initial_altitude=0,
-                    instrumental_departure="",
-                    runway_in_use="",
-                    altimeter=0.0,
-                    destination_icao="",
-                    clearance_text="",
-                    dependency="GND",
-                )
-            logger.info("[ORCH] arrival ground release — %s advanced to GND", advance_reg_gnd_arrival)
-        except Exception as exc:
-            logger.error("[ORCH] failed to reverse-advance %s to GND: %s", advance_reg_gnd_arrival, exc)
+    _persist_clearance(db, session_id, result)
+    _apply_dependency_advances(db, session_id, result)
 
     registration = result["registration"]
-    callsign = None
-    if registration:
-        aircraft = next((a for a in known_aircraft if a.get("registration") == registration), None)
-        if aircraft:
-            callsign = aircraft.get("callsign")
-
     return {
         "reply": result["reply"],
         "dependency": result["dependency"],
         "registration": registration,
-        "callsign": callsign,
+        "callsign": _callsign_for(known_aircraft, registration),
     }


### PR DESCRIPTION
> Stacked on #101 → #99 → #96 → #93. This PR's own diff is a single file: `services/orchestrator_service/runner.py`.

## What

The two worst functions in the orchestrator backend — `run_orchestrator_agent` (148 lines, cognitive complexity 36) and `_fetch_known_aircraft` (cognitive complexity 43).

### `run_orchestrator_agent` → 23 lines

It now names its three phases and nothing else:

```python
known_aircraft = _fetch_known_aircraft(db)
result = _invoke_agent(session_id, message, known_aircraft)
_persist_clearance(db, session_id, result)
_apply_dependency_advances(db, session_id, result)
```

- **`_invoke_agent`** owns the ADK session and its own event loop (with the comment explaining *why* it opens one), delegating to `_drain_events` — run to completion, keep the last final-response text — and `_read_agent_outcome` — read back what the tools left in state.
- **`_persist_clearance`** and **`_apply_dependency_advances`** are the two post-run writes; **`_callsign_for`** resolves the callsign for the response.
- The **three near-identical handoff blocks collapse into one** `_advance_dependency`, driven by a `_DEPENDENCY_ADVANCES` table. Their differences are now data: target phase, whether a missing row gets created (TWR keeps its no-create behaviour), and the exact log strings — every one of which is character-for-character unchanged.

### `_fetch_known_aircraft` → a three-line merge

One collector per source, each still degrading independently so an outage in any one never fails the dispatch:

```python
_collect_from_db(aircraft, db)
_collect_from_flight_plans(aircraft)
_collect_from_redis(aircraft)
```

The nesting is what made it complex, so it is gone: `_db_entry` early-returns for DEL aircraft instead of wrapping the clearance fields in an `if`, and `_merge_plan` / `_merge_live_aircraft` early-return instead of if/else-ing. Each `try` still spans exactly what it spanned before, so partial results from a source that fails mid-iteration are still kept.

## Behaviour is unchanged — including the part that is wrong

`_read_agent_outcome` still forwards **only** `advance_registration_gnd`, so the TWR and arrival handoffs still never reach the database. The two strict xfail tests in `test_runner.py` still xfail, and the code now carries an explicit comment saying so.

That is a real bug, not a refactor artifact — it is now filed as **#102**, with the fix (one line, plus dropping the two xfail markers) left for its own PR. This PR is a pure refactor and deliberately preserves it.

## Testing

`tests/unit/orchestrator/test_runner.py` is untouched — no assertion was adjusted. `pytest tests/unit/orchestrator tests/integration tests/debrief` — 259 passed, 2 xfailed. Full suite: 375 passed, 1 skipped, 4 xfailed.

Closes #56.