### PR TITLE
build(types): adopt mypy with shared/ as the first strict package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,25 @@ jobs:
         continue-on-error: true
         run: uv run ruff format --check
 
+  # Blocking, but narrow: only the packages listed below are strict-checked
+  # (see the [[tool.mypy.overrides]] block in pyproject.toml). Widen the scope
+  # one package at a time.
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra test
+
+      - name: mypy
+        run: uv run mypy shared
+
   # The per-service requirements.txt files are generated from the extras in
   # pyproject.toml; this catches a change to one that was not propagated.
   deps:

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,6 +1,0 @@
-[mypy]
-mypy_path = C:\X-Plane 12\Resources\plugins:C:\X-Plane 12\Resources\plugins\XPPython3
-check_untyped_defs = True
-
-[mypy-OpenGL.*]
-    ignore_missing_imports = True

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,36 @@ reports drift without gating merges. Please do not run `ruff format` or
 `ruff check --fix` across the whole repo in a feature branch — the repo-wide
 pass is its own PR. The job becomes blocking once that lands.
 
+## Type checking
+
+[Mypy](https://mypy.readthedocs.io/) is configured in `pyproject.toml` under
+`[tool.mypy]` and ships in the same `dev` group:
+
+```bash
+uv run mypy shared
+```
+
+Adoption is **gradual**. The global settings are lax so unannotated modules
+never block work; strictness is opted into one package at a time through a
+`[[tool.mypy.overrides]]` block. `shared/` is strict today and the `typecheck`
+CI job enforces it.
+
+To add a package to the check:
+
+1. Add its module pattern to the `module = ["shared.*"]` list in the strict
+   `[[tool.mypy.overrides]]` block in `pyproject.toml`.
+2. Add the path to the `mypy` invocation in the `typecheck` job of
+   `.github/workflows/ci.yml`.
+3. Run `uv run mypy <path>` and fix what it reports before opening the PR —
+   annotations only, no logic changes.
+
+If you develop the X-Plane plugin locally and want the XPPython3 stubs
+resolved, export `MYPYPATH` instead of committing a machine-specific path:
+
+```bash
+export MYPYPATH="/path/to/X-Plane 12/Resources/plugins/XPPython3"
+```
+
 ## Dependency layout
 
 The root `pyproject.toml` is the **single source of truth** for Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ test = [
 [dependency-groups]
 dev = [
     "ruff>=0.14",
+    "mypy>=1.11",
 ]
 
 [tool.setuptools.packages.find]
@@ -190,6 +191,38 @@ select = ["E", "W", "F", "I"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["shared", "plugins", "xplane_plugin"]
+
+# ---------------------------------------------------------------------------
+# Mypy — gradual adoption, package by package (issue #50).
+#
+# The global settings are lax so type checking never blocks work on modules
+# that have not been annotated yet. Strictness is opted into per package with
+# an override block; `shared/` is the first one because it has the highest
+# fan-in. To add a package, append its module pattern to the strict override
+# below and to the `mypy` invocation in the CI type-check job.
+# ---------------------------------------------------------------------------
+[tool.mypy]
+python_version = "3.11"
+# Third-party packages here ship no stubs (google-adk, xplane-airports,
+# faster-whisper, ...); do not fail on that.
+ignore_missing_imports = true
+follow_imports = "silent"
+warn_unused_configs = true
+show_error_codes = true
+pretty = true
+warn_redundant_casts = true
+
+# Strict for shared/ only.
+[[tool.mypy.overrides]]
+module = ["shared.*"]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_calls = true
+check_untyped_defs = true
+no_implicit_optional = true
+strict_equality = true
+warn_return_any = true
+warn_unused_ignores = true
 
 [tool.pytest.ini_options]
 pythonpath = [".", "services/orchestrator_service", "services/arrival_simulator_service"]

--- a/shared/models/aircraft.py
+++ b/shared/models/aircraft.py
@@ -36,8 +36,8 @@ class DelClearence:
     lat: float
     lon: float
     squawk: int
-    initial_altitude: int = 6000
     intrumental_departure: str
     runway_in_use: str
     altimeter: float
+    initial_altitude: int = 6000
     

--- a/shared/models/aircraft_state.py
+++ b/shared/models/aircraft_state.py
@@ -34,7 +34,7 @@ class AircraftState:
 
     timestamp: Optional[str] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.timestamp is None:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 

--- a/shared/models/command_parser.py
+++ b/shared/models/command_parser.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 from dataclasses import dataclass
 from enum import Enum
 
@@ -71,9 +71,9 @@ class ParsedCommand:
     raw_transcription: str = ""
     language: str = "en"
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         """Convierte a diccionario para JSON/MQTT"""
-        result = {
+        result: dict[str, Any] = {
             'intent': self.intent.value,
             'callsign': self.callsign,
             'confidence': self.confidence,

--- a/shared/models/communications.py
+++ b/shared/models/communications.py
@@ -11,8 +11,8 @@ class HandOff:
 
 class Frequencies(Enum):
 
-    ATIS: float = 121.980
-    DEL: float = 121.805
-    GND: float = 121.655
-    TWR: float = 118.330
+    ATIS = 121.980
+    DEL = 121.805
+    GND = 121.655
+    TWR = 118.330
     

--- a/shared/services/aircraft_state_store.py
+++ b/shared/services/aircraft_state_store.py
@@ -1,7 +1,7 @@
 import json
 import os
 import threading
-from typing import Optional
+from typing import Any, Optional, cast
 
 import redis
 from influxdb_client import InfluxDBClient
@@ -9,7 +9,7 @@ from influxdb_client import InfluxDBClient
 from ..models.aircraft_state import AircraftState
 
 
-def _load_env():
+def _load_env() -> None:
     """Load .env file into os.environ"""
     env_path = os.path.join(os.path.dirname(__file__), "..", "..", ".env")
     try:
@@ -33,7 +33,9 @@ _UPDATES_CHANNEL = "aircraft:updates"
 _STATE_TTL_SECONDS = 3600
 
 
-def _get_redis_client():
+# See the note in airport_data_store: redis-py's stubs type the sync client
+# as `Awaitable[T] | T`, so it stays `Any` here too.
+def _get_redis_client() -> Any:
     host = os.getenv("REDIS_HOST", "localhost")
     port = int(os.getenv("REDIS_PORT", 6379))
     db = int(os.getenv("REDIS_DB", 0))
@@ -43,25 +45,25 @@ def _get_redis_client():
 class AircraftStateStore:
     """Manages aircraft state in Redis and InfluxDB."""
 
-    def __init__(self, redis_client=None, influx_client=None):
+    def __init__(self, redis_client: Any = None, influx_client: Any = None) -> None:
         self._r = redis_client or _get_redis_client()
         self._influx = influx_client
         self._influx_write_api = None
 
         # Buffer for batching InfluxDB writes
-        self._influx_buffer = []
+        self._influx_buffer: list[Any] = []
         self._influx_buffer_lock = threading.Lock()
         self._influx_flush_size = 20  # flush every N points
 
         if self._influx is not None:
             self._init_influx()
 
-    def _init_influx(self):
+    def _init_influx(self) -> None:
         """Initialise the InfluxDB write API."""
         self._influx_write_api = self._influx.write_api()
 
 
-    def connect_influx(self):
+    def connect_influx(self) -> None:
         """Connect to InfluxDB. Called when the session starts."""
         try:
             url = os.getenv("INFLUXDB_URL", "http://localhost:8087")
@@ -102,7 +104,7 @@ class AircraftStateStore:
                 if len(self._influx_buffer) >= self._influx_flush_size:
                     self._flush_influx()
 
-    def _flush_influx(self):
+    def _flush_influx(self) -> None:
         """Write buffered points to InfluxDB. Must hold _influx_buffer_lock."""
         if not self._influx_buffer or self._influx_write_api is None:
             return
@@ -117,7 +119,7 @@ class AircraftStateStore:
         finally:
             self._influx_buffer.clear()
 
-    def flush(self):
+    def flush(self) -> None:
         """Force-flush any remaining InfluxDB buffer (call on session end)."""
         with self._influx_buffer_lock:
             self._flush_influx()
@@ -142,7 +144,7 @@ class AircraftStateStore:
 
     def get_active_registrations(self) -> set[str]:
         """Return the set of currently tracked aircraft registrations."""
-        return self._r.smembers(_ACTIVE_SET_KEY)
+        return cast(set, self._r.smembers(_ACTIVE_SET_KEY))
 
     # Read (historical from InfluxDB)
 
@@ -213,7 +215,7 @@ class AircraftStateStore:
         pipe.delete(_ACTIVE_SET_KEY)
         pipe.execute()
 
-    def close(self):
+    def close(self) -> None:
         """Flush buffers and close connections."""
         self.flush()
         if self._influx is not None:

--- a/shared/services/aircraft_tracker.py
+++ b/shared/services/aircraft_tracker.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from XPPython3 import xp
 
 from ..models.aircraft_state import AircraftState
@@ -23,9 +25,9 @@ class AircraftTracker:
     Tracks aircraft positions at 2 Hz using X-Plane flight loops.
     """
 
-    def __init__(self, store: AircraftStateStore):
+    def __init__(self, store: AircraftStateStore) -> None:
         self._store = store
-        self._flight_loop_id = None
+        self._flight_loop_id: Any = None
         self._running = False
 
         # Session metadata
@@ -35,10 +37,10 @@ class AircraftTracker:
         self._user_callsign = "USER"
 
         # Cached dataref handles (resolved once on start)
-        self._user_dref_handles = {}
+        self._user_dref_handles: dict[str, Any] = {}
 
         # AI aircraft registry: registration -> {datarefs, metadata}
-        self._ai_aircraft = {}
+        self._ai_aircraft: dict[str, dict[str, Any]] = {}
 
 
     def set_session(self, session_id: str) -> None:
@@ -143,7 +145,13 @@ class AircraftTracker:
 
     # -- Flight loop callback -------------------------------------------------
 
-    def _flight_loop_cb(self, sinceLast, elapsedTime, counter, refCon):
+    def _flight_loop_cb(
+        self,
+        sinceLast: float,
+        elapsedTime: float,
+        counter: int,
+        refCon: Any,
+    ) -> float:
         """Called by X-Plane at 2 Hz. Returns -2 to keep 2 Hz schedule."""
         if not self._running:
             return 0  # stop

--- a/shared/services/airport_data_store.py
+++ b/shared/services/airport_data_store.py
@@ -2,14 +2,18 @@ import json
 import os
 import uuid
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional, cast
 import redis
 
 
 _PREFIX = "airport:current"
 
 
-def _get_redis_client():
+# NOTE: redis-py types its sync commands as `Awaitable[T] | T` (the same
+# stubs serve the asyncio client), so a precise annotation here would make
+# every call site a union. The client stays `Any` and the public methods
+# below carry the real return types.
+def _get_redis_client() -> Any:
     """Create a Redis client from environment variables."""
     host = os.getenv("REDIS_HOST", "localhost")
     port = int(os.getenv("REDIS_PORT", 6379))
@@ -20,7 +24,7 @@ def _get_redis_client():
 class AirportDataStore:
     """Read/write parsed airport data in Redis."""
 
-    def __init__(self, client=None):
+    def __init__(self, client: Any = None) -> None:
         self._r = client or _get_redis_client()
 
     def store(self, icao: str, parsed_data: dict) -> None:
@@ -74,7 +78,7 @@ class AirportDataStore:
 
     def get_icao(self) -> Optional[str]:
         """Return the ICAO code of the currently stored airport."""
-        return self._r.get(f"{_PREFIX}:icao")
+        return cast(Optional[str], self._r.get(f"{_PREFIX}:icao"))
 
     def get_com_frequencies(self) -> list:
         """Return parsed COM frequencies for the current airport, or []."""
@@ -107,7 +111,7 @@ class AirportDataStore:
 
     def is_stand_occupied(self, stand_id: str) -> bool:
         """Return True if the stand is currently occupied."""
-        return self._r.hget(self._OCCUPANCY_KEY, stand_id) == "1"
+        return bool(self._r.hget(self._OCCUPANCY_KEY, stand_id) == "1")
 
     def get_stands_with_occupancy(self) -> list:
         """Return stands list with an 'occupied' bool field added to each."""
@@ -128,7 +132,7 @@ class AirportDataStore:
             else:
                 stand["occupied"] = False
 
-        return stands
+        return cast(list, stands)
 
     # Session management
     _SESSION_KEY = "session:current"
@@ -155,7 +159,7 @@ class AirportDataStore:
         data = self._r.hgetall(self._SESSION_KEY)
         return data if data else None
 
-    def _delete_current(self, pipe) -> None:
+    def _delete_current(self, pipe: Any) -> None:
         """Delete all keys under the current airport prefix."""
         keys = self._r.keys(f"{_PREFIX}:*")
         if keys:

--- a/shared/services/stand_assigner.py
+++ b/shared/services/stand_assigner.py
@@ -1,4 +1,5 @@
 import random
+from typing import Optional, cast
 
 # ICAO width code ordering for size comparison
 _WIDTH_ORDER = {"A": 0, "B": 1, "C": 2, "D": 3, "E": 4, "F": 5}
@@ -50,7 +51,7 @@ class StandAssigner:
 
         return assignments
 
-    def _find_compatible(self, aircraft_type: str, available: list):
+    def _find_compatible(self, aircraft_type: str, available: list) -> Optional[dict]:
         """Find first available stand compatible with this aircraft type."""
         classification = _AIRCRAFT_CLASSIFICATION.get(aircraft_type)
         if classification is None:
@@ -81,6 +82,6 @@ class StandAssigner:
             if not is_ga and stand.get("stand_type", "") != "gate":
                 continue
 
-            return stand
+            return cast(dict, stand)
 
         return None

--- a/shared/services/taxi_router/hmi_chat.py
+++ b/shared/services/taxi_router/hmi_chat.py
@@ -7,13 +7,13 @@ used when a pilot readback is unroutable ("unable, request alternative").
 
 import json
 import time
-from typing import Optional
+from typing import Any, Optional
 
 from . import config
 
 
 def publish_pilot_message(
-    redis_client,
+    redis_client: Any,
     *,
     callsign: str,
     registration: str,

--- a/shared/services/taxi_router/router.py
+++ b/shared/services/taxi_router/router.py
@@ -21,7 +21,7 @@ import logging
 import random
 import time
 import uuid
-from typing import Optional
+from typing import Any, Optional, cast
 
 from . import config
 from .destination_parser import extract_destination
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 
 # -- Shared helpers (lazy imports so unit tests don't need redis/networkx) ----
 
-def _get_redis_client():
+def _get_redis_client() -> Any:
+    # redis-py types the sync client as `Awaitable[T] | T`; keep it `Any`.
     import os
     import redis  # local import
 
@@ -45,7 +46,7 @@ def _get_redis_client():
     return redis.Redis(host=host, port=port, db=db, decode_responses=True)
 
 
-def _load_graph():
+def _load_graph() -> Any:
     """Load the airport graph from Redis. Imports are kept local so the
     pure-Python modules in this package can be unit-tested standalone."""
     import sys
@@ -56,8 +57,8 @@ def _load_graph():
     if str(gnd_dir) not in sys.path:
         sys.path.insert(0, str(gnd_dir))
 
-    from graph import AirportGraph  # type: ignore
-    from shared.services.airport_data_store import AirportDataStore  # type: ignore
+    from graph import AirportGraph
+    from shared.services.airport_data_store import AirportDataStore
 
     data = AirportDataStore().load()
     if data is None:
@@ -65,7 +66,7 @@ def _load_graph():
     return AirportGraph(data=data)
 
 
-def _aircraft_position(redis_client, registration: str) -> Optional[tuple[float, float, float]]:
+def _aircraft_position(redis_client: Any, registration: str) -> Optional[tuple[float, float, float]]:
     """Return (lat, lon, heading) from `aircraft:state:{reg}` or None."""
     state = redis_client.hgetall(f"aircraft:state:{registration}")
     if not state:
@@ -91,7 +92,7 @@ def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     return 2 * R * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
 
-def _pushback_distance_from_apt(graph, lat: float, lon: float) -> Optional[float]:
+def _pushback_distance_from_apt(graph: Any, lat: float, lon: float) -> Optional[float]:
     """Find the nearest init/both taxi-route node (per apt.dat row 1201) and
     return the haversine distance to it. That's where X-Plane's ATC engine
     assumes an aircraft enters/exits the taxi network from a stand -- the
@@ -147,17 +148,17 @@ def compute_taxi_route(
     lat, lon, _hdg = pos
     via = list(via or [])
     if via:
-        return graph.find_route_strict_from_position(
+        return cast(dict, graph.find_route_strict_from_position(
             start_lat=lat, start_lon=lon,
             sequence=via, destination_token=destination,
-        )
+        ))
     result = graph.find_route_from_position(
         start_lat=lat, start_lon=lon,
         end_token=destination, via=[],
     )
     if result.get("success"):
         result["strict"] = False
-    return result
+    return cast(dict, result)
 
 
 def dispatch_taxi_plan(
@@ -170,7 +171,7 @@ def dispatch_taxi_plan(
     delay_range_s: Optional[tuple[float, float]] = None,
     taxi_speed_kts: Optional[float] = None,
     session_id: Optional[str] = None,
-    redis_client=None,
+    redis_client: Any = None,
 ) -> dict:
     """Build and publish the full taxi plan after GND has produced a readback.
 
@@ -398,7 +399,7 @@ def _shorten_reason(
 
 
 def _reject(
-    redis_client,
+    redis_client: Any,
     *,
     callsign: str,
     registration: str,

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,7 @@ weather = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "ruff" },
 ]
 
@@ -243,7 +244,10 @@ requires-dist = [
 provides-extras = ["service-core", "agents", "orchestrator", "asr", "arrival-simulator", "flight-plan", "weather", "pilots-communication", "controller-hmi", "analysis", "test"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.14" }]
+dev = [
+    { name = "mypy", specifier = ">=1.11" },
+    { name = "ruff", specifier = ">=0.14" },
+]
 
 [[package]]
 name = "annotated-doc"
@@ -330,6 +334,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/00/0f6e8fcdb23ea632c866620cc872729ff43ed91d284c866b515c6342b173/arrow-1.3.0.tar.gz", hash = "sha256:d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85", size = 131960, upload-time = "2023-09-30T22:11:18.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/ed/e97229a566617f2ae958a6b13e7cc0f585470eac730a73e9e82c32a3cdd2/arrow-1.3.0-py3-none-any.whl", hash = "sha256:c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80", size = 66419, upload-time = "2023-09-30T22:11:16.072Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
 ]
 
 [[package]]
@@ -1547,6 +1576,27 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/25/a6498964cfeec270c468cffdc118f69c29b412593610d55fa1327ca51ff4/librt-0.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1b5a7bbff495baedbd9b916c367d66854008f8f3b575908ded477c499dc60082", size = 148029, upload-time = "2026-07-08T12:24:45.961Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/dc86d1bffd8e0c2818bace29d9f7783cfbb8e0673bf3673b5bbd5bbe0420/librt-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:34bc7938b9fdf14fe32a406c19c71faf894c5cee7e7474bd0be2f17200b82d14", size = 153036, upload-time = "2026-07-08T12:24:47.257Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3f/b923826660f02f286186cd9303d52bb05ced0a13708edc104dc8480920e3/librt-0.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f40e56b61b41be5f7dec938cfeffd660668cf4b5e72c78e7bd671d66b7bc2c79", size = 493062, upload-time = "2026-07-08T12:24:48.483Z" },
+    { url = "https://files.pythonhosted.org/packages/88/87/6c0980a9c9b1302cb68d108906697b89eceb55889bb1dcf77c109aa56ca5/librt-0.13.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:9c5d02b89de5acd0379a51ec44a89476fb03df6145442e1c8ecd6bee2f91b176", size = 485510, upload-time = "2026-07-08T12:24:49.727Z" },
+    { url = "https://files.pythonhosted.org/packages/32/81/795ae3b9df5dd94079fb807e38191855e023e8c6249014ae6bc3f0d9a490/librt-0.13.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7db9a3ff32ef5f7d1703d93831a3316cdf0b537de6a1cc03cc8fdd09b9194e89", size = 515909, upload-time = "2026-07-08T12:24:51.135Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e5/182de15abce8907108a6fdb41487de65beb5099b74dc5841b19b099168db/librt-0.13.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3dbb2a31882456cadc7053378e81ad7ed7693db4ac9f98ab5f81ef034aa8ec9f", size = 508620, upload-time = "2026-07-08T12:24:52.358Z" },
+    { url = "https://files.pythonhosted.org/packages/32/03/33978d32db76e1f66377e8f78e42a2ca3c162143331677d1f50bbad36cfb/librt-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c6014e3c80f9c1fe268ef8b0e0ef113bac672cc032f2f93866e7ddad4f3e663d", size = 530363, upload-time = "2026-07-08T12:24:53.503Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f5/b291fbd2d00f7d8287bcbf67b5aa0c6afed4bc26cef23e079629c47a2c04/librt-0.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:091b60a4d2174fc1ec5c34cdc0b72efb6224753d76b7da61ebeab7a191aec8bd", size = 534209, upload-time = "2026-07-08T12:24:55.138Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/03/6f41f17939d191bc21609f220da8509316bc62797f078545fe83be522e78/librt-0.13.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:66cb1138f384a191a6d75f986064841fcfdc0cea98f7bd9c9ab9b38049917588", size = 514254, upload-time = "2026-07-08T12:24:56.276Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c2/2e4befa5410a7443019c14abccc94ff619797171f6b72013635fb87f31d7/librt-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:17221a7569f8f292aa0014226e48aa25b8c2b08da18088cd230953d0ea0f9cd1", size = 557611, upload-time = "2026-07-08T12:24:57.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/54/8b69f81448417adbc040a2185f4e2eece1e1994b7dcfaeed4662b30f98a5/librt-0.13.0-cp311-cp311-win32.whl", hash = "sha256:fc67741da44c6eaa90e01eafb586bbba9b51eb5b6ed381ee6f5ae72eb3316d21", size = 104906, upload-time = "2026-07-08T12:24:58.806Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5a/f4aaf37b50f2fde12c8c663b83fdd499cdc24f957f19543d7414bfcc9e25/librt-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:cc99dfb62b23c9207c33d0be8a2e2af7a42e21e6ea388b380a0c948c7b88953b", size = 125852, upload-time = "2026-07-08T12:25:00.065Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/99/bf1820e6feeabc2f218c24450ec0c995d6a91e8ba0fd3caf042c9e8adb2a/librt-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:40ccd13c252d3fe473ffc8a57be7565abc8b64cf1b108344c859d5164f7f3e0c", size = 111832, upload-time = "2026-07-08T12:25:01.148Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1669,6 +1719,38 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b", size = 45981, upload-time = "2026-01-26T02:43:49.921Z" },
     { url = "https://files.pythonhosted.org/packages/ac/ad/9dd5305253fa00cd3c7555dbef69d5bf4133debc53b87ab8d6a44d411665/multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6", size = 43159, upload-time = "2026-01-26T02:43:51.635Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/b9/d75b3082b05f1b3028828aeb18e74ae5ab0a0936051bbf1f32f59f654747/mypy-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3419d00717afbc5265b50dd14b1278f29ea4884dd398ab67873489ac093fd329", size = 14838725, upload-time = "2026-07-13T11:32:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/50/79a65c6ea6e115bc73296038a4543b2d5c91f07912b918a2c616a2514bba/mypy-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cfca8ee88544090f86b6dcce05ec55d66eb48a762412ac2507810ba4bd793b6f", size = 13911128, upload-time = "2026-07-13T11:32:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/90/48/e11ed7716c26953ca321f726e452e374dbf81a6f2b8b212ec02af29b6b8f/mypy-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75cbb4b9ef04a0c84a957f07abc4504fbf64b8dcc145675101f2d3a78a4b1d6a", size = 14146742, upload-time = "2026-07-13T11:33:03.313Z" },
+    { url = "https://files.pythonhosted.org/packages/06/72/6807565b1c4861ef66f7fdd98b51c61556356eab80235717b46c53bb8627/mypy-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:982e3d53dd23d0a4cef67dd66791fdbede0cf38f9eb617bf47663554c51e1e36", size = 15081418, upload-time = "2026-07-13T11:31:13.899Z" },
+    { url = "https://files.pythonhosted.org/packages/00/80/1ea14c5d80e589e415973db3e47c78c2219a305b808b2b506395342c1d79/mypy-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:85c5385b93012ffa3b31479ab579aef5415f4f3a32c6cf1ae07a984d2a0ff461", size = 15328164, upload-time = "2026-07-13T11:31:35.723Z" },
+    { url = "https://files.pythonhosted.org/packages/37/28/8223157404a3d51920078459c37f80fbdc590e1d8ea049dc5ce48643022a/mypy-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:13b1b16e2fa39f3b2e33fb1c468abc7a69369fa2e886b4b87b5afc81472325cd", size = 11136472, upload-time = "2026-07-13T11:27:37.018Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/cc/ea27e5959c5f258585a756b252031f3b313583d81b5064b2bebc41d3706b/mypy-2.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:b5cd2f027a972a4a5f2278a11fac9747f5f81a53a30b714d74950b6807e55568", size = 10135800, upload-time = "2026-07-13T11:30:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -2041,6 +2123,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d4/de/53e0bcf53d13e005bd8c92e7855142494f41171b34c2536b86187474184d/parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a", size = 401205, upload-time = "2025-08-23T15:15:28.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887", size = 106668, upload-time = "2025-08-23T15:15:25.663Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> Stacked on #107 → #106 → #105. Review only the last commit.

## What

No type checking was configured in `pyproject.toml`. What *did* exist was a
tracked `.mypy.ini` containing:

```ini
[mypy]
mypy_path = C:\X-Plane 12\Resources\plugins:C:\X-Plane 12\Resources\plugins\XPPython3
check_untyped_defs = True
```

An absolute Windows path to one developer's X-Plane install, committed to the
repo — and because mypy prefers `.mypy.ini` over `pyproject.toml`, it would
have silently swallowed any `[tool.mypy]` section added next to it. Deleted;
the configuration now lives in `pyproject.toml`, and `CONTRIBUTING.md` explains
how to get the XPPython3 stubs resolved locally via `MYPYPATH` instead.

- `mypy` added to the `dev` dependency group.
- `[tool.mypy]` global config kept **lax** (`ignore_missing_imports`,
  `follow_imports = "silent"`) so unannotated modules never block work.
- Strict flags turned on for `shared.*` only, through
  `[[tool.mypy.overrides]]`: `disallow_untyped_defs`,
  `disallow_incomplete_defs`, `disallow_untyped_calls`, `check_untyped_defs`,
  `no_implicit_optional`, `strict_equality`, `warn_return_any`,
  `warn_unused_ignores`.
- A `typecheck` CI job running `uv run mypy shared`. Blocking, but narrow.
- `CONTRIBUTING.md` documents the three steps to add the next package.

## Scope: all of `shared/`, not a subpackage

`shared/` turned out clean enough to do whole: **52 errors across 10 of its 23
modules**, all annotation-level (22 `no-untyped-def`, 14 `no-untyped-call`, 7
`misc`, 5 `no-any-return`, 2 `var-annotated`, 2 `unused-ignore`). No narrowing
was needed. `mypy shared` → *Success: no issues found in 23 source files*.

**No logic was changed** — return/parameter annotations, container
annotations, and `cast()` where redis-py's stubs widen a sync call to
`Awaitable[T] | T` (its stubs serve the asyncio client too, so a precise
annotation would turn every call site into a union; the clients stay `Any` and
the *public* methods carry the real return types).

## Two real defects surfaced

1. **`shared/models/aircraft.py` could not be imported at all.**
   `DelClearence` declared `intrumental_departure`, `runway_in_use` and
   `altimeter` *after* `initial_altitude: int = 6000`, so `@dataclass` raised
   `TypeError: non-default argument 'intrumental_departure' follows default
   argument` at import time. Confirmed:

   ```
   >>> import shared.models.aircraft
   TypeError: non-default argument 'intrumental_departure' follows default argument
   ```

   Fields reordered. Nothing in the repo imports the class, so there is no
   call-site change.

2. **`shared/models/communications.py`** — the `Frequencies` enum members
   carried `: float` annotations. Latent rather than broken: they still produce
   members on 3.11, but this is invalid per the typing spec and the runtime has
   been tightening around it. Annotations dropped.

## Verification

- `uv run mypy shared` → clean.
- `351 passed, 1 skipped, 2 xfailed`; coverage 86.29% against the 84 gate from
  #107.

Closes #50
