### PR TITLE
build(lint): configure ruff and add a non-blocking CI lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,34 @@ jobs:
           path: coverage.xml
           if-no-files-found: warn
 
+  # Non-blocking on purpose (issue #48): ruff is configured here but the repo
+  # has not been reformatted yet, so this job reports style drift without
+  # gating anything. It becomes blocking in the follow-up PR that applies
+  # `ruff check --fix` + `ruff format` across the codebase.
+  lint:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install lint tooling
+        run: uv sync --only-group dev
+
+      - name: ruff check
+        continue-on-error: true
+        run: uv run ruff check --output-format=github
+
+      # Reported only, never enforced yet — the repo-wide reformat is a
+      # separate PR so it does not collide with the branches in flight.
+      - name: ruff format (report only)
+        continue-on-error: true
+        run: uv run ruff format --check
+
   # The per-service requirements.txt files are generated from the extras in
   # pyproject.toml; this catches a change to one that was not propagated.
   deps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,24 @@ uv sync --extra analysis # + notebooks, plots and ASR benchmarking
 uv run pytest
 ```
 
+## Linting
+
+[Ruff](https://docs.astral.sh/ruff/) is configured in `pyproject.toml` under
+`[tool.ruff]` and installed with the `dev` dependency group (`uv sync` pulls it
+in by default):
+
+```bash
+uv run ruff check          # lint
+uv run ruff check --fix    # autofix, on the files you touched
+uv run ruff format         # format, on the files you touched
+```
+
+The ruleset is deliberately small for now (`E`, `W`, `F`, `I`) and the CI lint
+job is **non-blocking**: the codebase has not been reformatted yet, so ruff
+reports drift without gating merges. Please do not run `ruff format` or
+`ruff check --fix` across the whole repo in a feature branch — the repo-wide
+pass is its own PR. The job becomes blocking once that lands.
+
 ## Dependency layout
 
 The root `pyproject.toml` is the **single source of truth** for Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,8 +144,52 @@ test = [
     "respx>=0.20",
 ]
 
+# Tooling installed for development only; never shipped in a service image.
+# `uv sync` installs this group by default.
+[dependency-groups]
+dev = [
+    "ruff>=0.14",
+]
+
 [tool.setuptools.packages.find]
 include = ["xplane_plugin*"]
+
+# ---------------------------------------------------------------------------
+# Ruff — deliberately lax first pass (issue #48).
+#
+# The goal is a signal, not a wall: the CI lint job is non-blocking and the
+# repo has NOT been reformatted yet. A repo-wide `ruff format` + `ruff check
+# --fix` lands as its own PR once the branches currently in flight are merged,
+# so the diff does not collide with them.
+# ---------------------------------------------------------------------------
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+extend-exclude = [
+    "data",
+    "logs",
+    "output",
+    "transcription",
+]
+
+[tool.ruff.lint]
+# pycodestyle (E/W), pyflakes (F), isort (I). Nothing opinionated yet;
+# UP/B/SIM come later, one rule family per PR.
+select = ["E", "W", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+# Re-export surfaces: names are imported to be part of the public API.
+"**/__init__.py" = ["F401"]
+# The X-Plane plugins run inside the simulator's own interpreter and must
+# patch sys.path before importing anything from the repo.
+"plugins/**" = ["E402"]
+"xplane_plugin/**" = ["E402"]
+# pytest fixtures shadow their own names; conftest patches sys.path too.
+"tests/**" = ["E402", "F811"]
+"**/conftest.py" = ["E402"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["shared", "plugins", "xplane_plugin"]
 
 [tool.pytest.ini_options]
 pythonpath = [".", "services/orchestrator_service", "services/arrival_simulator_service"]

--- a/uv.lock
+++ b/uv.lock
@@ -175,6 +175,11 @@ weather = [
     { name = "sqlalchemy" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'asr'", specifier = ">=0.30" },
@@ -236,6 +241,9 @@ requires-dist = [
     { name = "xplane-airports", marker = "extra == 'controller-hmi'", specifier = ">=4.0" },
 ]
 provides-extras = ["service-core", "agents", "orchestrator", "asr", "arrival-simulator", "flight-plan", "weather", "pilots-communication", "controller-hmi", "analysis", "test"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.14" }]
 
 [[package]]
 name = "annotated-doc"
@@ -2667,6 +2675,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/24/e3e72d265121e00b063aef3e3501e5b2473cf1b23511d56e529531acf01e/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:94c44ee01fd21c9058f124d2d4f0c9dc7634bec93cd4b38eefc385dabe71acbf", size = 560003, upload-time = "2025-08-27T12:16:08.06Z" },
     { url = "https://files.pythonhosted.org/packages/26/ca/f5a344c534214cc2d41118c0699fffbdc2c1bc7046f2a2b9609765ab9c92/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:df8b74962e35c9249425d90144e721eed198e6555a0e22a563d29fe4486b51f6", size = 590482, upload-time = "2025-08-27T12:16:10.137Z" },
     { url = "https://files.pythonhosted.org/packages/ce/08/4349bdd5c64d9d193c360aa9db89adeee6f6682ab8825dca0a3f535f434f/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:dc23e6820e3b40847e2f4a7726462ba0cf53089512abe9ee16318c366494c17a", size = 556523, upload-time = "2025-08-27T12:16:12.188Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> Stacked on #105 (`feat/62-deps-consolidation`). Review only the last commit;
> merge #105 first and this retargets to `dev`.

## What

The repo had no linter or formatter configured, so ~230 Python files each
followed their own style.

- `ruff` added to a new `dev` dependency group (`uv sync` installs it by
  default).
- `[tool.ruff]` with a deliberately **lax** first ruleset: pycodestyle (`E`,
  `W`), pyflakes (`F`) and isort (`I`), at a generous 120-column limit.
  `UP`/`B`/`SIM` are left for later, one family per PR.
- Per-file ignores where the code is right and the rule is wrong: `F401` in
  `__init__.py` re-export surfaces, `E402` under `plugins/` and
  `xplane_plugin/` (they must patch `sys.path` before importing repo code) and
  in the test tree, `F811` in tests.
- A `lint` job in `ci.yml` running `ruff check` and `ruff format --check`,
  both **non-blocking** (`continue-on-error` at job and step level, so the
  format step still reports when the check step fails).

## This PR does not reformat anything

**No source file is touched — this is configuration only.** A repo-wide
`ruff check --fix` + `ruff format` is a deliberate **follow-up PR**, to be
applied once the branches currently in flight have merged. Running it now
would rewrite most of the codebase and conflict with every one of them. The
lint job becomes blocking in that same follow-up.

## Baseline

`ruff check` reports **330 findings, 227 autofixable**:

| Count | Rule |
|---|---|
| 110 | `I001` unsorted-imports |
| 69 | `W293` blank-line-with-whitespace |
| 52 | `E702` multiple-statements-on-one-line-semicolon (43 of them in `scripts/plot_asr_benchmark.py`) |
| 27 | `E501` line-too-long |
| 24 | `F401` unused-import |
| 21 | `W291` trailing-whitespace |
| 9 | `E402`, 7 `W292`, 5 `E741`, 3 `F541`, 3 `F841` | |

Nothing structural — it is whitespace, import order and dead imports, which is
what makes the mass-format PR safe to do in one shot later.

## Verification

`351 passed, 1 skipped, 2 xfailed` on this branch.

Closes #48
