### PR TITLE
ci(coverage): enforce the coverage gate instead of overriding it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,10 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra test
 
-      # Coverage is informational for now: --cov-fail-under=0 overrides the
-      # fail_under=70 gate in pyproject.toml so the build never fails on the
-      # coverage number while we establish a baseline.
-      - name: Run test suite (coverage informational)
-        run: uv run pytest --cov --cov-report=xml --cov-report=term --cov-fail-under=0
+      # The coverage gate comes from [tool.coverage.report] fail_under in
+      # pyproject.toml and is enforced here: a drop below it fails the build.
+      - name: Run test suite
+        run: uv run pytest --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage report
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,4 +249,8 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "if __name__ == .__main__.:",
 ]
-fail_under = 70
+# Real gate, enforced in CI (issue #47). Measured baseline on the branch point
+# for this change: 86.29% (773 statements, 106 missed). The threshold is
+# baseline - 2, rounded down, as a buffer against line-count noise; raise it in
+# follow-up PRs as coverage grows.
+fail_under = 84


### PR DESCRIPTION
> Stacked on #106 (`feat/48-ruff-config`), which is stacked on #105. Review only
> the last commit.

## What

`ci.yml` ran `pytest --cov-fail-under=0`, overriding the `fail_under` in
`pyproject.toml`, with a comment saying coverage was "informational for now […]
while we establish a baseline". Coverage could degrade silently and never fail
the build.

- Measured the baseline.
- `fail_under` in `pyproject.toml`: **70 → 84**.
- `--cov-fail-under=0` and the "informational for now" comment removed from
  `.github/workflows/ci.yml`.

## Measured baseline

Run on this branch point (current `dev`), the same invocation CI uses:

```
351 passed, 1 skipped, 2 xfailed
TOTAL   773 statements   106 missed   86.29%
```

**Baseline 86.29%.** Gate = 86.29 − 2 = 84.29, **rounded down to 84**, as the
issue prescribes. `Required test coverage of 84.0% reached. Total coverage:
86.29%` — CI has 2.29 points of headroom.

Worth noting the number is much higher than the aspirational 70 that was
already in `pyproject.toml`: the taxi-router test work merged into `dev`
recently (#83–#87) moved it a long way.

No test failures unrelated to this change. The 2 xfails and 1 skip are
pre-existing and documented in-place (the `runner.py` handoff bug and the
`find_nearest_node` precedence bug).

## Known limitation — flagged, not papered over

Ten of the sixteen entries in `[tool.coverage.run] source` are plain **file**
paths (`services/orchestrator_service/runner.py`, `session_log.py`,
`debrief_builder.py`, `config.py`, `frequency_audit.py`, and the five
`arrival_simulator_service/core/*.py`). `coverage.py` only accepts packages or
directories there, so it drops each one with a `module-not-imported` warning
and they never appear in the report — even though the test suite *does* import
several of them.

So 86.29% is measured over six of the sixteen intended entries. That is
pre-existing, and fixing it changes *what* is measured, which would invalidate
any baseline set in the same PR. It belongs in its own PR where the gate can be
re-baselined against the corrected `source` list. Recorded in the commit
message so it is not lost.

Closes #47
