### PR TITLE
fix(ci): measure the coverage source that the config declares, re-baseline the gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,24 +240,36 @@ filterwarnings = [
 ]
 
 [tool.coverage.run]
-# Only modules that the test battery is intended to cover. Other modules
-# (aircraft_mover FSM, debrief endpoint, shared/services/aircraft_*) are
-# tracked but excluded from the fail_under threshold since they are out of
-# scope for the current phase — see memoria 5.3.3 for the deferred items.
+# The three units the test battery is written against: the orchestrator
+# service, the arrival simulator's core, and the shared taxi router.
+#
+# ONLY DIRECTORIES BELONG HERE — never individual .py paths. coverage.py
+# resolves every `source` entry as an importable package/module name or as a
+# directory; a bare file path matches neither, so it is dropped with a
+# `module-not-imported` CoverageWarning and silently vanishes from the
+# denominator. That is exactly what used to happen: ten of the fourteen
+# entries here were file paths, so the reported total was measured over the
+# four directory entries alone. Two of those paths (core/phases.py,
+# core/geo.py) did not even exist any more and nobody noticed.
+#
+# Directory entries also fix the `runner.py` blind spot: tests import it as a
+# bare top-level module (`import runner`, via the sys.path entry that
+# tests/conftest.py installs), so no module-name-based rule could ever match
+# it. A directory entry matches on the file's path instead, which is stable
+# regardless of how the module was imported.
+#
+# DELIBERATELY OUT OF THE GATE (untested or not importable under pytest):
+#   xplane_plugin/          runs inside X-Plane's embedded interpreter; never
+#                           imported by the suite, so it would enter at 0%
+#   agents/{del,gnd,twr}/   Cloud Run agent images, no test modules
+#   services/flight_plan_service, controller_hmi_service, pilots_communication
+#                           no test modules
+# Genuinely exercised but not gated yet (widen in a follow-up, deliberately —
+# measured on this branch): services/weather_service 83.6%, plugins/GND 45.0%,
+# services/asr_service/core 75.1%, agents/common 100%.
 source = [
-    "services/orchestrator_service/agent",
-    "services/orchestrator_service/api",
-    "services/orchestrator_service/db",
-    "services/orchestrator_service/frequency_audit.py",
-    "services/orchestrator_service/runner.py",
-    "services/orchestrator_service/session_log.py",
-    "services/orchestrator_service/debrief_builder.py",
-    "services/orchestrator_service/config.py",
-    "services/arrival_simulator_service/core/event_bridge.py",
-    "services/arrival_simulator_service/core/arrival_planner.py",
-    "services/arrival_simulator_service/core/runway_config.py",
-    "services/arrival_simulator_service/core/phases.py",
-    "services/arrival_simulator_service/core/geo.py",
+    "services/orchestrator_service",
+    "services/arrival_simulator_service/core",
     "shared/services/taxi_router",
 ]
 omit = [
@@ -278,14 +290,23 @@ omit = [
 ]
 
 [tool.coverage.report]
+# Guard against a second flavour of the silent-omission bug above: when
+# scanning a `source` directory for files that were never imported, coverage
+# skips any subdirectory without an __init__.py. A new subpackage added
+# without one would quietly leave the denominator. No-op today (every
+# subdirectory in scope has an __init__.py) — it is here so it stays that way.
+include_namespace_packages = true
 exclude_lines = [
     "pragma: no cover",
     "raise NotImplementedError",
     "if TYPE_CHECKING:",
     "if __name__ == .__main__.:",
 ]
-# Real gate, enforced in CI (issue #47). Measured baseline on the branch point
-# for this change: 86.29% (773 statements, 106 missed). The threshold is
-# baseline - 2, rounded down, as a buffer against line-count noise; raise it in
-# follow-up PRs as coverage grows.
+# Real gate, enforced in CI (issue #47). Re-baselined on the corrected
+# `source` above: 86.05% (1541 statements, 215 missed). The previous baseline
+# (91.71%) was measured over 808 statements because ten `source` entries were
+# being dropped — the new figure is lower over nearly twice the surface, and
+# the difference is a measurement correction, not a coverage regression.
+# Threshold is baseline - 2, rounded down, as a buffer against line-count
+# noise; raise it in follow-up PRs as coverage grows.
 fail_under = 84


### PR DESCRIPTION
## The defect

`[tool.coverage.run] source` listed fourteen entries, **ten of them plain `.py` file paths**. coverage.py resolves each `source` entry as an importable package/module name **or** as a directory — a bare file path matches neither, so it is dropped with a `module-not-imported` `CoverageWarning` and disappears from the denominator entirely.

The reported total was therefore computed over the **four directory entries only**. The gate (`fail_under = 84`) was being met by a 91.71% figure measured over a quarter of the surface the config claimed.

### Verified dropped entries

Captured from the actual `CoverageWarning` output of `uv run pytest --cov --cov-report=term` on `dev` (46b3491):

| Entry | Note |
|---|---|
| `services/orchestrator_service/frequency_audit.py` | 107 stmts, actually 100% covered |
| `services/orchestrator_service/runner.py` | 133 stmts, actually 94% covered |
| `services/orchestrator_service/session_log.py` | 72 stmts, actually 86% covered |
| `services/orchestrator_service/debrief_builder.py` | 99 stmts, actually 98% covered |
| `services/orchestrator_service/config.py` | 18 stmts, actually 100% covered |
| `services/arrival_simulator_service/core/event_bridge.py` | 69 stmts, 55% |
| `services/arrival_simulator_service/core/arrival_planner.py` | 60 stmts, 98% |
| `services/arrival_simulator_service/core/runway_config.py` | 19 stmts, 100% |
| `services/arrival_simulator_service/core/phases.py` | **file does not exist** |
| `services/arrival_simulator_service/core/geo.py` | **file does not exist** |

Two entries had been pointing at deleted files for who knows how long — nothing in CI could tell us, because a stale path and a valid-but-unresolvable path produce the identical warning and the identical silence.

The `runner.py` symptom the issue describes is the same root cause seen from the other end: `tests/unit/orchestrator/test_runner.py` imports it as a bare top-level module (`import runner`) via the `sys.path` entry that `tests/conftest.py` installs, so coverage had no module name to associate the file path with. It is genuinely exercised — it just never reached the table.

## The fix

```toml
source = [
    "services/orchestrator_service",
    "services/arrival_simulator_service/core",
    "shared/services/taxi_router",
]
```

**Mechanism: directory entries, not `source_pkgs`.** `source_pkgs` would be the idiomatic choice for real installed packages, but it does not fit this repo. `services/orchestrator_service/` has no `__init__.py`; its modules are imported as bare top-level names (`runner`, `config`, `session_log`) through `sys.path` injection from `tests/conftest.py` and `[tool.pytest.ini_options] pythonpath`. Registering `runner` as a `source_pkgs` entry would work only for as long as that `sys.path` shim exists and would break the moment the service is packaged properly. A directory entry matches on the **file's path**, which is stable regardless of how — or whether — the module was imported. That is also what makes `runner.py` show up now without touching any Python.

Additionally, `include_namespace_packages = true` guards against the second flavour of the same bug: when scanning a `source` directory for files that were never imported, coverage skips any subdirectory lacking an `__init__.py`, so a new subpackage could quietly leave the denominator. It is a no-op against the current tree (verified: identical 1541/215 with and without it) and is there to keep it that way.

**`omit` is unchanged.** The comment on `source` now states the rule explicitly: *only directories belong here, never individual `.py` paths.*

## What is in and what is out

**Graded (1541 statements):** `services/orchestrator_service` (all of it, including `utils.py` and the previously-invisible top-level modules), `services/arrival_simulator_service/core`, `shared/services/taxi_router` — minus the pre-existing `omit` list.

Note this is *wider* than before even within the declared units: `core/plan_catalog.py` (33%) and `core/scheduler.py` (39%) sit inside `core/` and were never named individually, so they were invisible under the old config too. They are graded now.

**Deliberately out of the gate**, and now said out loud in the config rather than left to a silent warning:

- `xplane_plugin/` — 947 statements, **0%**. It runs inside X-Plane's embedded interpreter and is never imported by the suite. Measuring it honestly would take the headline from 86% to ~66% and would make the gate a proxy for "how much of XPPython3 have we stubbed" rather than a regression guard on backend logic. Excluding it is a judgement call, not an accident, and this is where it is recorded.
- `agents/{del,gnd,twr}/` (511 stmts, 0%), `services/flight_plan_service` (444, 0%), `services/controller_hmi_service/api` (496, 0%), `services/pilots_communication` (18, 0%) — deployment units with no test modules at all.

**Genuinely exercised but still ungated** — worth widening into, deliberately, in a follow-up rather than smuggling into a measurement-fix PR. Measured on this branch: `services/weather_service` **83.6%** (66 tests behind it), `services/asr_service/core` **75.1%**, `plugins/GND` **45.0%**, `agents/common` **100%**. Leaving 66 weather tests gating nothing is a real gap; it is just a different decision from this one, and mixing them would make the number movement unattributable.

For reference, the fully honest whole-repo figure is **44.05%** across 5743 statements. That is the number if we ever decide the gate should measure breadth rather than guard the tested core.

## Old vs new

| | Old | New |
|---|---|---|
| Reported coverage | **91.71%** | **86.05%** |
| Statements measured | 808 | **1541** |
| Statements missed | 67 | 215 |
| `source` entries silently dropped | 10 of 14 | **0** |
| `fail_under` | 84 | 84 |

**The 5.66-point drop is a measurement correction, not a regression.** Not one line of Python changed and not one test outcome changed; the denominator nearly doubled because the config now measures what it always claimed to. Every newly-visible orchestrator module is in fact well covered (94–100%) — the drop comes from previously-hidden statements in `core/scheduler.py`, `core/plan_catalog.py`, `core/event_bridge.py` and `utils.py`.

`fail_under` is re-derived under the existing baseline-minus-2 rounded-down rule: `86.05 - 2 = 84.05` → **84**. It lands on the same integer as before, which is a coincidence worth naming: the gate's *value* is unchanged, but what it certifies is now roughly twice the surface. The comment above `fail_under` records the new provenance so the next person to raise it knows what it was measured against.

## Verification

- `uv run pytest --cov --cov-report=xml --cov-report=term` (the exact CI `test` step) passes: `Required test coverage of 84.0% reached. Total coverage: 86.05%`.
- **Zero** `CoverageWarning`s in the output — was ten.
- Test outcomes identical to the `dev` baseline: **614 passed, 1 skipped, 2 xfailed**.

## Scope

Config-only: `pyproject.toml`, `[tool.coverage.*]` exclusively. **No Python source was touched** — the directory-entry mechanism made the `runner.py` import fix unnecessary. `[tool.ruff]` untouched and no formatter was run, so this should not collide with the repo-wide format sweep.
