### PR TITLE
ci: run CI on pull requests targeting feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: [ main, dev, test ]
+  # `branches` here matches the PR's BASE ref, not its head. Listing only
+  # main/dev meant a stacked PR -- one whose base is another feature branch --
+  # never triggered CI at all, so a whole stack could be merged unverified.
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, 'feat/**', 'fix/**', 'chore/**', 'docs/**', 'refactor/**' ]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Problem

`pull_request.branches` in `.github/workflows/ci.yml` matches the **base** ref of a pull request, not its head. The list was `[ main, dev ]`, so a *stacked* PR — one opened against another feature branch — never triggered the workflow at all.

This is not hypothetical: in the batch that produced PRs #92–#111, **ten of the nineteen PRs never ran CI even once**, because they were stacked on their parent branch. The eight that did run were all red on the `frontend` job, which was independently broken until #91, so in practice no PR in the batch was ever verified in isolation before being merged.

## Fix

Add the branch-prefix globs this repo actually uses as PR bases:

```yaml
  pull_request:
    branches: [ main, dev, 'feat/**', 'fix/**', 'chore/**', 'docs/**', 'refactor/**' ]
```

The inline comment records *why*, since the base-vs-head distinction is exactly what made the gap invisible.

## Verification

The workflow still parses and exposes the same five jobs (`test`, `lint`, `typecheck`, `deps`, `frontend`); only the trigger list changed. The real proof is behavioural — the next PR opened against a `feat/**` base should show a CI run, which this PR cannot demonstrate about itself since its own base is `dev`.