### PR TITLE
refactor(api): group long endpoint parameter lists into pydantic request models

### DIFF
--- a/openwiki/services/asr_service.md
+++ b/openwiki/services/asr_service.md
@@ -44,6 +44,12 @@ the caller supplied as two extra sentences ("Active callsigns: ...", "Expected S
 `use_initial_prompt=False` suppresses the prompt regardless of mode, kept for backward
 compatibility.
 
+All of those switches arrive as multipart form fields alongside the audio, and they are grouped in
+`TranscribeOptions` ([`api/schemas.py`](../../services/asr_service/api/schemas.py)) rather than
+listed one by one on the handler; `audio` stays a plain `UploadFile`. The model also owns the
+JSON-array-or-CSV parsing of `session_callsigns`/`session_sids` (`options.callsigns`,
+`options.sids`). Field names, defaults and the multipart contract are unchanged.
+
 ## The correction pipeline
 
 `api/routes.py` hands the raw Whisper string to

--- a/openwiki/services/weather_service.md
+++ b/openwiki/services/weather_service.md
@@ -45,7 +45,10 @@ LEVC, LEAL, LEZL, LEMG); anything else falls back to a generic two-runway defaul
 five-step lookup for transition level — FL65 when pressure is high, stepping up to FL90 as QNH
 drops below 978 hPa — and an in-memory counter per ICAO hands out a sequential ATIS letter with
 its phonetic name ("information ALFA"), wrapping back to A after Z. ATC can override the
-auto-picked runway, approach, QFE and remarks through query params on `GET /atis/{icao}`; a
+auto-picked runway, approach, QFE and remarks through query params on `GET /atis/{icao}` — they are
+grouped in the `ATISOptions` model
+([`models/schemas.py`](../../services/weather_service/models/schemas.py)) and bound with
+`Depends(ATISOptions.as_query)`, so the query string itself is unchanged; a
 `preview=true` flag runs the same generation without saving to PostgreSQL or advancing the letter —
 the HMI's own `/atis/generate` proxy exposes that same flag to the ATC-facing form.
 

--- a/services/asr_service/api/routes.py
+++ b/services/asr_service/api/routes.py
@@ -1,12 +1,12 @@
-import json
 import logging
 import os
 import time
 
 import httpx
-from fastapi import APIRouter, Form, UploadFile, File
+from fastapi import APIRouter, Depends, UploadFile, File
 
 from . import transcribe_service
+from .schemas import TranscribeOptions
 from core.config import get_settings, AVAILABLE_MODELS
 from core.postprocess import postprocess_transcription, FUZZY_THRESHOLD
 from core.llm_postprocess import llm_map_entities
@@ -40,23 +40,6 @@ def get_config():
     return get_settings().model_dump()
 
 
-def _parse_list_field(raw: str | None) -> list[str]:
-    """Parse a Form field that may be a JSON array (["A", "B"]) or a CSV string ("A,B")."""
-    if not raw:
-        return []
-    raw = raw.strip()
-    if not raw:
-        return []
-    if raw.startswith("["):
-        try:
-            parsed = json.loads(raw)
-            if isinstance(parsed, list):
-                return [str(v).strip() for v in parsed if str(v).strip()]
-        except json.JSONDecodeError:
-            logger.warning("[ASR] could not parse '%s' as JSON list — falling back to CSV", raw)
-    return [v.strip() for v in raw.split(",") if v.strip()]
-
-
 def _build_initial_prompt(
     context_mode: str, session_callsigns: list[str], session_sids: list[str],
 ) -> str | None:
@@ -81,31 +64,26 @@ def _build_initial_prompt(
 @router.post("/transcribe")
 async def transcribe(
     audio: UploadFile = File(...),
-    session_id: str = Form(""),
-    apply_corrections: bool = Form(True),
-    use_initial_prompt: bool = Form(True),
-    context_mode: str = Form("generic"),
-    session_callsigns: str | None = Form(None),
-    session_sids: str | None = Form(None),
-    llm_fallback: bool | None = Form(None),
+    options: TranscribeOptions = Depends(TranscribeOptions.as_form),
 ):
     audio_bytes = await audio.read()
     filename = audio.filename or "audio.webm"
     content_type = (audio.content_type or "audio/webm").split(";")[0].strip()
 
-    callsigns_list = _parse_list_field(session_callsigns)
-    sids_list = _parse_list_field(session_sids)
+    callsigns_list = options.callsigns
+    sids_list = options.sids
 
     # use_initial_prompt=False keeps overriding everything (backward compatible
     # with the pre-existing flag); otherwise the prompt follows context_mode.
     initial_prompt = (
-        _build_initial_prompt(context_mode, callsigns_list, sids_list)
-        if use_initial_prompt else None
+        _build_initial_prompt(options.context_mode, callsigns_list, sids_list)
+        if options.use_initial_prompt else None
     )
 
     logger.info(
         "[ASR] transcribe: %d bytes, file=%s, ct=%s, corrections=%s, context_mode=%s",
-        len(audio_bytes), filename, content_type, apply_corrections, context_mode,
+        len(audio_bytes), filename, content_type,
+        options.apply_corrections, options.context_mode,
     )
 
     raw_text, duration_s = await transcribe_service.transcribe_raw(
@@ -114,7 +92,7 @@ async def transcribe(
 
     cfg = get_settings()
 
-    if apply_corrections:
+    if options.apply_corrections:
         steps = postprocess_transcription(
             raw_text,
             session_callsigns=callsigns_list or None,
@@ -138,7 +116,7 @@ async def transcribe(
     # LLM fallback — only in session mode, when enabled, when we actually have
     # session lists AND the deterministic pass could not confidently resolve an
     # entity we have a list for (callsign, or SID if session SIDs were given).
-    llm_enabled = cfg.llm_fallback if llm_fallback is None else llm_fallback
+    llm_enabled = cfg.llm_fallback if options.llm_fallback is None else options.llm_fallback
     cs_unresolved = bool(callsigns_list) and (
         steps["cs_fuzzy_candidate"] is None or steps["cs_fuzzy_score"] < FUZZY_THRESHOLD
     )
@@ -150,8 +128,8 @@ async def transcribe(
     llm_applied = False
     llm_latency_s = 0.0
     if (
-        apply_corrections
-        and context_mode == "session"
+        options.apply_corrections
+        and options.context_mode == "session"
         and llm_enabled
         and (callsigns_list or sids_list)
         and deterministic_failed
@@ -174,7 +152,7 @@ async def transcribe(
         "postprocess_steps": steps,
         "duration_s": duration_s,
         "model": cfg.hf_model,
-        "context_mode": context_mode,
+        "context_mode": options.context_mode,
         "llm_applied": llm_applied,
         "llm_latency_s": llm_latency_s,
     }
@@ -185,7 +163,7 @@ async def transcribe(
             async with httpx.AsyncClient(timeout=60) as client:
                 dispatch_resp = await client.post(
                     f"{_ORCHESTRATOR_URL}/dispatch",
-                    json={"session_id": session_id, "message": final_text},
+                    json={"session_id": options.session_id, "message": final_text},
                 )
                 dispatch_resp.raise_for_status()
                 dispatch_data = dispatch_resp.json()

--- a/services/asr_service/api/schemas.py
+++ b/services/asr_service/api/schemas.py
@@ -1,0 +1,84 @@
+"""Request models for the ASR API.
+
+Keeps the endpoint signatures short (issue #64) and gives the multipart fields a
+single validated home instead of a flat parameter list on the handler.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from fastapi import Form
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+def parse_list_field(raw: str | None) -> list[str]:
+    """Parse a Form field that may be a JSON array (["A", "B"]) or a CSV string ("A,B")."""
+    if not raw:
+        return []
+    raw = raw.strip()
+    if not raw:
+        return []
+    if raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return [str(v).strip() for v in parsed if str(v).strip()]
+        except json.JSONDecodeError:
+            logger.warning("[ASR] could not parse '%s' as JSON list — falling back to CSV", raw)
+    return [v.strip() for v in raw.split(",") if v.strip()]
+
+
+class TranscribeOptions(BaseModel):
+    """Non-file fields of ``POST /transcribe``.
+
+    The audio itself stays an ``UploadFile`` parameter on the endpoint; only the
+    surrounding switches are grouped here. Bound to the request through
+    :meth:`as_form`, so the multipart contract is unchanged — same field names,
+    same defaults, same "everything is optional except the audio" behavior for
+    the HMI proxy, the X-Plane plugin and ``agents_evaluation/benchmark_asr.py``.
+    """
+
+    session_id: str = ""
+    apply_corrections: bool = True
+    use_initial_prompt: bool = True
+    context_mode: str = "generic"
+    session_callsigns: Optional[str] = None
+    session_sids: Optional[str] = None
+    llm_fallback: Optional[bool] = None
+
+    @classmethod
+    def as_form(
+        cls,
+        session_id: str = Form(""),
+        apply_corrections: bool = Form(True),
+        use_initial_prompt: bool = Form(True),
+        context_mode: str = Form("generic"),
+        session_callsigns: str | None = Form(None),
+        session_sids: str | None = Form(None),
+        llm_fallback: bool | None = Form(None),
+    ) -> "TranscribeOptions":
+        """FastAPI dependency: collect the multipart fields into a ``TranscribeOptions``."""
+        return cls(
+            session_id=session_id,
+            apply_corrections=apply_corrections,
+            use_initial_prompt=use_initial_prompt,
+            context_mode=context_mode,
+            session_callsigns=session_callsigns,
+            session_sids=session_sids,
+            llm_fallback=llm_fallback,
+        )
+
+    @property
+    def callsigns(self) -> list[str]:
+        """Active callsigns for this session, JSON array or CSV."""
+        return parse_list_field(self.session_callsigns)
+
+    @property
+    def sids(self) -> list[str]:
+        """Expected SIDs for this session, JSON array or CSV."""
+        return parse_list_field(self.session_sids)

--- a/services/weather_service/api/routes.py
+++ b/services/weather_service/api/routes.py
@@ -5,7 +5,14 @@ from fastapi import APIRouter, HTTPException, Depends, Query
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from models.schemas import ATISResponse, ATISRequest, MetarResponse, HealthResponse, CloudLayer
+from models.schemas import (
+    ATISOptions,
+    ATISRequest,
+    ATISResponse,
+    CloudLayer,
+    HealthResponse,
+    MetarResponse,
+)
 from core.atis_generator import ATISGenerator
 from core.metar_taf_fetcher import (
     NoWeatherDataError,
@@ -45,29 +52,12 @@ async def health_check():
 @router.get("/atis/{icao_code}", response_model=ATISResponse, tags=["ATIS"])
 async def generate_atis(
     icao_code: str,
-    departure_runway: Optional[str] = Query(None, description="Departure runway"),
-    arrival_runway: Optional[str] = Query(None, description="Arrival runway"),
-    approach: Optional[str] = Query(None, description="Approach type"),
-    qfe: Optional[int] = Query(None, description="QFE in hPa (set by ATC)"),
-    include_tl: bool = Query(True, description="Include Transition Level in ATIS"),
-    include_ta: bool = Query(True, description="Include Transition Altitude in ATIS"),
-    remarks: Optional[str] = Query(None, description="ATC remarks (appended as RMK)"),
-    preview: bool = Query(False, description="Preview mode: no DB save, letter not incremented"),
-    db: Session = Depends(get_db)
+    options: ATISOptions = Depends(ATISOptions.as_query),
+    db: Session = Depends(get_db),
 ):
     """Generate ATIS for an airport"""
     try:
-        atis = await generator.generate(
-            icao_code=icao_code,
-            departure_runway=departure_runway,
-            arrival_runway=arrival_runway,
-            approach=approach,
-            qfe=qfe,
-            include_tl=include_tl,
-            include_ta=include_ta,
-            remarks=remarks,
-            preview=preview,
-        )
+        atis = await generator.generate(icao_code=icao_code, **options.model_dump())
     except NoWeatherDataError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except WeatherUpstreamError as e:
@@ -78,7 +68,7 @@ async def generate_atis(
             status_code=502, detail=f"Malformed METAR data for {icao_code.upper()}"
         )
 
-    if not preview:
+    if not options.preview:
         try:
             repo = ATISRepository(db)
             repo.create(atis)

--- a/services/weather_service/models/schemas.py
+++ b/services/weather_service/models/schemas.py
@@ -1,6 +1,8 @@
-from pydantic import BaseModel
-from typing import Optional
 from datetime import datetime
+from typing import Optional
+
+from fastapi import Query
+from pydantic import BaseModel
 
 
 class CloudLayer(BaseModel):
@@ -61,6 +63,57 @@ class ATISRequest(BaseModel):
     icao_code: str
     runway_in_use: Optional[str] = None
     approach_type: Optional[str] = None
+
+
+class ATISOptions(BaseModel):
+    """ATC overrides for ``GET /atis/{icao_code}``.
+
+    Everything the controller can set on a broadcast, grouped so the endpoint
+    signature stays short (issue #64). All fields are optional: whatever is not
+    provided is derived from the METAR (runways, approach) or defaults to the
+    values below.
+
+    Bound to the request through :meth:`as_query`, which keeps the endpoint a
+    plain query-string GET — same parameter names, defaults and descriptions as
+    before, so existing clients (HMI proxy, X-Plane plugin, scripts) are
+    unaffected. The adapter is used instead of FastAPI's native query models
+    because the service image pins ``fastapi==0.109.0``, which predates them.
+    """
+
+    departure_runway: Optional[str] = None
+    arrival_runway: Optional[str] = None
+    approach: Optional[str] = None
+    qfe: Optional[int] = None
+    include_tl: bool = True
+    include_ta: bool = True
+    remarks: Optional[str] = None
+    preview: bool = False
+
+    @classmethod
+    def as_query(
+        cls,
+        departure_runway: Optional[str] = Query(None, description="Departure runway"),
+        arrival_runway: Optional[str] = Query(None, description="Arrival runway"),
+        approach: Optional[str] = Query(None, description="Approach type"),
+        qfe: Optional[int] = Query(None, description="QFE in hPa (set by ATC)"),
+        include_tl: bool = Query(True, description="Include Transition Level in ATIS"),
+        include_ta: bool = Query(True, description="Include Transition Altitude in ATIS"),
+        remarks: Optional[str] = Query(None, description="ATC remarks (appended as RMK)"),
+        preview: bool = Query(
+            False, description="Preview mode: no DB save, letter not incremented"
+        ),
+    ) -> "ATISOptions":
+        """FastAPI dependency: collect the query string into an ``ATISOptions``."""
+        return cls(
+            departure_runway=departure_runway,
+            arrival_runway=arrival_runway,
+            approach=approach,
+            qfe=qfe,
+            include_tl=include_tl,
+            include_ta=include_ta,
+            remarks=remarks,
+            preview=preview,
+        )
 
 
 class MetarResponse(BaseModel):

--- a/tests/weather/test_request_models.py
+++ b/tests/weather/test_request_models.py
@@ -1,0 +1,109 @@
+"""Contract tests for the grouped ATIS request model (issue #64).
+
+`generate_atis` used to take nine flat parameters; they now live in
+`models.schemas.ATISOptions`. The HTTP contract must be untouched, so these
+tests lock the query-parameter names, defaults and descriptions that the
+OpenAPI schema exposes to the HMI proxy and the other clients.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+
+from tests.weather.service_imports import routes, schemas
+
+PREFIX = "/api/v1/weather"
+
+EXPECTED_QUERY_PARAMS = {
+    "departure_runway": ("Departure runway", None),
+    "arrival_runway": ("Arrival runway", None),
+    "approach": ("Approach type", None),
+    "qfe": ("QFE in hPa (set by ATC)", None),
+    "include_tl": ("Include Transition Level in ATIS", True),
+    "include_ta": ("Include Transition Altitude in ATIS", True),
+    "remarks": ("ATC remarks (appended as RMK)", None),
+    "preview": ("Preview mode: no DB save, letter not incremented", False),
+}
+
+
+@pytest.fixture(scope="module")
+def atis_operation() -> dict:
+    app = FastAPI()
+    app.include_router(routes.router, prefix=PREFIX)
+    return app.openapi()["paths"][f"{PREFIX}/atis/{{icao_code}}"]["get"]
+
+
+def test_the_endpoint_still_exposes_every_query_parameter(atis_operation):
+    names = {p["name"] for p in atis_operation["parameters"] if p["in"] == "query"}
+
+    assert names == set(EXPECTED_QUERY_PARAMS)
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_QUERY_PARAMS))
+def test_query_parameter_metadata_is_preserved(atis_operation, name):
+    param = next(p for p in atis_operation["parameters"] if p["name"] == name)
+    description, default = EXPECTED_QUERY_PARAMS[name]
+
+    assert param["in"] == "query"
+    assert param["required"] is False
+    assert param["description"] == description
+    assert param["schema"].get("default") == default
+
+
+def test_icao_code_stays_a_path_parameter(atis_operation):
+    icao = next(p for p in atis_operation["parameters"] if p["name"] == "icao_code")
+
+    assert icao["in"] == "path"
+    assert icao["required"] is True
+
+
+# ---------------------------------------------------------------------------
+# The model itself
+# ---------------------------------------------------------------------------
+
+
+def test_defaults_match_the_previous_signature():
+    options = schemas.ATISOptions()
+
+    assert options.model_dump() == {
+        "departure_runway": None,
+        "arrival_runway": None,
+        "approach": None,
+        "qfe": None,
+        "include_tl": True,
+        "include_ta": True,
+        "remarks": None,
+        "preview": False,
+    }
+
+
+def test_as_query_collects_the_parameters():
+    options = schemas.ATISOptions.as_query(
+        departure_runway="17",
+        arrival_runway="35",
+        approach="ILS",
+        qfe=990,
+        include_tl=False,
+        include_ta=False,
+        remarks="birds",
+        preview=True,
+    )
+
+    assert options.departure_runway == "17"
+    assert options.arrival_runway == "35"
+    assert options.approach == "ILS"
+    assert options.qfe == 990
+    assert options.include_tl is False
+    assert options.include_ta is False
+    assert options.remarks == "birds"
+    assert options.preview is True
+
+
+def test_model_dump_matches_the_generator_keyword_arguments():
+    """``generate_atis`` splats the model into ``ATISGenerator.generate``."""
+    import inspect
+
+    generate_params = set(inspect.signature(routes.generator.generate).parameters)
+
+    assert set(schemas.ATISOptions().model_dump()) | {"icao_code"} == generate_params


### PR DESCRIPTION
> Stacked on #100 (`feat/63-async-httpx`). Review that one first; this PR's diff against `dev` will collapse once #100 merges.

## What

Two endpoints had grown a flat parameter list long enough to bury the handler body (the `param_count` metric in the issue): `generate_atis` (9 parameters) and `transcribe` (7 form fields + the upload).

### `weather_service` — `GET /atis/{icao_code}`

`models/schemas.py` gains `ATISOptions`, grouping the eight ATC overrides (`departure_runway`, `arrival_runway`, `approach`, `qfe`, `include_tl`, `include_ta`, `remarks`, `preview`). The endpoint is now:

```python
async def generate_atis(
    icao_code: str,
    options: ATISOptions = Depends(ATISOptions.as_query),
    db: Session = Depends(get_db),
):
    atis = await generator.generate(icao_code=icao_code, **options.model_dump())
```

### `asr_service` — `POST /transcribe`

`api/schemas.py` (new) gains `TranscribeOptions`, grouping the seven **non-file** fields (`session_id`, `apply_corrections`, `use_initial_prompt`, `context_mode`, `session_callsigns`, `session_sids`, `llm_fallback`). `audio` stays a plain `UploadFile = File(...)`, as the issue asks for multipart endpoints. The JSON-array-or-CSV parsing of the session lists moves onto the model as the `callsigns`/`sids` properties, so `_parse_list_field` no longer sits loose in `routes.py`.

`core/postprocess.py` was not touched (another agent is refactoring it).

### Why `as_query`/`as_form` instead of FastAPI's native models

FastAPI's query-parameter models landed in 0.115 and form models in 0.113. The weather image pins `fastapi==0.109.0` and the ASR service requires `>=0.111`, so both predate the feature. The classmethod adapter is the version-proof equivalent, keeps the pydantic model as the single source of truth, and produces exactly the same OpenAPI. Documented in the model docstrings so it does not read as cargo cult.

## The contract is identical — verified, not assumed

- **Weather**: dumped the OpenAPI `parameters` block of every weather endpoint on `dev` and on this branch and diffed them — **identical**, including each parameter's `in`, `required`, `description` and `schema.default`.
- **ASR**: dumped the `multipart/form-data` schema and drove `POST /transcribe` through `TestClient` on `dev` and on this branch (real multipart body, transcription/postprocess stubbed). Same output on both sides: `required: ['audio']`, same eight properties with the same defaults, same parsed callsigns/SIDs, same generated `initial_prompt`, same 422 when `audio` is missing.

**Callers grepped and checked, none needed a change:**

| Caller | Why it is unaffected |
|---|---|
| `services/controller_hmi_service/api/routes.py::generate_atis` | builds the same query-param dict and forwards it |
| `services/controller_hmi_service/api/routes.py::proxy_asr_transcribe` | forwards the raw multipart body byte-for-byte |
| `frontend/src/legacy/atis.ts`, `types/api.ts` | talk to the HMI proxy, same JSON body |
| `services/orchestrator_service/agent/tools/forward.py`, `api/weather.py` | only hit `/atis/{icao}` and `/atis/{icao}/latest` with no options |
| `agents_evaluation/benchmark_asr.py` | posts `context_mode`, `session_callsigns`, `session_sids` — same field names |
| `xplane_plugin/` | does not call either endpoint |

## Testing

- New `tests/weather/test_request_models.py`: asserts the endpoint still exposes exactly the eight query params, each with its original description, `required: false` and default; that `icao_code` stays a path param; that `ATISOptions()` defaults match the old signature; and that `model_dump()` keys still line up with `ATISGenerator.generate`'s keyword arguments.
- `pytest -q` -> **371 passed, 1 skipped, 4 xfailed**.
- No automated test for the ASR endpoint: the service cannot be imported in this venv (`pydantic_settings`, `python-multipart` and `rapidfuzz` are not test dependencies), which is also why `tests/` has no ASR suite today. Covered by the manual before/after `TestClient` comparison described above.

## Docs

openwiki updated: `services/weather_service.md` (`ATISOptions` + `as_query`) and `services/asr_service.md` (`TranscribeOptions` owns the form fields and the list parsing).

Closes #64
